### PR TITLE
chore(security): require owner review for automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Keep repository governance and automation changes under the owner's review.
+/.github/CODEOWNERS @tt-a1i
+/.github/workflows/** @tt-a1i
+/.github/actions/** @tt-a1i


### PR DESCRIPTION
## Summary

- require owner review for changes to CODEOWNERS
- require owner review for GitHub Actions workflows and local actions
- leave ordinary source, dependency, test, documentation, and script changes under the existing collaborator review flow

## Validation

- 

This intentionally limits the owner gate to repository governance and automation control-plane files.