### PR TITLE
docs: surface DeepSeek Harness quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,13 @@ For an explicit, non-interactive Cursor install:
 npx -y skills add tt-a1i/archify --skill archify --agent cursor --global --copy --yes
 ```
 
-To try it without a permanent install:
+To try without installing:
 
 ```bash
 npx skills use tt-a1i/archify@archify --agent codex
 ```
 
-Using DeepSeek Harness? Install the separate, opt-in community bundle:
-
-```bash
-dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
-```
-
-[Compatibility, limitations, and security details](integrations/deepseek-harness/README.md)
+[DSH community opt-in](integrations/deepseek-harness/README.md): `dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`
 
 The [agent switcher](https://tt-a1i.github.io/archify/start.html?agent=cursor&type=architecture) covers `cursor`, `codex`, `claude-code`, and `opencode`. For Raven's manual ZIP install, extract [`archify.zip`](archify.zip) into `~/.raven/workspace/skills`; it yields `~/.raven/workspace/skills/archify`. Raven is not a switcher target.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ To try it without a permanent install:
 npx skills use tt-a1i/archify@archify --agent codex
 ```
 
+Using DeepSeek Harness? Install the separate, opt-in community bundle:
+
+```bash
+dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
+```
+
+[Compatibility, limitations, and security details](integrations/deepseek-harness/README.md)
+
 The [agent switcher](https://tt-a1i.github.io/archify/start.html?agent=cursor&type=architecture) covers `cursor`, `codex`, `claude-code`, and `opencode`. For Raven's manual ZIP install, extract [`archify.zip`](archify.zip) into `~/.raven/workspace/skills`; it yields `~/.raven/workspace/skills/archify`. Raven is not a switcher target.
 
 ### 2. Ask for one bounded view

--- a/README_EN.md
+++ b/README_EN.md
@@ -106,19 +106,13 @@ For an explicit, non-interactive Cursor install:
 npx -y skills add tt-a1i/archify --skill archify --agent cursor --global --copy --yes
 ```
 
-To try it without a permanent install:
+To try without installing:
 
 ```bash
 npx skills use tt-a1i/archify@archify --agent codex
 ```
 
-Using DeepSeek Harness? Install the separate, opt-in community bundle:
-
-```bash
-dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
-```
-
-[Compatibility, limitations, and security details](integrations/deepseek-harness/README.md)
+[DSH community opt-in](integrations/deepseek-harness/README.md): `dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`
 
 The [agent switcher](https://tt-a1i.github.io/archify/start.html?agent=cursor&type=architecture) covers `cursor`, `codex`, `claude-code`, and `opencode`. For Raven's manual ZIP install, extract [`archify.zip`](archify.zip) into `~/.raven/workspace/skills`; it yields `~/.raven/workspace/skills/archify`. Raven is not a switcher target.
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -112,6 +112,14 @@ To try it without a permanent install:
 npx skills use tt-a1i/archify@archify --agent codex
 ```
 
+Using DeepSeek Harness? Install the separate, opt-in community bundle:
+
+```bash
+dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
+```
+
+[Compatibility, limitations, and security details](integrations/deepseek-harness/README.md)
+
 The [agent switcher](https://tt-a1i.github.io/archify/start.html?agent=cursor&type=architecture) covers `cursor`, `codex`, `claude-code`, and `opencode`. For Raven's manual ZIP install, extract [`archify.zip`](archify.zip) into `~/.raven/workspace/skills`; it yields `~/.raven/workspace/skills/archify`. Raven is not a switcher target.
 
 ### 2. Ask for one bounded view

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,6 +108,14 @@ npx -y skills add tt-a1i/archify --skill archify --agent cursor --global --copy 
 npx skills use tt-a1i/archify@archify --agent codex
 ```
 
+使用 DeepSeek Harness？安装独立、显式启用的社区集成包：
+
+```bash
+dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
+```
+
+[兼容范围、限制与安全说明](integrations/deepseek-harness/README.md)
+
 [Agent 切换器](https://tt-a1i.github.io/archify/start.html?agent=cursor&type=architecture)只为 `cursor`、`codex`、`claude-code` 和 `opencode` 生成命令。Raven 仅支持 ZIP 手动安装：将 [`archify.zip`](archify.zip) 解压到 `~/.raven/workspace/skills`，解压后会得到 `~/.raven/workspace/skills/archify`；Raven 不属于切换器目标。
 
 ### 2. 先画一个边界清楚的视图

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,13 +108,7 @@ npx -y skills add tt-a1i/archify --skill archify --agent cursor --global --copy 
 npx skills use tt-a1i/archify@archify --agent codex
 ```
 
-使用 DeepSeek Harness？安装独立、显式启用的社区集成包：
-
-```bash
-dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0
-```
-
-[兼容范围、限制与安全说明](integrations/deepseek-harness/README.md)
+DeepSeek Harness（社区集成、显式启用）：运行 `dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`；参见[兼容范围、限制与安全说明](integrations/deepseek-harness/README.md)。
 
 [Agent 切换器](https://tt-a1i.github.io/archify/start.html?agent=cursor&type=architecture)只为 `cursor`、`codex`、`claude-code` 和 `opencode` 生成命令。Raven 仅支持 ZIP 手动安装：将 [`archify.zip`](archify.zip) 解压到 `~/.raven/workspace/skills`，解压后会得到 `~/.raven/workspace/skills/archify`；Raven 不属于切换器目标。
 


### PR DESCRIPTION
## Summary
- add the published DSH community bundle command inside Quick Start
- keep Skills CLI, Cursor, Codex, Claude Code, OpenCode, and Raven as the default path
- link compatibility, limitations, and security details

## Verification
- DSH contract tests: 20/20
- README.md and README_EN.md remain byte-identical
- public npm package: @tt-a1i/archify-dsh@0.1.0
- non-DSH runtime and package contents are unchanged