### PR TITLE
fix(viewer): dim/restore arrowheads on focus and chapter hover preview

### DIFF
--- a/archify/assets/template.html
+++ b/archify/assets/template.html
@@ -4646,6 +4646,12 @@
       opacity: 0.28 !important;
       filter: grayscale(0.72) !important;
     }
+    /* The chapter's own edges stay fully lit (line + arrowhead) so the
+       hovered chain visibly lights up against the dimmed rest. */
+    svg[data-chapter-preview] [data-edge-from][data-chapter-preview-role="edge-live"] {
+      opacity: 1 !important;
+      filter: none !important;
+    }
     svg[data-preset="blueprint"][data-chapter-preview] [data-node-id] { filter: none !important; }
 
     /* Dashed boundary variants */
@@ -8409,7 +8415,11 @@
           node.removeAttribute('data-focus-selected');
           node.setAttribute('aria-pressed', 'false');
         });
-        edges().forEach(function (edge) { edge.removeAttribute('data-focus-match'); });
+        edges().forEach(function (edge) {
+          edge.removeAttribute('data-focus-match');
+          var originalMarker = edge.getAttribute('data-marker-original');
+          if (originalMarker) { edge.setAttribute('marker-end', originalMarker); edge.removeAttribute('data-marker-original'); }
+        });
         chip.hidden = true;
         label.textContent = '';
         detail.textContent = '';
@@ -8483,10 +8493,24 @@
         normalized.forEach(function (id) { selected[id] = true; related[id] = true; });
         var selectionMode = options.mode === 'selection' || normalized.length > 1;
 
+        function dimMarker(markerEnd) {
+          if (typeof markerEnd !== 'string') return markerEnd;
+          var m = markerEnd.match(/url\(#([^)]+)\)/);
+          if (!m || /dim$/.test(m[1])) return markerEnd;
+          return 'url(#' + m[1] + '-dim)';
+        }
         edges().forEach(function (edge) {
           var from = edge.getAttribute('data-edge-from');
           var to = edge.getAttribute('data-edge-to');
           var match = selectionMode ? selected[from] && selected[to] : selected[from] || selected[to];
+          // SVG markers do not inherit path opacity; swap the arrowhead to a
+          // translucent dim variant so focused chains visibly light up.
+          if (edge.getAttribute('data-marker-original') == null) {
+            edge.setAttribute('data-marker-original', edge.getAttribute('marker-end') || '');
+          }
+          edge.setAttribute('marker-end', match
+            ? (edge.getAttribute('data-marker-original') || '')
+            : dimMarker(edge.getAttribute('data-marker-original') || ''));
           if (!match) return;
           edge.setAttribute('data-focus-match', '');
           if (!selectionMode) { related[from] = true; related[to] = true; }
@@ -9322,6 +9346,9 @@
         Array.prototype.forEach.call(svg.querySelectorAll('[data-chapter-preview-role]'), function (node) {
           node.removeAttribute('data-chapter-preview-role');
         });
+        Array.prototype.forEach.call(svg.querySelectorAll('[data-edge-from][data-edge-to]'), function (edge) {
+          edge.removeAttribute('data-chapter-preview-role');
+        });
         chapterButtons.forEach(function (button) { button.removeAttribute('data-preview-active'); });
         activePreviewIndex = -1;
         if (previewOwnerToken && Archify.motionGovernor) {
@@ -9363,6 +9390,27 @@
         Array.prototype.forEach.call(svg.querySelectorAll('[data-node-id]'), function (node) {
           var role = roles[node.getAttribute('data-node-id')];
           if (role) node.setAttribute('data-chapter-preview-role', role);
+        });
+        // Preview must light up the chapter's own arrows too: shared SVG
+        // markers do not inherit path opacity, so swap unmatched edges to a
+        // translucent dim arrowhead (mirrors the focus logic in setMany).
+        var previewFocus = {};
+        views[index].focus.forEach(function (fid) { previewFocus[fid] = true; });
+        Array.prototype.forEach.call(svg.querySelectorAll('[data-edge-from][data-edge-to]'), function (edge) {
+          if (edge.getAttribute('data-marker-original') == null) {
+            edge.setAttribute('data-marker-original', edge.getAttribute('marker-end') || '');
+          }
+          var pFrom = edge.getAttribute('data-edge-from');
+          var pTo = edge.getAttribute('data-edge-to');
+          var inChapter = previewFocus[pFrom] && previewFocus[pTo];
+          var original = edge.getAttribute('data-marker-original') || '';
+          var pm = original.match(/url\(#([^)]+)\)/);
+          edge.setAttribute('marker-end', inChapter
+            ? original
+            : (pm && !/dim$/.test(pm[1]) ? 'url(#' + pm[1] + '-dim)' : original));
+          // Keep the chapter's own edge paths fully lit during preview.
+          if (inChapter) edge.setAttribute('data-chapter-preview-role', 'edge-live');
+          else edge.removeAttribute('data-chapter-preview-role');
         });
         svg.setAttribute('data-chapter-preview', views[index].id);
         chapterButtons[index].setAttribute('data-preview-active', 'true');

--- a/archify/renderers/shared/utils.mjs
+++ b/archify/renderers/shared/utils.mjs
@@ -19,6 +19,21 @@ export function renderDefinitions() {
           <marker id="arrowhead-dashed" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
             <polygon points="0 0, 10 3.5, 0 7" class="m-dashed" />
           </marker>
+          <!-- Dim variants: shared SVG markers are drawn independently of the
+               referencing path, so focus/preview dimming swaps marker-end to a
+               translucent arrowhead (markers do not inherit path opacity). -->
+          <marker id="arrowhead-dim" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-default" opacity="0.28" />
+          </marker>
+          <marker id="arrowhead-emphasis-dim" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-emphasis" opacity="0.28" />
+          </marker>
+          <marker id="arrowhead-security-dim" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-security" opacity="0.28" />
+          </marker>
+          <marker id="arrowhead-dashed-dim" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-dashed" opacity="0.28" />
+          </marker>
           <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
             <path d="M 40 0 L 0 0 0 40" class="c-grid" stroke-width="0.5"/>
           </pattern>


### PR DESCRIPTION
## Problem

SVG marker arrowheads are drawn **independently of the referencing path** — path `opacity` never dims or lights up the arrow itself. So in guided-view focus (`setMany`) and chapter hover preview (`showChapterPreview`), the line dimmed to `0.13`/`0.1` but **every arrowhead stayed fully lit**, making chain highlighting look broken (the focused chain's arrows never visibly "light up").

## Fix

- **`renderers/shared/utils.mjs`**: add four translucent **dim marker variants** (`arrowhead[-emphasis|-security|-dashed]-dim`, opacity `0.28`).
- **`assets/template.html`**:
  - `setMany` (guided-view focus / node selection): unmatched edges swap `marker-end` to the dim variant; matched edges keep/restore their authored arrowhead. `clear()` restores all.
  - `showChapterPreview` (chapter rail hover): in-chapter edges get `data-chapter-preview-role="edge-live"` + their authored arrowhead (CSS keeps line *and* arrow fully lit); all other edges dim. `clearChapterPreviewPresentation` restores markers and roles.

## Verification

- `node --check` on all inline scripts.
- Upstream `validate --quality showcase` on a real architecture spec: **9/9 checks, 0 errors / 0 warnings**.
- Runtime check via headless Chrome on the generated HTML: hovering chapter ② dims 7 non-chain arrowheads and keeps the 2 chain arrowheads fully lit (`LIVE=2 / DIM=7 / OTHER=0`).
- Test suites `chapter-delta-preview`, `architecture-delta`, `focus`, `story`: **22/22 pass**.