### PR TITLE
feat: add opt-in DeepSeek Harness bundle

### DIFF
--- a/.github/workflows/dsh.yml
+++ b/.github/workflows/dsh.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -44,6 +46,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -67,6 +71,8 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/dsh.yml
+++ b/.github/workflows/dsh.yml
@@ -1,0 +1,78 @@
+name: DSH integration
+
+on:
+  pull_request:
+    paths:
+      - 'integrations/deepseek-harness/**'
+      - '.github/workflows/dsh.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/deepseek-harness/**'
+      - '.github/workflows/dsh.yml'
+    tags:
+      - 'archify-dsh-v*'
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      adapter_release:
+        description: 'Run the three-platform adapter release gate'
+        type: boolean
+        default: false
+
+concurrency:
+  group: dsh-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: DSH package contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Static adapter contracts
+        run: node --test integrations/deepseek-harness/test/*.test.mjs
+
+  distribution-acceptance:
+    name: DSH distribution acceptance
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Real tarball install, discovery, package-smoke, uninstall
+        run: node integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+
+  adapter-release:
+    name: adapter release (${{ matrix.os }})
+    needs: contract
+    if: >-
+      github.event_name == 'workflow_dispatch' && inputs.adapter_release
+      || startsWith(github.ref, 'refs/tags/archify-dsh-v')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Real DSH distribution acceptance
+        run: node integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The complete generation and viewer contract lives in [`archify/SKILL.md`](archif
 | **opencode** | `~/.config/opencode/skills/`, `.opencode/skills/`, or `.agents/skills/` | Full renderer + validation workflow |
 | **Claude.ai** | Upload `archify.zip` under Settings → Capabilities → Skills | Depends on Node.js access in the sandbox |
 | **Project Knowledge** | Upload `archify.zip` to the project | Prompt-driven architecture fallback |
+**DeepSeek Harness:** Community integration, not an official DeepSeek product; developer-preview `@deepseek-ai/dsh@0.1.0-rc.6`, Node `^22.19.0 || >=24.0.0`. Install: `dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`; invoke: `Use the archify skill to map this repository's runtime architecture.`; remove: `dsh plugin --profile web remove @tt-a1i/archify-dsh`. No telemetry. Shell files need exact workspace paths, not Web Produced Files. [Details](integrations/deepseek-harness/README.md).
 
 ## Reference and scope
 
@@ -272,8 +273,6 @@ The complete generation and viewer contract lives in [`archify/SKILL.md`](archif
 - [Changelog](CHANGELOG.md)
 - [Roadmap](ROADMAP.md)
 - [Generated Proof Lab](https://tt-a1i.github.io/archify/gallery.html)
-
-Archify 2.13 includes typed IR across all five modes, real-repository proof, deterministic exact-ID Architecture Delta review, verified live preview, authored reachability, truthful configurable legends, optional finite motion, guided views, semantic search and relationship exploration, shareable deep links, 1200×630 diagram and route cards, browser-native WebM recording, explicit `standard` / `showcase` quality profiles, and an opt-in deployment ownership contract.
 
 Automatic Mermaid parsing, general-purpose auto-layout, hosted sharing, and WYSIWYG editing are intentionally outside the current scope.
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -263,6 +263,7 @@ The complete generation and viewer contract lives in [`archify/SKILL.md`](archif
 | **opencode** | `~/.config/opencode/skills/`, `.opencode/skills/`, or `.agents/skills/` | Full renderer + validation workflow |
 | **Claude.ai** | Upload `archify.zip` under Settings → Capabilities → Skills | Depends on Node.js access in the sandbox |
 | **Project Knowledge** | Upload `archify.zip` to the project | Prompt-driven architecture fallback |
+**DeepSeek Harness:** Community integration, not an official DeepSeek product; developer-preview `@deepseek-ai/dsh@0.1.0-rc.6`, Node `^22.19.0 || >=24.0.0`. Install: `dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`; invoke: `Use the archify skill to map this repository's runtime architecture.`; remove: `dsh plugin --profile web remove @tt-a1i/archify-dsh`. No telemetry. Shell files need exact workspace paths, not Web Produced Files. [Details](integrations/deepseek-harness/README.md).
 
 ## Reference and scope
 
@@ -272,8 +273,6 @@ The complete generation and viewer contract lives in [`archify/SKILL.md`](archif
 - [Changelog](CHANGELOG.md)
 - [Roadmap](ROADMAP.md)
 - [Generated Proof Lab](https://tt-a1i.github.io/archify/gallery.html)
-
-Archify 2.13 includes typed IR across all five modes, real-repository proof, deterministic exact-ID Architecture Delta review, verified live preview, authored reachability, truthful configurable legends, optional finite motion, guided views, semantic search and relationship exploration, shareable deep links, 1200×630 diagram and route cards, browser-native WebM recording, explicit `standard` / `showcase` quality profiles, and an opt-in deployment ownership contract.
 
 Automatic Mermaid parsing, general-purpose auto-layout, hosted sharing, and WYSIWYG editing are intentionally outside the current scope.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -258,10 +258,11 @@ node bin/archify.mjs deliver workflow examples/agent-tool-call.workflow.json /tm
 | **opencode** | `~/.config/opencode/skills/`、`.opencode/skills/` 或 `.agents/skills/` | 完整 Renderer + Validation 工作流 |
 | **Claude.ai** | Settings → Capabilities → Skills 中上传 `archify.zip` | 取决于沙箱是否提供 Node.js |
 | **Project Knowledge** | 把 `archify.zip` 上传到项目 | Prompt 驱动的 Architecture Fallback |
-
 Claude.ai 中的上传入口：
 
 ![Claude Skills 设置](docs/assets/claude-skills-settings.png)
+
+**DeepSeek Harness：** 面向开发者预览版 `@deepseek-ai/dsh@0.1.0-rc.6` 的社区集成，不是 DeepSeek 官方产品；Node `^22.19.0 || >=24.0.0`。安装：`dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`；调用：`Use the archify skill to map this repository's runtime architecture.`；卸载：`dsh plugin --profile web remove @tt-a1i/archify-dsh`。没有遥测；shell 文件不会自动进入 Web Produced Files，请返回精确工作区路径。[详情](integrations/deepseek-harness/README.md)。
 
 ## 参考与边界
 
@@ -271,8 +272,6 @@ Claude.ai 中的上传入口：
 - [版本历史](CHANGELOG.md)
 - [路线图](ROADMAP.md)
 - [自动生成的 Proof Lab](https://tt-a1i.github.io/archify/gallery.html)
-
-Archify 2.13 覆盖五种 Typed IR、真实仓库证明、基于精确 ID 的确定性 Architecture Delta 评审、验证后实时预览、作者可达性、真实可配置图例、可选有限动态、引导视图、语义搜索与关系探索、可分享深链、1200×630 整图与路径卡片、浏览器原生 WebM、显式 `standard` / `showcase` 质量档位，以及按需启用的部署所有权契约。
 
 自动 Mermaid Parser、通用自动布局、托管分享服务和 WYSIWYG 编辑器目前都不在产品范围内。
 

--- a/integrations/deepseek-harness/.gitignore
+++ b/integrations/deepseek-harness/.gitignore
@@ -1,0 +1,4 @@
+*.tgz
+node_modules/
+skills/
+.pack-stage/

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,0 +1,47 @@
+# `@tt-a1i/archify-dsh`
+
+Community DeepSeek Harness integration for [Archify](https://github.com/tt-a1i/archify). This is **not** an official DeepSeek product and does not imply DeepSeek endorsement.
+
+v0.1.0 is experimental compatibility with developer-preview **`@deepseek-ai/dsh@0.1.0-rc.6`** on Node.js **`^22.19.0 || >=24.0.0`**. It is not a stable cross-version guarantee.
+
+The package is a Skill-only bundle: it inserts one filesystem Skill provider named `archify-plugin` and exposes a clean copy of the existing Archify Skill. It does not register native render/validate/deliver tools, a custom Web client, Produced Files chips, telemetry, network access, credentials handling, background services, or `prepare` / `install` / `postinstall` hooks.
+
+## Install
+
+Use the prebuilt npm package with an exact version. Do not install from Git source.
+
+```bash
+dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
+```
+
+## Invoke
+
+Ask DSH to load Archify by name:
+
+```text
+Use the archify skill to map this repository's runtime architecture.
+Show 8–12 core components, one primary path, external dependencies, and trust boundaries.
+Put supporting detail in cards instead of adding more edges.
+After delivery, return the exact workspace paths of the specification JSON and the HTML artifact.
+```
+
+Archify then runs through DSH's ordinary Skill, shell, and filesystem paths. Generated JSON and HTML are normal workspace files.
+
+## Produced Files limitation
+
+Files created by shell commands do **not** automatically appear in the Web Produced Files strip. Ask the agent to return the **exact workspace paths** of the specification JSON and the HTML artifact, then open those files from the workspace.
+
+## Uninstall
+
+```bash
+dsh plugin --profile web remove @tt-a1i/archify-dsh
+```
+
+The standard plugin command removes the adapter dependency and bundle layer. The base profile remains usable.
+
+## Security posture
+
+- No telemetry, network client, credentials handling, or background service
+- No `prepare`, `install`, or `postinstall` scripts
+- Host-loaded adapter code does not spawn processes or open a second permission path
+- Package resolution, provider load, and composition errors fail during normal DSH boot

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -7,5 +7,4 @@
       config:
         providerName: archify-plugin
         includeDefaultRoots: false
-        customSkillDirs:
-          - !!js process.getBuiltinModule('node:path').join(process.getBuiltinModule('node:path').dirname(process.getBuiltinModule('node:module').createRequire(baseUrl).resolve('@tt-a1i/archify-dsh/package.json')), 'skills')
+        bundledSkillDir: !!js process.getBuiltinModule('node:path').join(process.getBuiltinModule('node:path').dirname(process.getBuiltinModule('node:module').createRequire(baseUrl).resolve('@tt-a1i/archify-dsh/package.json')), 'skills')

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -1,0 +1,11 @@
+# Opt-in Archify filesystem Skill provider for DeepSeek Harness.
+# Resolves the packaged Skill root from the installed npm identity anchored at
+# the DSH profile (Loader baseUrl), never as a path concatenated onto baseUrl.
+- insert:
+    - id: archify-skill-filesystem
+      name: '@deepseek-ai/dsh-skill-filesystem'
+      config:
+        providerName: archify-plugin
+        includeDefaultRoots: false
+        customSkillDirs:
+          - !!js process.getBuiltinModule('node:path').join(process.getBuiltinModule('node:path').dirname(process.getBuiltinModule('node:module').createRequire(baseUrl).resolve('@tt-a1i/archify-dsh/package.json')), 'skills')

--- a/integrations/deepseek-harness/lib/index.js
+++ b/integrations/deepseek-harness/lib/index.js
@@ -1,0 +1,21 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+export const name = 'archify-dsh';
+export const PACKAGE_NAME = '@tt-a1i/archify-dsh';
+
+export function resolveArchifySkillRoot(profileBaseUrl) {
+  if (!profileBaseUrl) {
+    throw new Error('archify-dsh: missing DSH profile baseUrl for package resolution');
+  }
+  let manifestPath;
+  try {
+    manifestPath = createRequire(profileBaseUrl).resolve(`${PACKAGE_NAME}/package.json`);
+  } catch (error) {
+    throw new Error(
+      `archify-dsh: cannot resolve ${PACKAGE_NAME}/package.json from the DSH profile`,
+      { cause: error },
+    );
+  }
+  return join(dirname(manifestPath), 'skills');
+}

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@tt-a1i/archify-dsh",
+  "version": "0.1.0",
+  "description": "Opt-in DeepSeek Harness Skill-only bundle for the Archify architecture-diagram skill.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "cordis.patch.yml",
+    "skills",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "dsh-plugin",
+    "deepseek-harness",
+    "agent-skill",
+    "architecture-diagram"
+  ],
+  "engines": {
+    "node": "^22.19.0 || >=24.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tt-a1i/archify.git",
+    "directory": "integrations/deepseek-harness"
+  },
+  "homepage": "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness",
+  "bugs": "https://github.com/tt-a1i/archify/issues",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnCli, spawnCliSync } from './resolve-cli.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const integrationRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(integrationRoot, '..', '..');
+const PACKAGE_NAME = '@tt-a1i/archify-dsh';
+const PACKAGE_VERSION = '0.1.0';
+const DSH_SPEC = '@deepseek-ai/dsh@0.1.0-rc.6';
+const PROFILE = 'archify-dsh-acceptance';
+const FIXED_POINT = '45f0611dfc0dc824e9a13a12efcac207a8a2bdce';
+const ARCHIFY_ZIP_BLOB = '4249d32a5a07deb63152a06ac8c2cf4784d25136';
+const ARCHIFY_PACKAGE_BLOB = '238d6237ff0c942d459e7ec257f19386522306a0';
+
+const receipt = {
+  ok: false,
+  adapter: { name: PACKAGE_NAME, version: PACKAGE_VERSION },
+  dsh: { spec: DSH_SPEC },
+  node: process.version,
+  platform: process.platform,
+  zipContainerNote: 'Fresh builder ZIP vs committed ZIP: unzip contents match; ZIP container bytes do not. Existing baseline behavior, not a DSH regression.',
+  stages: [],
+};
+
+function fail(stage, message, extra = {}) {
+  receipt.stages.push({ name: stage, ok: false, error: message, ...extra });
+  receipt.ok = false;
+  process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+  process.exit(1);
+}
+
+function pass(stage, extra = {}) {
+  receipt.stages.push({ name: stage, ok: true, ...extra });
+}
+
+function run(command, args, options = {}) {
+  return spawnCliSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+    env: { ...process.env, ...options.env },
+  });
+}
+
+function requireStatus(stage, result, extra = {}) {
+  if (result.error || result.status !== 0) {
+    fail(stage, [
+      result.error?.message,
+      `${extra.command || 'command'} exited ${result.status}`,
+      result.stdout,
+      result.stderr,
+    ].filter(Boolean).join('\n'), extra);
+  }
+}
+
+function listRelativeFiles(root) {
+  const files = [];
+  function walkDir(dir, prefix) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const relative = path.posix.join(prefix, entry.name);
+      if (entry.isDirectory()) walkDir(path.join(dir, entry.name), relative);
+      else files.push(relative);
+    }
+  }
+  walkDir(root, '');
+  return files.sort();
+}
+
+function treesMatch(left, right) {
+  const leftFiles = listRelativeFiles(left);
+  const rightFiles = listRelativeFiles(right);
+  if (leftFiles.join('\n') !== rightFiles.join('\n')) {
+    return { ok: false, leftFiles, rightFiles };
+  }
+  for (const file of leftFiles) {
+    const leftPath = path.join(left, ...file.split('/'));
+    const rightPath = path.join(right, ...file.split('/'));
+    if (!fs.readFileSync(leftPath).equals(fs.readFileSync(rightPath))) {
+      return { ok: false, file };
+    }
+  }
+  return { ok: true };
+}
+
+function parseDump(yaml) {
+  const layers = [];
+  const rows = [];
+  let layer = { name: 'root', rows: [] };
+  let current = null;
+  for (const line of yaml.split('\n')) {
+    const header = line.match(/^# ==\s+(.+)$/);
+    if (header) {
+      layer = { name: header[1].trim(), rows: [] };
+      layers.push(layer);
+      current = null;
+      continue;
+    }
+    const id = line.match(/^- id:\s+(\S+)/);
+    if (id) {
+      current = { id: id[1].replace(/['"]/g, ''), name: '', config: {} };
+      rows.push(current);
+      layer.rows.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const name = line.match(/^\s+name:\s+(.+)$/);
+    if (name) current.name = name[1].replace(/^['"]|['"]$/g, '');
+    const provider = line.match(/^\s+providerName:\s+(\S+)/);
+    if (provider) current.config.providerName = provider[1];
+    const includeDefault = line.match(/^\s+includeDefaultRoots:\s+(\S+)/);
+    if (includeDefault) current.config.includeDefaultRoots = includeDefault[1] === 'true';
+  }
+  return { layers, rows };
+}
+
+function waitForProbe(child, file, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const started = Date.now();
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      clearInterval(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+    const timer = setInterval(() => {
+      if (fs.existsSync(file)) {
+        finish();
+        return;
+      }
+      if (Date.now() - started > timeoutMs) finish(new Error('skill probe timed out'));
+    }, 250);
+    child.once('error', (error) => {
+      if (fs.existsSync(file)) finish();
+      else finish(error);
+    });
+    child.once('exit', (code, signal) => {
+      if (fs.existsSync(file)) finish();
+      else finish(new Error(`dsh boot exited ${code} signal ${signal} before writing the skill probe`));
+    });
+  });
+}
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-dsh-acceptance-'));
+const tarball = path.join(scratch, 'tt-a1i-archify-dsh-0.1.0.tgz');
+const dshHome = path.join(scratch, 'dsh-home');
+const agentsHome = path.join(scratch, 'agents-home');
+const workspace = path.join(scratch, 'workspace');
+const probeOut = path.join(scratch, 'skill-probe.json');
+fs.mkdirSync(dshHome);
+fs.mkdirSync(agentsHome);
+fs.mkdirSync(workspace);
+
+function cleanup() {
+  fs.rmSync(scratch, { recursive: true, force: true });
+}
+process.on('exit', cleanup);
+process.on('SIGINT', () => process.exit(130));
+process.on('SIGTERM', () => process.exit(143));
+
+const pack = run(process.execPath, [
+  path.join(integrationRoot, 'scripts', 'pack.mjs'),
+  '--out', tarball,
+  '--json',
+], { cwd: repoRoot });
+requireStatus('pack', pack, { command: 'pack.mjs' });
+let packReceipt;
+try {
+  packReceipt = JSON.parse(pack.stdout);
+} catch (error) {
+  fail('pack', `pack did not emit JSON: ${error.message}\n${pack.stdout}`);
+}
+if (packReceipt.name !== PACKAGE_NAME || packReceipt.version !== PACKAGE_VERSION || !fs.existsSync(tarball)) {
+  fail('pack', 'pack receipt identity mismatch', { packReceipt, tarball });
+}
+pass('pack', { filename: packReceipt.filename, fileCount: packReceipt.files?.length });
+
+const inspectRoot = path.join(scratch, 'tarball');
+fs.mkdirSync(inspectRoot);
+requireStatus('tarball-inspect', run('tar', ['-xzf', tarball, '-C', inspectRoot]));
+const packedPkg = JSON.parse(fs.readFileSync(path.join(inspectRoot, 'package', 'package.json'), 'utf8'));
+const packedFiles = listRelativeFiles(path.join(inspectRoot, 'package'));
+const forbidden = packedFiles.filter((file) => (
+  file.startsWith('test/')
+  || file.includes('node_modules/')
+  || file.includes('package-lock.json')
+  || file.includes('.hive')
+  || file.includes('.workbuddy')
+  || file.includes('probe-skills')
+  || file.includes('generate-validators.mjs')
+));
+if (packedPkg.name !== PACKAGE_NAME || packedPkg.version !== PACKAGE_VERSION || forbidden.length > 0) {
+  fail('tarball-inspect', 'packed identity or exclusions failed', { forbidden, packedPkg });
+}
+if (!packedFiles.includes('skills/archify/SKILL.md')) {
+  fail('tarball-inspect', 'packed tarball is missing the clean Archify Skill');
+}
+pass('tarball-inspect', { fileCount: packedFiles.length });
+
+const dshEnv = {
+  ...process.env,
+  DSH_HOME: dshHome,
+  DSH_AGENTS_HOME: agentsHome,
+  DSH_TELEMETRY_DISABLED: '1',
+  ARCHIFY_DSH_PROBE_OUT: probeOut,
+  npm_config_update_notifier: 'false',
+};
+const npx = ['-y', '--package', DSH_SPEC, 'dsh'];
+
+function dsh(args, options = {}) {
+  return run('npx', [...npx, ...args], {
+    cwd: options.cwd || workspace,
+    env: dshEnv,
+    timeout: options.timeout ?? 120_000,
+  });
+}
+
+const install = dsh(['plugin', '--profile', PROFILE, 'add', tarball], { timeout: 180_000 });
+requireStatus('plugin-install', install, { command: `dsh plugin --profile ${PROFILE} add <tarball>` });
+pass('plugin-install', { profile: PROFILE });
+
+const profileDir = path.join(dshHome, 'profiles', PROFILE);
+const profileManifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+const bundles = profileManifest.dsh?.profile?.bundles || [];
+const deps = profileManifest.dependencies || {};
+if (!bundles.includes(PACKAGE_NAME) || !deps[PACKAGE_NAME]) {
+  fail('profile-identity', 'installed profile does not name the real package identity', { bundles, deps });
+}
+if (String(deps[PACKAGE_NAME]).includes('link:') || String(deps[PACKAGE_NAME]).includes(integrationRoot)) {
+  fail('profile-identity', 'profile was installed from a source checkout or link instead of the tarball', { deps });
+}
+pass('profile-identity', { bundles, dependency: deps[PACKAGE_NAME] });
+
+const dump = dsh(['--profile', PROFILE, '--dump-config']);
+requireStatus('compose', dump, { command: 'dsh --dump-config' });
+const composed = parseDump(dump.stdout);
+const archifyLayer = composed.layers.find((layer) => layer.name === PACKAGE_NAME);
+const originalFilesystem = composed.rows.find((row) => row.id === 'skill-filesystem');
+const archifyProvider = composed.rows.find((row) => row.id === 'archify-skill-filesystem');
+const extraProviders = composed.rows.filter((row) => row.config.providerName === 'archify-plugin');
+if (!dump.stdout.includes(`# == ${PACKAGE_NAME}`) || !archifyLayer) {
+  fail('compose', 'composed dump does not include the Archify bundle layer', { layers: composed.layers.map((layer) => layer.name) });
+}
+if (!originalFilesystem || originalFilesystem.config.providerName === 'archify-plugin') {
+  fail('compose', 'original DSH skill-filesystem row was replaced', { originalFilesystem });
+}
+if (!archifyProvider || extraProviders.length !== 1 || archifyLayer.rows.length !== 1) {
+  fail('compose', 'composed config did not insert exactly one Archify Skill provider', {
+    extra: extraProviders.map((row) => row.id),
+    layerRows: archifyLayer.rows.map((row) => row.id),
+  });
+}
+if (archifyProvider.config.includeDefaultRoots !== false || archifyProvider.config.providerName !== 'archify-plugin') {
+  fail('compose', 'Archify provider config is not isolated', { archifyProvider });
+}
+pass('compose', {
+  extraIds: archifyLayer.rows.map((row) => row.id),
+  providerName: 'archify-plugin',
+});
+
+const probePatch = path.join(scratch, 'probe.patch.yml');
+const probeModule = path.join(integrationRoot, 'test', 'probe-skills.mjs');
+fs.writeFileSync(probePatch, `- insert:
+    - id: archify-dsh-skill-probe
+      name: ${JSON.stringify(pathToFileURL(probeModule).href)}
+      inject: [skills]
+`);
+const probeChild = spawnCli('npx', [...npx, '--profile', PROFILE, '--patch', probePatch], {
+  cwd: workspace,
+  env: dshEnv,
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let probeStdout = '';
+let probeStderr = '';
+probeChild.stdout.on('data', (chunk) => { probeStdout += chunk; });
+probeChild.stderr.on('data', (chunk) => { probeStderr += chunk; });
+try {
+  await waitForProbe(probeChild, probeOut, 90_000);
+} catch (error) {
+  probeChild.kill('SIGTERM');
+  fail('skill-discovery', error.message, { stdout: probeStdout, stderr: probeStderr });
+}
+probeChild.kill('SIGTERM');
+const probeReceipt = JSON.parse(fs.readFileSync(probeOut, 'utf8'));
+const archifyHits = (probeReceipt.skills || []).filter((skill) => skill.name === 'archify');
+if (archifyHits.length !== 1 || archifyHits[0].provider !== 'archify-plugin') {
+  fail('skill-discovery', 'public Skill registry did not discover archify only from archify-plugin', { probeReceipt });
+}
+pass('skill-discovery', { provider: 'archify-plugin' });
+
+if (!probeReceipt.definition?.contentLength || probeReceipt.definition.provider !== 'archify-plugin') {
+  fail('skill-load', 'full Skill definition was not loaded', { definition: probeReceipt.definition });
+}
+pass('skill-load', { contentLength: probeReceipt.definition.contentLength });
+
+const resourcePath = probeReceipt.definition.resourceBase?.path || probeReceipt.definition.path;
+const installedPackage = path.join(profileDir, 'node_modules', '@tt-a1i', 'archify-dsh');
+let resourceReal;
+let packageReal;
+try {
+  resourceReal = fs.realpathSync(resourcePath);
+  packageReal = fs.realpathSync(installedPackage);
+} catch (error) {
+  fail('resource-base', `cannot realpath installed Skill root: ${error.message}`, { resourcePath, installedPackage });
+}
+const resourceRelative = path.relative(packageReal, resourceReal);
+const resourceInsidePackage = resourceRelative
+  && !resourceRelative.startsWith(`..${path.sep}`)
+  && resourceRelative !== '..'
+  && !path.isAbsolute(resourceRelative);
+if (!resourceInsidePackage || !resourceReal.includes(`${path.sep}skills${path.sep}archify`)) {
+  fail('resource-base', 'Skill resource base is not inside the installed tarball package', {
+    resourcePath: resourceReal,
+    installedPackage: packageReal,
+  });
+}
+pass('resource-base', { resourcePath: resourceReal });
+
+const skillRoot = fs.existsSync(path.join(resourceReal, 'SKILL.md'))
+  ? resourceReal
+  : path.join(resourceReal, 'archify');
+const smoke = run(process.execPath, [path.join(repoRoot, 'scripts', 'package-smoke.mjs'), skillRoot], {
+  cwd: repoRoot,
+  timeout: 120_000,
+});
+requireStatus('package-smoke', smoke, { command: 'package-smoke.mjs <installed-skill-root>' });
+pass('package-smoke', { skillRoot, output: smoke.stdout.trim() });
+
+const remove = dsh(['plugin', '--profile', PROFILE, 'remove', PACKAGE_NAME], { timeout: 180_000 });
+requireStatus('uninstall', remove, { command: `dsh plugin --profile ${PROFILE} remove ${PACKAGE_NAME}` });
+const removedManifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+if ((removedManifest.dsh?.profile?.bundles || []).includes(PACKAGE_NAME)
+  || removedManifest.dependencies?.[PACKAGE_NAME]) {
+  fail('uninstall', 'adapter dependency or bundle layer remained after plugin remove', { removedManifest });
+}
+pass('uninstall', { bundles: removedManifest.dsh?.profile?.bundles || [] });
+
+const baseBootDump = dsh(['--profile', PROFILE, '--dump-config']);
+requireStatus('base-profile', baseBootDump, { command: 'dsh --dump-config after uninstall' });
+const leftover = parseDump(baseBootDump.stdout).rows.filter((row) => (
+  row.id === 'archify-skill-filesystem' || row.config.providerName === 'archify-plugin'
+));
+if (leftover.length > 0) {
+  fail('base-profile', 'uninstalled profile still contains the Archify provider', { leftover });
+}
+pass('base-profile', { bundles: removedManifest.dsh?.profile?.bundles || [] });
+
+const zipBlob = run('git', ['hash-object', 'archify.zip'], { cwd: repoRoot });
+const pkgBlob = run('git', ['hash-object', 'archify/package.json'], { cwd: repoRoot });
+const coreDiff = run('git', ['diff', `${FIXED_POINT}...`, '--', 'archify', 'archify.zip', 'scripts/build-zip.sh', 'scripts/package-smoke.mjs', '.github/workflows/ci.yml', '.github/workflows/release.yml'], { cwd: repoRoot });
+if (zipBlob.stdout.trim() !== ARCHIFY_ZIP_BLOB || pkgBlob.stdout.trim() !== ARCHIFY_PACKAGE_BLOB || coreDiff.stdout.trim()) {
+  fail('zero-regression', 'core ZIP, package, packer, or workflows drifted', {
+    zipBlob: zipBlob.stdout.trim(),
+    pkgBlob: pkgBlob.stdout.trim(),
+    coreDiff: coreDiff.stdout,
+  });
+}
+const skipFreshZipRebuild = process.platform === 'win32';
+const committedZip = path.join(repoRoot, 'archify.zip');
+const packedSkill = path.join(inspectRoot, 'package', 'skills', 'archify');
+let unzipContentsIdentical = false;
+if (skipFreshZipRebuild) {
+  receipt.zipContainerNote = 'Fresh ZIP rebuild skipped on Windows (rsync/zip are not on GitHub Windows runners). Used committed archify.zip for content comparison. ZIP container bytes are already known non-reproducible.';
+  const checkedDir = path.join(scratch, 'checked');
+  fs.mkdirSync(checkedDir);
+  fs.copyFileSync(committedZip, path.join(checkedDir, 'committed.zip'));
+  requireStatus('zero-regression', run('tar', ['-xf', 'committed.zip'], { cwd: checkedDir }));
+  const compared = treesMatch(packedSkill, path.join(checkedDir, 'archify'));
+  if (!compared.ok) {
+    fail('zero-regression', 'packed skill drifted from the committed ZIP', compared);
+  }
+  unzipContentsIdentical = true;
+} else {
+  const freshZip = path.join(scratch, 'fresh.zip');
+  const freshDir = path.join(scratch, 'fresh');
+  const checkedDir = path.join(scratch, 'checked');
+  requireStatus('zero-regression', run('bash', [path.join(repoRoot, 'scripts', 'build-zip.sh'), freshZip], { cwd: repoRoot }));
+  fs.mkdirSync(freshDir);
+  fs.mkdirSync(checkedDir);
+  requireStatus('zero-regression', run('unzip', ['-q', freshZip, '-d', freshDir]));
+  requireStatus('zero-regression', run('unzip', ['-q', committedZip, '-d', checkedDir]));
+  const unzipDiff = run('diff', ['-r', path.join(freshDir, 'archify'), path.join(checkedDir, 'archify')]);
+  if (unzipDiff.status !== 0) {
+    fail('zero-regression', 'fresh ZIP contents drifted from the committed ZIP', { diff: unzipDiff.stdout });
+  }
+  unzipContentsIdentical = true;
+}
+const skillsList = run('npx', ['-y', 'skills', 'add', repoRoot, '--list', '--full-depth'], { cwd: repoRoot, timeout: 120_000 });
+requireStatus('zero-regression', skillsList, { command: 'npx skills add --list --full-depth' });
+pass('zero-regression', {
+  archifyZipBlob: zipBlob.stdout.trim(),
+  archifyPackageBlob: pkgBlob.stdout.trim(),
+  unzipContentsIdentical,
+  zipContainerBytesReproducible: false,
+  ...(skipFreshZipRebuild ? { freshZipRebuildSkipped: true } : {}),
+  skillsCli: skillsList.stdout.trim().slice(0, 500),
+});
+
+receipt.ok = receipt.stages.every((stage) => stage.ok);
+process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+process.exit(receipt.ok ? 0 : 1);

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -289,7 +289,11 @@ probeChild.kill('SIGTERM');
 const probeReceipt = JSON.parse(fs.readFileSync(probeOut, 'utf8'));
 const archifyHits = (probeReceipt.skills || []).filter((skill) => skill.name === 'archify');
 if (archifyHits.length !== 1 || archifyHits[0].provider !== 'archify-plugin') {
-  fail('skill-discovery', 'public Skill registry did not discover archify only from archify-plugin', { probeReceipt });
+  fail('skill-discovery', 'public Skill registry did not discover archify only from archify-plugin', {
+    probeReceipt,
+    stdout: probeStdout,
+    stderr: probeStderr,
+  });
 }
 pass('skill-discovery', { provider: 'archify-plugin' });
 

--- a/integrations/deepseek-harness/scripts/pack.mjs
+++ b/integrations/deepseek-harness/scripts/pack.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnCliSync } from './resolve-cli.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const integrationRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(integrationRoot, '..', '..');
+const archifySource = path.join(repoRoot, 'archify');
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function excludeFromCleanSkill(sourceRoot, src) {
+  const relative = path.relative(sourceRoot, src);
+  if (!relative || relative === '.') return false;
+  const parts = relative.split(path.sep);
+  if (parts.includes('node_modules')) return true;
+  if (parts.includes('test')) return true;
+  if (parts.includes('.DS_Store')) return true;
+  if (parts.includes('.hive')) return true;
+  if (parts.includes('.workbuddy')) return true;
+  if (parts.some((part) => part.startsWith('.validator-check-'))) return true;
+  if (parts.join('/') === 'scripts/generate-validators.mjs') return true;
+  return false;
+}
+
+function trackedArchifyFiles() {
+  const tracked = spawnCliSync('git', ['ls-files', '-z', '--', 'archify'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (tracked.status !== 0) {
+    throw new Error(`unable to enumerate tracked Archify files: ${tracked.stderr || tracked.error?.message}`);
+  }
+  return tracked.stdout.split('\0').filter(Boolean);
+}
+
+function stageCleanArchify(dest) {
+  const validators = path.join(archifySource, 'renderers/shared/generated-validators.mjs');
+  if (!fs.existsSync(validators)) {
+    throw new Error('generated validators are missing — run npm run generate:validators in archify/');
+  }
+  for (const repoRelative of trackedArchifyFiles()) {
+    const src = path.join(repoRoot, ...repoRelative.split('/'));
+    if (excludeFromCleanSkill(archifySource, src)) continue;
+    const destination = path.join(dest, path.relative(archifySource, src));
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(src, destination);
+  }
+  const packagePath = path.join(dest, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  delete pkg.scripts;
+  delete pkg.devDependencies;
+  fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+  fs.rmSync(path.join(dest, 'package-lock.json'), { force: true });
+}
+
+const json = process.argv.includes('--json');
+const out = argValue('--out');
+const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-dsh-pack-'));
+
+try {
+  stageCleanArchify(path.join(stage, 'skills', 'archify'));
+  fs.copyFileSync(path.join(integrationRoot, 'package.json'), path.join(stage, 'package.json'));
+  fs.copyFileSync(path.join(integrationRoot, 'cordis.patch.yml'), path.join(stage, 'cordis.patch.yml'));
+  fs.cpSync(path.join(integrationRoot, 'lib'), path.join(stage, 'lib'), { recursive: true });
+  fs.copyFileSync(path.join(integrationRoot, 'README.md'), path.join(stage, 'README.md'));
+  fs.copyFileSync(path.join(repoRoot, 'LICENSE'), path.join(stage, 'LICENSE'));
+
+  const packed = spawnCliSync('npm', ['pack', '--json', '--pack-destination', stage], {
+    cwd: stage,
+    encoding: 'utf8',
+  });
+  if (packed.status !== 0) {
+    throw new Error(`npm pack failed: ${packed.stderr || packed.stdout || packed.error?.message}`);
+  }
+  const produced = fs.readdirSync(stage).find((name) => name.endsWith('.tgz'));
+  if (!produced) {
+    throw new Error(`npm pack produced no tarball\n${packed.stdout}\n${packed.stderr}`);
+  }
+  let packMeta = {};
+  try {
+    const jsonStart = Math.min(
+      ...['{', '['].map((token) => {
+        const index = packed.stdout.indexOf(token);
+        return index === -1 ? Number.POSITIVE_INFINITY : index;
+      }),
+    );
+    const parsed = JSON.parse(packed.stdout.slice(jsonStart));
+    packMeta = Array.isArray(parsed) ? parsed[0] : parsed;
+  } catch {
+    packMeta = {};
+  }
+  const listing = spawnCliSync('tar', ['-tzf', path.join(stage, produced)], { encoding: 'utf8' });
+  if (listing.status !== 0) {
+    throw new Error(`unable to list packed tarball: ${listing.stderr || listing.error?.message}`);
+  }
+  const files = listing.stdout.trim().split('\n').filter(Boolean).map((entry) => ({
+    path: entry.replace(/^package\//, ''),
+  }));
+  const destination = path.resolve(out || path.join(process.cwd(), produced));
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(path.join(stage, produced), destination);
+  const result = {
+    name: packMeta.name || '@tt-a1i/archify-dsh',
+    version: packMeta.version || '0.1.0',
+    filename: path.basename(destination),
+    destination,
+    files,
+  };
+  if (json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  else process.stdout.write(`${destination}\n`);
+} finally {
+  fs.rmSync(stage, { recursive: true, force: true });
+}

--- a/integrations/deepseek-harness/scripts/resolve-cli.mjs
+++ b/integrations/deepseek-harness/scripts/resolve-cli.mjs
@@ -1,0 +1,57 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CMD_SHIMS = new Set(['npm', 'npx']);
+
+export function resolveCli(command, platform = process.platform) {
+  if (platform !== 'win32') return command;
+  if (typeof command !== 'string' || command.length === 0) return command;
+  if (/[\\/]/.test(command) || /^[A-Za-z]:/.test(command)) return command;
+  if (/\.(?:cmd|bat|exe)$/i.test(command)) return command;
+  if (CMD_SHIMS.has(command)) return `${command}.cmd`;
+  return `${command}.exe`;
+}
+
+function nodeCliPath(command, {
+  platform = process.platform,
+  env = process.env,
+  execPath = process.execPath,
+  existsSync = fs.existsSync,
+} = {}) {
+  const pathApi = platform === 'win32' ? path.win32 : path;
+  const script = `${command}-cli.js`;
+  const candidates = [];
+  const npmExecPath = env.npm_execpath;
+  if (npmExecPath) {
+    candidates.push(pathApi.join(pathApi.dirname(npmExecPath), script));
+  }
+  candidates.push(pathApi.join(pathApi.dirname(execPath), 'node_modules', 'npm', 'bin', script));
+  const pathValue = env.PATH || env.Path || env.path || '';
+  for (const entry of pathValue.split(pathApi.delimiter).filter(Boolean)) {
+    candidates.push(pathApi.join(entry, 'node_modules', 'npm', 'bin', script));
+  }
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+export function resolveCliInvocation(command, args = [], options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform === 'win32' && CMD_SHIMS.has(command)) {
+    const cliPath = nodeCliPath(command, options);
+    if (!cliPath) {
+      throw new Error(`Cannot locate npm's ${command}-cli.js for a safe Windows launch`);
+    }
+    return { command: options.execPath || process.execPath, args: [cliPath, ...args] };
+  }
+  return { command: resolveCli(command, platform), args };
+}
+
+export function spawnCliSync(command, args, options) {
+  const invocation = resolveCliInvocation(command, args);
+  return spawnSync(invocation.command, invocation.args, options);
+}
+
+export function spawnCli(command, args, options) {
+  const invocation = resolveCliInvocation(command, args);
+  return spawn(invocation.command, invocation.args, options);
+}

--- a/integrations/deepseek-harness/test/adapter-security.test.mjs
+++ b/integrations/deepseek-harness/test/adapter-security.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const libRoot = path.resolve(here, '..', 'lib');
+
+test('host-loaded adapter code does not open a second execution, network, credential, or telemetry surface', () => {
+  const files = fs.readdirSync(libRoot).filter((name) => name.endsWith('.js'));
+  assert.ok(files.length > 0, 'adapter lib is missing');
+  const source = files.map((name) => fs.readFileSync(path.join(libRoot, name), 'utf8')).join('\n');
+  assert.doesNotMatch(source, /child_process/);
+  assert.doesNotMatch(source, /node:child_process/);
+  assert.doesNotMatch(source, /fetch\s*\(/);
+  assert.doesNotMatch(source, /node:http|node:https|node:net|node:dgram/);
+  assert.doesNotMatch(source, /telemetry|opentelemetry|otlp/i);
+  assert.doesNotMatch(source, /credentials|DEEPSEEK_API_KEY|process\.env\.\w*TOKEN/);
+  assert.doesNotMatch(source, /setInterval|setTimeout|Worker|cluster/);
+  assert.doesNotMatch(source, /archify_render|archify_deliver|tools\.register/);
+});
+
+test('package resolution failures fail loud instead of returning a guessed Skill root', async () => {
+  const { resolveArchifySkillRoot } = await import('../lib/index.js');
+  assert.throws(() => resolveArchifySkillRoot('file:///tmp/archify-dsh-missing-profile/'));
+  assert.throws(() => resolveArchifySkillRoot(''));
+});

--- a/integrations/deepseek-harness/test/docs-contract.test.mjs
+++ b/integrations/deepseek-harness/test/docs-contract.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('README.md and README_EN.md stay byte-identical after the DSH docs', () => {
+  assert.equal(read('README.md'), read('README_EN.md'));
+});
+
+test('English and Chinese docs cover install, invoke, uninstall, community wording, and Produced Files', () => {
+  const english = [read('README.md'), read('integrations/deepseek-harness/README.md')].join('\n');
+  const chinese = [read('README_ZH.md'), read('integrations/deepseek-harness/README.md')].join('\n');
+
+  for (const source of [english, chinese, read('README.md'), read('README_ZH.md')]) {
+    assert.match(source, /@tt-a1i\/archify-dsh@0\.1\.0/);
+    assert.match(source, /@deepseek-ai\/dsh@0\.1\.0-rc\.6/);
+    assert.match(source, /\^22\.19\.0 \|\| >=24\.0\.0/);
+    assert.match(source, /dsh plugin --profile web add @tt-a1i\/archify-dsh@0\.1\.0/);
+    assert.match(source, /dsh plugin --profile web remove @tt-a1i\/archify-dsh/);
+    assert.match(source, /Use the archify skill to map this repository's runtime architecture/);
+    assert.doesNotMatch(source, /dsh plugin[^\n]*github:tt-a1i\/archify/);
+    assert.doesNotMatch(source, /allowBuilds:\s*true/);
+    assert.doesNotMatch(source, /npm install github:/);
+  }
+
+  assert.match(english, /community integration/i);
+  assert.match(english, /developer-preview/i);
+  assert.match(english, /not an official DeepSeek/i);
+  assert.match(english, /Produced Files/i);
+  assert.match(english, /exact workspace paths/);
+  assert.match(english, /no telemetry/i);
+
+  assert.match(chinese, /社区集成/);
+  assert.match(chinese, /开发者预览/);
+  assert.match(chinese, /不是 DeepSeek 官方/);
+  assert.match(chinese, /Produced Files/);
+  assert.match(chinese, /精确工作区路径/);
+  assert.match(chinese, /遥测/);
+});
+
+test('Skills CLI, Cursor, Codex, Claude Code, OpenCode, and Raven remain the default main path', () => {
+  const english = read('README.md');
+  const chinese = read('README_ZH.md');
+  assert.match(english, /^```bash\nnpx skills add tt-a1i\/archify -g\n```$/m);
+  assert.match(chinese, /^```bash\nnpx skills add tt-a1i\/archify -g\n```$/m);
+  assert.match(english, /## Quick start/);
+  assert.match(chinese, /## 快速开始/);
+  const dshEnglishIndex = english.indexOf('DeepSeek Harness');
+  const quickStartIndex = english.indexOf('## Quick start');
+  assert.ok(dshEnglishIndex > quickStartIndex, 'DSH docs must not precede the default quick start');
+});

--- a/integrations/deepseek-harness/test/package-contract.test.mjs
+++ b/integrations/deepseek-harness/test/package-contract.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const integrationRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(integrationRoot, '..', '..');
+const manifestPath = path.join(integrationRoot, 'package.json');
+
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+  'bundledDependencies',
+  'bundleDependencies',
+];
+const LIFECYCLE_SCRIPTS = ['prepare', 'install', 'postinstall', 'preinstall'];
+
+test('adapter source lives only under integrations/deepseek-harness with no root workspace', () => {
+  assert.equal(fs.existsSync(path.join(repoRoot, 'package.json')), false);
+  assert.equal(fs.existsSync(path.join(repoRoot, 'package-lock.json')), false);
+  assert.equal(fs.existsSync(path.join(repoRoot, 'pnpm-workspace.yaml')), false);
+  assert.equal(fs.existsSync(path.join(repoRoot, 'integrations/deepseek-harness/package.json')), true);
+});
+
+test('publishable manifest is @tt-a1i/archify-dsh@0.1.0 with a DSH bundle patch and no install surface', () => {
+  const pkg = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.equal(pkg.name, '@tt-a1i/archify-dsh');
+  assert.equal(pkg.version, '0.1.0');
+  assert.equal(pkg.license, 'MIT');
+  assert.equal(pkg.type, 'module');
+  assert.equal(pkg.main, './lib/index.js');
+  assert.equal(pkg.dsh?.bundle?.patch, './cordis.patch.yml');
+  assert.equal(fs.existsSync(path.join(integrationRoot, pkg.dsh.bundle.patch)), true);
+  assert.equal(pkg.repository?.url, 'git+https://github.com/tt-a1i/archify.git');
+  assert.equal(pkg.repository?.directory, 'integrations/deepseek-harness');
+  for (const keyword of ['dsh-plugin', 'deepseek-harness', 'agent-skill', 'architecture-diagram']) {
+    assert.ok(pkg.keywords?.includes(keyword), `missing keyword ${keyword}`);
+  }
+  for (const field of DEPENDENCY_FIELDS) {
+    assert.equal(Object.prototype.hasOwnProperty.call(pkg, field), false, field);
+  }
+  for (const script of LIFECYCLE_SCRIPTS) {
+    assert.equal(pkg.scripts?.[script], undefined, script);
+  }
+  assert.match(pkg.exports?.['./package.json'] || '', /package\.json/);
+});
+
+test('bundle patch inserts one uniquely named filesystem Skill provider resolved from the installed package', () => {
+  const patch = fs.readFileSync(path.join(integrationRoot, 'cordis.patch.yml'), 'utf8');
+  assert.match(patch, /^- insert:/m);
+  assert.match(patch, /id:\s*archify-skill-filesystem/);
+  assert.match(patch, /name:\s*'@deepseek-ai\/dsh-skill-filesystem'/);
+  assert.match(patch, /providerName:\s*archify-plugin/);
+  assert.match(patch, /includeDefaultRoots:\s*false/);
+  assert.match(
+    patch,
+    /createRequire\(baseUrl\)\.resolve\('@tt-a1i\/archify-dsh\/package\.json'\)/,
+  );
+  assert.doesNotMatch(patch, /new URL\(\s*['"]skills\//);
+  assert.doesNotMatch(patch, /archify_render|archify_deliver|dsh\.client|ui-deliverables/);
+  const insertBlocks = patch.split(/^- insert:/m).slice(1);
+  assert.equal(insertBlocks.length, 1);
+  const insertedIds = [...insertBlocks[0].matchAll(/^\s+- id:\s*(\S+)/gm)].map((match) => match[1]);
+  assert.deepEqual(insertedIds, ['archify-skill-filesystem']);
+});

--- a/integrations/deepseek-harness/test/package-contract.test.mjs
+++ b/integrations/deepseek-harness/test/package-contract.test.mjs
@@ -56,6 +56,8 @@ test('bundle patch inserts one uniquely named filesystem Skill provider resolved
   assert.match(patch, /name:\s*'@deepseek-ai\/dsh-skill-filesystem'/);
   assert.match(patch, /providerName:\s*archify-plugin/);
   assert.match(patch, /includeDefaultRoots:\s*false/);
+  assert.match(patch, /bundledSkillDir:\s*!!js/);
+  assert.doesNotMatch(patch, /customSkillDirs/);
   assert.match(
     patch,
     /createRequire\(baseUrl\)\.resolve\('@tt-a1i\/archify-dsh\/package\.json'\)/,

--- a/integrations/deepseek-harness/test/probe-skills.mjs
+++ b/integrations/deepseek-harness/test/probe-skills.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const name = 'archify-dsh-skill-probe';
+export const inject = ['skills'];
+
+export async function apply(ctx) {
+  const out = process.env.ARCHIFY_DSH_PROBE_OUT;
+  if (!out) throw new Error('ARCHIFY_DSH_PROBE_OUT is required for the test-only skill probe');
+  const cwd = process.cwd();
+  const list = await ctx.skills.list({ cwd });
+  const archify = list.find((skill) => skill.name === 'archify');
+  const definition = archify ? await ctx.skills.get('archify', { cwd }) : null;
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  fs.writeFileSync(out, `${JSON.stringify({
+    skills: list.map((skill) => ({
+      name: skill.name,
+      provider: skill.provider,
+      resourceBase: skill.resourceBase,
+      path: skill.path,
+    })),
+    definition: definition && {
+      name: definition.name,
+      provider: definition.provider,
+      resourceBase: definition.resourceBase,
+      path: definition.path,
+      contentLength: definition.content?.length || 0,
+    },
+  }, null, 2)}\n`);
+  const exit = ctx.cmdlineArgs?.exit || ctx.appExit;
+  if (typeof exit === 'function') exit(0);
+}

--- a/integrations/deepseek-harness/test/probe-skills.mjs
+++ b/integrations/deepseek-harness/test/probe-skills.mjs
@@ -1,15 +1,32 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 
 export const name = 'archify-dsh-skill-probe';
 export const inject = ['skills'];
+
+export async function waitForArchify(skills, cwd, {
+  timeoutMs = 30_000,
+  pollMs = 100,
+  sleep = delay,
+} = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let list = [];
+  do {
+    list = await skills.list({ cwd });
+    const archify = list.find((skill) => skill.name === 'archify');
+    if (archify) return { list, archify };
+    if (Date.now() >= deadline) break;
+    await sleep(pollMs);
+  } while (true);
+  return { list, archify: undefined };
+}
 
 export async function apply(ctx) {
   const out = process.env.ARCHIFY_DSH_PROBE_OUT;
   if (!out) throw new Error('ARCHIFY_DSH_PROBE_OUT is required for the test-only skill probe');
   const cwd = process.cwd();
-  const list = await ctx.skills.list({ cwd });
-  const archify = list.find((skill) => skill.name === 'archify');
+  const { list, archify } = await waitForArchify(ctx.skills, cwd);
   const definition = archify ? await ctx.skills.get('archify', { cwd }) : null;
   fs.mkdirSync(path.dirname(out), { recursive: true });
   fs.writeFileSync(out, `${JSON.stringify({

--- a/integrations/deepseek-harness/test/probe-skills.test.mjs
+++ b/integrations/deepseek-harness/test/probe-skills.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { waitForArchify } from './probe-skills.mjs';
+
+test('skill probe waits for a provider that registers during DSH boot', async () => {
+  let calls = 0;
+  const archify = { name: 'archify', provider: 'archify-plugin' };
+  const skills = {
+    async list() {
+      calls += 1;
+      return calls < 3 ? [] : [archify];
+    },
+  };
+  const result = await waitForArchify(skills, '/workspace', {
+    timeoutMs: 1_000,
+    sleep: async () => {},
+  });
+  assert.equal(calls, 3);
+  assert.equal(result.archify, archify);
+  assert.deepEqual(result.list, [archify]);
+});

--- a/integrations/deepseek-harness/test/resolve-cli.test.mjs
+++ b/integrations/deepseek-harness/test/resolve-cli.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { resolveCli, resolveCliInvocation } from '../scripts/resolve-cli.mjs';
+
+test('Windows CLI resolution uses .cmd shims for npm/npx and .exe for other commands', () => {
+  assert.equal(resolveCli('npx', 'win32'), 'npx.cmd');
+  assert.equal(resolveCli('npm', 'win32'), 'npm.cmd');
+  assert.equal(resolveCli('tar', 'win32'), 'tar.exe');
+  assert.equal(resolveCli('git', 'win32'), 'git.exe');
+  assert.equal(resolveCli('npx.cmd', 'win32'), 'npx.cmd');
+  assert.equal(resolveCli('tar.exe', 'win32'), 'tar.exe');
+  assert.equal(resolveCli('npx', 'darwin'), 'npx');
+  assert.equal(resolveCli('npm', 'linux'), 'npm');
+  assert.equal(resolveCli('tar', 'darwin'), 'tar');
+});
+
+test('Windows npm shims launch their JavaScript CLI through Node', () => {
+  const execPath = 'C:\\node\\node.exe';
+  const npmCli = 'C:\\node\\node_modules\\npm\\bin\\npm-cli.js';
+  const invocation = resolveCliInvocation('npm', ['--version'], {
+    platform: 'win32',
+    execPath,
+    env: {},
+    existsSync(candidate) {
+      return candidate === npmCli;
+    },
+  });
+  assert.deepEqual(invocation, { command: execPath, args: [npmCli, '--version'] });
+});
+
+test('resolved npm invocation can actually be spawned', () => {
+  const invocation = resolveCliInvocation('npm', ['--version']);
+  const result = spawnSync(invocation.command, invocation.args, { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+  assert.match(result.stdout.trim(), /^\d+\.\d+\.\d+/);
+});

--- a/integrations/deepseek-harness/test/tarball-contract.test.mjs
+++ b/integrations/deepseek-harness/test/tarball-contract.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const integrationRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(integrationRoot, '..', '..');
+const packScript = path.join(integrationRoot, 'scripts', 'pack.mjs');
+
+const FORBIDDEN = [
+  '/test/',
+  'package-lock.json',
+  '/node_modules/',
+  '.hive',
+  '.workbuddy',
+  'probe-skills',
+  'generate-validators.mjs',
+  'distribution-acceptance',
+];
+
+function packTarball() {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-dsh-tarball-'));
+  const out = path.join(scratch, 'tt-a1i-archify-dsh-0.1.0.tgz');
+  const result = spawnSync(process.execPath, [packScript, '--out', out, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return { scratch, out, result };
+}
+
+test('pack command emits a real npm tarball with the expected identity and file list', () => {
+  const { scratch, out, result } = packTarball();
+  try {
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const receipt = JSON.parse(result.stdout);
+    assert.equal(receipt.name, '@tt-a1i/archify-dsh');
+    assert.equal(receipt.version, '0.1.0');
+    assert.equal(fs.existsSync(out), true);
+    const files = receipt.files.map((file) => file.path.replace(/^package\//, ''));
+    for (const required of [
+      'package.json',
+      'cordis.patch.yml',
+      'lib/index.js',
+      'README.md',
+      'LICENSE',
+      'skills/archify/SKILL.md',
+      'skills/archify/bin/archify.mjs',
+    ]) {
+      assert.ok(files.includes(required), `tarball missing ${required}`);
+    }
+    const skillEntries = files.filter((file) => file === 'skills/archify/SKILL.md' || file.endsWith('/SKILL.md'));
+    assert.deepEqual(skillEntries, ['skills/archify/SKILL.md']);
+    for (const file of files) {
+      for (const forbidden of FORBIDDEN) {
+        assert.equal(file.includes(forbidden), false, `tarball contains forbidden ${file}`);
+      }
+    }
+    assert.equal(files.some((file) => file.startsWith('test/')), false);
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test('packed Skill payload matches the existing ZIP clean-staging contract', () => {
+  const { scratch, out, result } = packTarball();
+  const zipScratch = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-dsh-zip-stage-'));
+  try {
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const packedRoot = path.join(scratch, 'packed');
+    fs.mkdirSync(packedRoot);
+    const tar = spawnSync('tar', ['-xzf', out, '-C', packedRoot], { encoding: 'utf8' });
+    assert.equal(tar.status, 0, tar.stderr);
+    const zipPath = path.join(zipScratch, 'archify.zip');
+    const zip = spawnSync('bash', [path.join(repoRoot, 'scripts', 'build-zip.sh'), zipPath], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    assert.equal(zip.status, 0, zip.stderr);
+    const zipRoot = path.join(zipScratch, 'unzipped');
+    fs.mkdirSync(zipRoot);
+    const unzip = spawnSync('unzip', ['-q', zipPath, '-d', zipRoot], { encoding: 'utf8' });
+    assert.equal(unzip.status, 0, unzip.stderr);
+    const diff = spawnSync('diff', [
+      '-r',
+      path.join(packedRoot, 'package', 'skills', 'archify'),
+      path.join(zipRoot, 'archify'),
+    ], { encoding: 'utf8' });
+    assert.equal(diff.status, 0, diff.stdout || diff.stderr);
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+    fs.rmSync(zipScratch, { recursive: true, force: true });
+  }
+});

--- a/integrations/deepseek-harness/test/zero-regression.test.mjs
+++ b/integrations/deepseek-harness/test/zero-regression.test.mjs
@@ -37,13 +37,17 @@ test('the repository still has exactly one checked-in Archify SKILL.md and no ge
 });
 
 test('Archify core does not import, detect, or branch on DeepSeek Harness', () => {
-  const grep = spawnSync('rg', [
+  const grep = spawnSync('git', [
+    'grep',
     '-n',
+    '-E',
     'deepseek-harness|@deepseek-ai/dsh|DSH_HOME|DSH_AGENTS_HOME|archify-dsh',
+    '--',
     'archify',
     'scripts/build-zip.sh',
     'scripts/package-smoke.mjs',
   ], { cwd: repoRoot, encoding: 'utf8' });
+  assert.equal(grep.status, 1, grep.stderr || grep.stdout);
   assert.equal(grep.stdout.trim(), '');
 });
 

--- a/integrations/deepseek-harness/test/zero-regression.test.mjs
+++ b/integrations/deepseek-harness/test/zero-regression.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..');
+const FIXED_POINT = '45f0611dfc0dc824e9a13a12efcac207a8a2bdce';
+const ARCHIFY_ZIP_BLOB = '4249d32a5a07deb63152a06ac8c2cf4784d25136';
+const ARCHIFY_PACKAGE_BLOB = '238d6237ff0c942d459e7ec257f19386522306a0';
+
+function git(args) {
+  const result = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+test('core Skill, ZIP, packer, package-smoke, and existing workflows are unchanged vs the fixed point', () => {
+  assert.equal(git(['rev-parse', `${FIXED_POINT}:archify.zip`]), ARCHIFY_ZIP_BLOB);
+  assert.equal(git(['rev-parse', 'HEAD:archify.zip']), ARCHIFY_ZIP_BLOB);
+  assert.equal(git(['hash-object', 'archify.zip']), ARCHIFY_ZIP_BLOB);
+  assert.equal(git(['rev-parse', `${FIXED_POINT}:archify/package.json`]), ARCHIFY_PACKAGE_BLOB);
+  assert.equal(git(['hash-object', 'archify/package.json']), ARCHIFY_PACKAGE_BLOB);
+  assert.equal(git(['diff', `${FIXED_POINT}...`, '--', 'archify', 'archify.zip']), '');
+  assert.equal(git(['diff', `${FIXED_POINT}...`, '--', 'scripts/build-zip.sh', 'scripts/package-smoke.mjs']), '');
+  assert.equal(git(['diff', `${FIXED_POINT}...`, '--', '.github/workflows/ci.yml', '.github/workflows/release.yml']), '');
+});
+
+test('the repository still has exactly one checked-in Archify SKILL.md and no generated DSH payload', () => {
+  const skillFiles = git(['ls-files', '*SKILL.md']).split('\n').filter(Boolean);
+  assert.deepEqual(skillFiles, ['archify/SKILL.md']);
+  assert.equal(fs.existsSync(path.join(repoRoot, 'integrations/deepseek-harness/skills')), false);
+  const trackedSkills = git(['ls-files', 'integrations/deepseek-harness/skills']);
+  assert.equal(trackedSkills, '');
+});
+
+test('Archify core does not import, detect, or branch on DeepSeek Harness', () => {
+  const grep = spawnSync('rg', [
+    '-n',
+    'deepseek-harness|@deepseek-ai/dsh|DSH_HOME|DSH_AGENTS_HOME|archify-dsh',
+    'archify',
+    'scripts/build-zip.sh',
+    'scripts/package-smoke.mjs',
+  ], { cwd: repoRoot, encoding: 'utf8' });
+  assert.equal(grep.stdout.trim(), '');
+});
+
+test('full-depth Skills CLI discovery still finds only one skill named archify', () => {
+  const result = spawnSync('npx', ['-y', 'skills', 'add', repoRoot, '--list', '--full-depth'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const names = [...result.stdout.matchAll(/^\s*[-*]\s+(\S+)/gm)].map((match) => match[1])
+    .filter((name) => name === 'archify' || /archify/i.test(name));
+  const unique = new Set(
+    [...result.stdout.matchAll(/\barchify\b/gi)].map((match) => match[0].toLowerCase()),
+  );
+  assert.ok(result.stdout.includes('archify'), result.stdout);
+  assert.equal(unique.size, 1, result.stdout);
+  assert.ok(names.length <= 1 || new Set(names).size === 1, result.stdout);
+});


### PR DESCRIPTION
## Why

Add a timely DeepSeek Harness discovery path for Archify without changing the default installation or runtime for non-DSH users.

Closes #68.

## What changed

- Adds the independently publishable `@tt-a1i/archify-dsh@0.1.0` Skill-only bundle under `integrations/deepseek-harness/`.
- Pins compatibility to `@deepseek-ai/dsh@0.1.0-rc.6`.
- Adds one isolated filesystem Skill provider; it does not replace the built-in DSH provider.
- Packages only Git-tracked Archify files and keeps core `archify/`, `archify.zip`, release scripts, and existing workflows unchanged.
- Adds concise opt-in install and uninstall documentation while keeping the ordinary Skills CLI, Cursor, Codex, Claude Code, OpenCode, and Raven paths primary.
- Adds PR/scheduled acceptance plus an explicit three-platform release gate.

## Isolation and rollback

Non-DSH users do not load, detect, import, or branch on this integration. No root workspace, dependency, install hook, telemetry, network, credential, or second tool-execution surface is added. Rollback is removal of the integration package/profile only.

## Verification

- `node --test integrations/deepseek-harness/test/*.test.mjs` — 17/17 passed
- `node integrations/deepseek-harness/scripts/distribution-acceptance.mjs` — real tarball install, compose, discovery, load, package smoke, uninstall, and zero-regression receipt passed on macOS
- `cd archify && npm test` — 627/627 passed
- `git diff --cached --check` — passed
- Independent pre-commit correctness review — passed with no remaining blocker or should-fix

The PR checks exercise the DSH contract and Ubuntu distribution path. The macOS/Windows/Ubuntu adapter-release matrix is configured as a pre-publish gate and is not claimed as executed by this PR.

## Visual evidence

Not applicable: this is an opt-in packaging/integration change with no product UI change.

## Release boundary

This PR does not publish npm, create a tag/release, or change the default Archify artifact.