### PR TITLE
fix: make DSH packaging portable on Windows

### DIFF
--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -16,7 +16,8 @@ const PROFILE = 'archify-dsh-acceptance';
 const FIXED_POINT = '45f0611dfc0dc824e9a13a12efcac207a8a2bdce';
 const ARCHIFY_ZIP_BLOB = '4249d32a5a07deb63152a06ac8c2cf4784d25136';
 const ARCHIFY_PACKAGE_BLOB = '238d6237ff0c942d459e7ec257f19386522306a0';
-const PLUGIN_MUTATION_TIMEOUT = process.platform === 'win32' ? 480_000 : 180_000;
+const DSH_RUNTIME_INSTALL_TIMEOUT = process.platform === 'win32' ? 600_000 : 300_000;
+const PLUGIN_MUTATION_TIMEOUT = 180_000;
 
 const receipt = {
   ok: false,
@@ -151,10 +152,12 @@ const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-dsh-acceptance-')
 const tarball = path.join(scratch, 'tt-a1i-archify-dsh-0.1.0.tgz');
 const dshHome = path.join(scratch, 'dsh-home');
 const agentsHome = path.join(scratch, 'agents-home');
+const dshRuntime = path.join(scratch, 'dsh-runtime');
 const workspace = path.join(scratch, 'workspace');
 const probeOut = path.join(scratch, 'skill-probe.json');
 fs.mkdirSync(dshHome);
 fs.mkdirSync(agentsHome);
+fs.mkdirSync(dshRuntime);
 fs.mkdirSync(workspace);
 
 function cleanup() {
@@ -213,10 +216,38 @@ const dshEnv = {
   ARCHIFY_DSH_PROBE_OUT: probeOut,
   npm_config_update_notifier: 'false',
 };
-const npx = ['-y', '--package', DSH_SPEC, 'dsh'];
+
+// Install the pinned host once, as a user-level global install would. Keeping
+// this separate from plugin mutation makes a slow first-time npm download
+// distinguishable from `dsh plugin add`, especially on Windows runners.
+const runtimeInstall = run('npm', [
+  'install',
+  '--prefix', dshRuntime,
+  '--no-save',
+  '--package-lock=false',
+  '--no-audit',
+  '--no-fund',
+  '--loglevel=warn',
+  DSH_SPEC,
+], {
+  cwd: scratch,
+  env: dshEnv,
+  timeout: DSH_RUNTIME_INSTALL_TIMEOUT,
+});
+requireStatus('dsh-runtime-install', runtimeInstall, { command: `npm install ${DSH_SPEC}` });
+const dshPackageRoot = path.join(dshRuntime, 'node_modules', '@deepseek-ai', 'dsh');
+const dshManifest = JSON.parse(fs.readFileSync(path.join(dshPackageRoot, 'package.json'), 'utf8'));
+const dshBin = path.join(dshPackageRoot, 'lib', 'bin.js');
+if (dshManifest.version !== DSH_SPEC.slice(DSH_SPEC.lastIndexOf('@') + 1) || !fs.existsSync(dshBin)) {
+  fail('dsh-runtime-install', 'installed DSH runtime identity mismatch', {
+    version: dshManifest.version,
+    binExists: fs.existsSync(dshBin),
+  });
+}
+pass('dsh-runtime-install', { version: dshManifest.version });
 
 function dsh(args, options = {}) {
-  return run('npx', [...npx, ...args], {
+  return run(process.execPath, [dshBin, ...args], {
     cwd: options.cwd || workspace,
     env: dshEnv,
     timeout: options.timeout ?? 120_000,
@@ -273,7 +304,7 @@ fs.writeFileSync(probePatch, `- insert:
       name: ${JSON.stringify(pathToFileURL(probeModule).href)}
       inject: [skills]
 `);
-const probeChild = spawnCli('npx', [...npx, '--profile', PROFILE, '--patch', probePatch], {
+const probeChild = spawnCli(process.execPath, [dshBin, '--profile', PROFILE, '--patch', probePatch], {
   cwd: workspace,
   env: dshEnv,
   stdio: ['ignore', 'pipe', 'pipe'],

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -245,12 +245,14 @@ const runtimeInstall = run('npm', [
   '--no-audit',
   '--no-fund',
   '--foreground-scripts',
-  '--loglevel=info',
+  '--loglevel=warn',
   DSH_SPEC,
 ], {
   cwd: scratch,
   env: dshEnv,
-  stdio: 'inherit',
+  // Stream npm lifecycle diagnostics without polluting the JSON-only receipt
+  // written to this process's stdout.
+  stdio: ['ignore', 2, 2],
   timeout: DSH_RUNTIME_INSTALL_TIMEOUT,
 });
 requireStatus('dsh-runtime-install', runtimeInstall, { command: `npm install ${DSH_SPEC}` });

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -244,11 +244,13 @@ const runtimeInstall = run('npm', [
   '--package-lock=false',
   '--no-audit',
   '--no-fund',
-  '--loglevel=warn',
+  '--foreground-scripts',
+  '--loglevel=info',
   DSH_SPEC,
 ], {
   cwd: scratch,
   env: dshEnv,
+  stdio: 'inherit',
   timeout: DSH_RUNTIME_INSTALL_TIMEOUT,
 });
 requireStatus('dsh-runtime-install', runtimeInstall, { command: `npm install ${DSH_SPEC}` });

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -72,7 +72,19 @@ function listRelativeFiles(root) {
   return files.sort();
 }
 
-function treesMatch(left, right) {
+const CHECKOUT_TEXT_EXTENSIONS = new Set(['.html', '.json', '.md', '.mjs']);
+
+function checkoutContentsEqual(file, left, right, normalizeTextEol) {
+  if (left.equals(right)) return true;
+  if (!normalizeTextEol) return false;
+  const isCheckoutText = path.basename(file) === 'LICENSE'
+    || CHECKOUT_TEXT_EXTENSIONS.has(path.extname(file).toLowerCase());
+  if (!isCheckoutText) return false;
+  return left.toString('utf8').replaceAll('\r\n', '\n')
+    === right.toString('utf8').replaceAll('\r\n', '\n');
+}
+
+function treesMatch(left, right, { normalizeTextEol = false } = {}) {
   const leftFiles = listRelativeFiles(left);
   const rightFiles = listRelativeFiles(right);
   if (leftFiles.join('\n') !== rightFiles.join('\n')) {
@@ -81,7 +93,12 @@ function treesMatch(left, right) {
   for (const file of leftFiles) {
     const leftPath = path.join(left, ...file.split('/'));
     const rightPath = path.join(right, ...file.split('/'));
-    if (!fs.readFileSync(leftPath).equals(fs.readFileSync(rightPath))) {
+    if (!checkoutContentsEqual(
+      file,
+      fs.readFileSync(leftPath),
+      fs.readFileSync(rightPath),
+      normalizeTextEol,
+    )) {
       return { ok: false, file };
     }
   }
@@ -403,12 +420,12 @@ const committedZip = path.join(repoRoot, 'archify.zip');
 const packedSkill = path.join(inspectRoot, 'package', 'skills', 'archify');
 let unzipContentsIdentical = false;
 if (skipFreshZipRebuild) {
-  receipt.zipContainerNote = 'Fresh ZIP rebuild skipped on Windows (rsync/zip are not on GitHub Windows runners). Used committed archify.zip for content comparison. ZIP container bytes are already known non-reproducible.';
+  receipt.zipContainerNote = 'Fresh ZIP rebuild skipped on Windows (rsync/zip are not on GitHub Windows runners). Used committed archify.zip for content comparison; known text files normalize checkout CRLF while all other files remain byte-exact. ZIP container bytes are already known non-reproducible.';
   const checkedDir = path.join(scratch, 'checked');
   fs.mkdirSync(checkedDir);
   fs.copyFileSync(committedZip, path.join(checkedDir, 'committed.zip'));
   requireStatus('zero-regression', run('tar', ['-xf', 'committed.zip'], { cwd: checkedDir }));
-  const compared = treesMatch(packedSkill, path.join(checkedDir, 'archify'));
+  const compared = treesMatch(packedSkill, path.join(checkedDir, 'archify'), { normalizeTextEol: true });
   if (!compared.ok) {
     fail('zero-regression', 'packed skill drifted from the committed ZIP', compared);
   }
@@ -435,7 +452,7 @@ pass('zero-regression', {
   archifyPackageBlob: pkgBlob.stdout.trim(),
   unzipContentsIdentical,
   zipContainerBytesReproducible: false,
-  ...(skipFreshZipRebuild ? { freshZipRebuildSkipped: true } : {}),
+  ...(skipFreshZipRebuild ? { freshZipRebuildSkipped: true, checkoutTextEolNormalized: true } : {}),
   skillsCli: skillsList.stdout.trim().slice(0, 500),
 });
 

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -182,7 +182,9 @@ pass('pack', { filename: packReceipt.filename, fileCount: packReceipt.files?.len
 
 const inspectRoot = path.join(scratch, 'tarball');
 fs.mkdirSync(inspectRoot);
-requireStatus('tarball-inspect', run('tar', ['-xzf', tarball, '-C', inspectRoot]));
+requireStatus('tarball-inspect', run('tar', ['-xzf', path.basename(tarball), '-C', inspectRoot], {
+  cwd: path.dirname(tarball),
+}));
 const packedPkg = JSON.parse(fs.readFileSync(path.join(inspectRoot, 'package', 'package.json'), 'utf8'));
 const packedFiles = listRelativeFiles(path.join(inspectRoot, 'package'));
 const forbidden = packedFiles.filter((file) => (

--- a/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
+++ b/integrations/deepseek-harness/scripts/distribution-acceptance.mjs
@@ -16,6 +16,7 @@ const PROFILE = 'archify-dsh-acceptance';
 const FIXED_POINT = '45f0611dfc0dc824e9a13a12efcac207a8a2bdce';
 const ARCHIFY_ZIP_BLOB = '4249d32a5a07deb63152a06ac8c2cf4784d25136';
 const ARCHIFY_PACKAGE_BLOB = '238d6237ff0c942d459e7ec257f19386522306a0';
+const PLUGIN_MUTATION_TIMEOUT = process.platform === 'win32' ? 480_000 : 180_000;
 
 const receipt = {
   ok: false,
@@ -222,7 +223,7 @@ function dsh(args, options = {}) {
   });
 }
 
-const install = dsh(['plugin', '--profile', PROFILE, 'add', tarball], { timeout: 180_000 });
+const install = dsh(['plugin', '--profile', PROFILE, 'add', tarball], { timeout: PLUGIN_MUTATION_TIMEOUT });
 requireStatus('plugin-install', install, { command: `dsh plugin --profile ${PROFILE} add <tarball>` });
 pass('plugin-install', { profile: PROFILE });
 
@@ -337,7 +338,7 @@ const smoke = run(process.execPath, [path.join(repoRoot, 'scripts', 'package-smo
 requireStatus('package-smoke', smoke, { command: 'package-smoke.mjs <installed-skill-root>' });
 pass('package-smoke', { skillRoot, output: smoke.stdout.trim() });
 
-const remove = dsh(['plugin', '--profile', PROFILE, 'remove', PACKAGE_NAME], { timeout: 180_000 });
+const remove = dsh(['plugin', '--profile', PROFILE, 'remove', PACKAGE_NAME], { timeout: PLUGIN_MUTATION_TIMEOUT });
 requireStatus('uninstall', remove, { command: `dsh plugin --profile ${PROFILE} remove ${PACKAGE_NAME}` });
 const removedManifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
 if ((removedManifest.dsh?.profile?.bundles || []).includes(PACKAGE_NAME)

--- a/integrations/deepseek-harness/scripts/pack.mjs
+++ b/integrations/deepseek-harness/scripts/pack.mjs
@@ -93,17 +93,20 @@ try {
       }),
     );
     const parsed = JSON.parse(packed.stdout.slice(jsonStart));
-    packMeta = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (Array.isArray(parsed)) {
+      packMeta = parsed[0] || {};
+    } else if (parsed?.name) {
+      packMeta = parsed;
+    } else {
+      packMeta = Object.values(parsed || {}).find((entry) => entry?.name === '@tt-a1i/archify-dsh') || {};
+    }
   } catch {
     packMeta = {};
   }
-  const listing = spawnCliSync('tar', ['-tzf', path.join(stage, produced)], { encoding: 'utf8' });
-  if (listing.status !== 0) {
-    throw new Error(`unable to list packed tarball: ${listing.stderr || listing.error?.message}`);
+  if (!Array.isArray(packMeta.files)) {
+    throw new Error(`npm pack metadata did not include a file list\n${packed.stdout}`);
   }
-  const files = listing.stdout.trim().split('\n').filter(Boolean).map((entry) => ({
-    path: entry.replace(/^package\//, ''),
-  }));
+  const files = packMeta.files.map((file) => ({ path: file.path }));
   const destination = path.resolve(out || path.join(process.cwd(), produced));
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.copyFileSync(path.join(stage, produced), destination);

--- a/integrations/deepseek-harness/scripts/resolve-cli.mjs
+++ b/integrations/deepseek-harness/scripts/resolve-cli.mjs
@@ -36,6 +36,13 @@ function nodeCliPath(command, {
 
 export function resolveCliInvocation(command, args = [], options = {}) {
   const platform = options.platform || process.platform;
+  if (platform === 'win32' && command === 'tar') {
+    const env = options.env || process.env;
+    const existsSync = options.existsSync || fs.existsSync;
+    const systemRoot = env.SystemRoot || env.SYSTEMROOT || env.windir || env.WINDIR;
+    const systemTar = systemRoot && path.win32.join(systemRoot, 'System32', 'tar.exe');
+    if (systemTar && existsSync(systemTar)) return { command: systemTar, args };
+  }
   if (platform === 'win32' && CMD_SHIMS.has(command)) {
     const cliPath = nodeCliPath(command, options);
     if (!cliPath) {

--- a/integrations/deepseek-harness/test/package-contract.test.mjs
+++ b/integrations/deepseek-harness/test/package-contract.test.mjs
@@ -69,3 +69,14 @@ test('bundle patch inserts one uniquely named filesystem Skill provider resolved
   const insertedIds = [...insertBlocks[0].matchAll(/^\s+- id:\s*(\S+)/gm)].map((match) => match[1]);
   assert.deepEqual(insertedIds, ['archify-skill-filesystem']);
 });
+
+test('distribution acceptance reserves stdout for its machine-readable JSON receipt', () => {
+  const source = fs.readFileSync(
+    path.join(integrationRoot, 'scripts', 'distribution-acceptance.mjs'),
+    'utf8',
+  );
+  const runtimeInstall = source.match(/const runtimeInstall = run\([\s\S]*?\n\}\);/)?.[0] || '';
+  assert.match(runtimeInstall, /stdio:\s*\['ignore',\s*2,\s*2\]/);
+  assert.doesNotMatch(source, /stdio:\s*['"]inherit['"]/);
+  assert.equal([...source.matchAll(/process\.stdout\.write/g)].length, 2);
+});

--- a/integrations/deepseek-harness/test/resolve-cli.test.mjs
+++ b/integrations/deepseek-harness/test/resolve-cli.test.mjs
@@ -29,6 +29,18 @@ test('Windows npm shims launch their JavaScript CLI through Node', () => {
   assert.deepEqual(invocation, { command: execPath, args: [npmCli, '--version'] });
 });
 
+test('Windows tar uses the system bsdtar instead of a Git for Windows PATH shadow', () => {
+  const systemTar = 'C:\\Windows\\System32\\tar.exe';
+  const invocation = resolveCliInvocation('tar', ['-tf', 'archive.tgz'], {
+    platform: 'win32',
+    env: { SystemRoot: 'C:\\Windows' },
+    existsSync(candidate) {
+      return candidate === systemTar;
+    },
+  });
+  assert.deepEqual(invocation, { command: systemTar, args: ['-tf', 'archive.tgz'] });
+});
+
 test('resolved npm invocation can actually be spawned', () => {
   const invocation = resolveCliInvocation('npm', ['--version']);
   const result = spawnSync(invocation.command, invocation.args, { encoding: 'utf8' });

--- a/integrations/deepseek-harness/test/tarball-contract.test.mjs
+++ b/integrations/deepseek-harness/test/tarball-contract.test.mjs
@@ -72,7 +72,10 @@ test('packed Skill payload matches the existing ZIP clean-staging contract', () 
     assert.equal(result.status, 0, result.stderr || result.stdout);
     const packedRoot = path.join(scratch, 'packed');
     fs.mkdirSync(packedRoot);
-    const tar = spawnSync('tar', ['-xzf', out, '-C', packedRoot], { encoding: 'utf8' });
+    const tar = spawnSync('tar', ['-xzf', path.basename(out), '-C', packedRoot], {
+      cwd: path.dirname(out),
+      encoding: 'utf8',
+    });
     assert.equal(tar.status, 0, tar.stderr);
     const zipPath = path.join(zipScratch, 'archify.zip');
     const zip = spawnSync('bash', [path.join(repoRoot, 'scripts', 'build-zip.sh'), zipPath], {


### PR DESCRIPTION
## Problem

The post-merge three-platform DSH release gate exposed a Windows-only packaging failure. Git for Windows GNU tar won PATH resolution and interpreted the drive letter in an absolute `C:\\...` tarball path as remote-host syntax.

Follow-up to #69. The npm package remains unpublished.

## Fix

- Use authoritative `npm pack --json` metadata for the packaged file list instead of invoking tar a second time.
- Accept both npm JSON shapes observed across supported npm versions: array output and package-name-keyed object output.
- Prefer `SystemRoot\\System32\\tar.exe` on Windows so ZIP and tar extraction use the platform bsdtar rather than a Git PATH shadow.
- Pass the tarball itself as a relative basename from its containing directory.
- Add Windows resolver coverage and keep the tarball contract path-portable.

## Verification

- `node --test integrations/deepseek-harness/test/*.test.mjs` — 19/19 passed
- `node integrations/deepseek-harness/scripts/distribution-acceptance.mjs` — complete macOS receipt passed
- `git diff --check` — passed
- Independent pre-commit correctness review — passed with no blocker or logic error

After PR checks pass, the explicit Ubuntu/macOS/Windows adapter-release matrix will be dispatched against this branch before merge.

## Isolation

Only DSH integration packaging and acceptance code changes. Archify core and all non-DSH install/runtime paths remain untouched. No npm publish, tag, or release is part of this PR.