### PR TITLE
test(mco): tighten repository evidence and artifact proof

### DIFF
--- a/archify/test/real-repository-proof.test.mjs
+++ b/archify/test/real-repository-proof.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { verifyRepositoryEvidence } from '../renderers/shared/repository-evidence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const skillRoot = path.resolve(__dirname, '..');
@@ -15,15 +16,8 @@ const shareCardPath = path.join(repoRoot, 'docs', 'assets', 'mco-runtime-share-c
 const experimentSourcePath = path.join(repoRoot, 'experiments', 'mco-showcase', 'mco-runtime.architecture.json');
 const experimentArtifactPath = path.join(repoRoot, 'experiments', 'mco-showcase', 'mco-runtime.html');
 const cli = path.join(skillRoot, 'bin', 'archify.mjs');
-const pinnedRepository = JSON.parse(fs.readFileSync(sourcePath, 'utf8')).meta.repository;
-
-function canonicalRepositoryUrl(value) {
-  return value.trim()
-    .replace(/^git@github\.com:/i, 'https://github.com/')
-    .replace(/\.git\/?$/i, '')
-    .replace(/\/$/, '')
-    .toLowerCase();
-}
+const pinnedSource = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+const pinnedRepository = pinnedSource.meta.repository;
 
 function evidencePayload(html) {
   const match = html.match(/<script id="archify-source-evidence-data" type="application\/json">([\s\S]*?)<\/script>/);
@@ -37,22 +31,20 @@ function connectionLabelGeometry(html) {
   )].map((match) => [match[1], { x: Number(match[2]), y: Number(match[3]) }]));
 }
 
-function localMcoRoot() {
-  const candidates = [
-    process.env.ARCHIFY_MCO_REPO_ROOT,
-    path.resolve(repoRoot, '..', 'mco'),
-  ].filter(Boolean);
-  return candidates.find(candidate => {
-    if (!fs.existsSync(path.join(candidate, '.git'))) return false;
-    const revision = spawnSync('git', ['-C', candidate, 'cat-file', '-e', `${pinnedRepository.revision}^{commit}`]);
-    if (revision.status !== 0) return false;
-    const origin = spawnSync('git', ['-C', candidate, 'remote', 'get-url', 'origin'], { encoding: 'utf8' });
-    return origin.status === 0
-      && canonicalRepositoryUrl(origin.stdout) === canonicalRepositoryUrl(pinnedRepository.url);
-  }) || null;
+function automaticMcoRoot() {
+  const candidate = path.resolve(repoRoot, '..', 'mco');
+  if (!fs.existsSync(path.join(candidate, '.git'))) return null;
+  try {
+    verifyRepositoryEvidence('architecture', pinnedSource, candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
 }
 
-const pinnedMcoRoot = localMcoRoot();
+const pinnedMcoRoot = process.env.ARCHIFY_MCO_REPO_ROOT
+  ? path.resolve(process.env.ARCHIFY_MCO_REPO_ROOT)
+  : automaticMcoRoot();
 
 test('MCO showcase preserves checked-in connection-label geometry', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-mco-showcase-layout-'));
@@ -146,7 +138,7 @@ test('checked-in MCO artifacts are byte-reproducible from the pinned repository 
   }
 });
 
-test('MCO proof is source-backed, reproducible, and linked from every README', () => {
+test('MCO public proof is source-backed, valid, and linked from every README', () => {
   const source = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
   assert.equal(source.meta.title, 'MCO Runtime Architecture');
   assert.equal(source.meta.quality_profile, 'showcase');
@@ -171,25 +163,32 @@ test('MCO proof is source-backed, reproducible, and linked from every README', (
   const checkedInHtml = fs.readFileSync(artifactPath, 'utf8');
   const evidence = evidencePayload(checkedInHtml);
   assert.equal(evidence.verified, true);
+  assert.equal(evidence.repository.url, source.meta.repository.url);
   assert.equal(evidence.repository.revision, source.meta.repository.revision);
+  assert.equal(evidence.repository.shortRevision, source.meta.repository.revision.slice(0, 7));
   assert.equal(evidence.referenceCount, references);
   assert.match(checkedInHtml, /Archify\.sourceEvidence\.installBeacons\(\)/);
   execFileSync(process.execPath, [cli, 'check', artifactPath], { encoding: 'utf8' });
 
-  const output = path.join(os.tmpdir(), `archify-mco-proof-no-root-${process.pid}.html`);
-  const result = spawnSync(process.execPath, [
-    cli,
-    'deliver',
-    'architecture',
-    sourcePath,
-    output,
-    '--quality',
-    'showcase',
-    '--json',
-  ], { encoding: 'utf8' });
-  assert.equal(result.status, 1);
-  assert.match(JSON.parse(result.stdout).error, /Pass --repo-root/);
-  assert.equal(fs.existsSync(output), false);
+  const noRootTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-mco-proof-no-root-'));
+  try {
+    const output = path.join(noRootTmp, 'mco-runtime.html');
+    const result = spawnSync(process.execPath, [
+      cli,
+      'deliver',
+      'architecture',
+      sourcePath,
+      output,
+      '--quality',
+      'showcase',
+      '--json',
+    ], { encoding: 'utf8' });
+    assert.equal(result.status, 1);
+    assert.match(JSON.parse(result.stdout).error, /Pass --repo-root/);
+    assert.equal(fs.existsSync(output), false);
+  } finally {
+    fs.rmSync(noRootTmp, { recursive: true, force: true });
+  }
 
   const png = fs.readFileSync(shareCardPath);
   assert.equal(png.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');
@@ -197,10 +196,14 @@ test('MCO proof is source-backed, reproducible, and linked from every README', (
   assert.equal(png.readUInt32BE(20), 630);
   assert.ok(png.byteLength > 20_000, 'MCO Share Card is unexpectedly small');
 
+  const repositorySlug = new URL(source.meta.repository.url).pathname.replace(/^\/|\/$/g, '');
+  const shortRevision = source.meta.repository.revision.slice(0, 7);
   for (const filename of ['README.md', 'README_EN.md', 'README_ZH.md']) {
     const readme = fs.readFileSync(path.join(repoRoot, filename), 'utf8');
     assert.match(readme, /docs\/assets\/mco-runtime-share-card\.png/);
     assert.match(readme, /cases\/mco-runtime\.architecture\.html\?theme=dark&present=1#view=dispatch-path/);
     assert.match(readme, /docs\/cases\/mco-runtime\.architecture\.json/);
+    assert.ok(readme.includes(`[\`${repositorySlug}\`](${source.meta.repository.url})`), `${filename}: repository link drifted`);
+    assert.ok(readme.includes(`\`${shortRevision}\``), `${filename}: repository revision drifted`);
   }
 });

--- a/archify/test/real-repository-proof.test.mjs
+++ b/archify/test/real-repository-proof.test.mjs
@@ -12,12 +12,29 @@ const repoRoot = path.resolve(skillRoot, '..');
 const sourcePath = path.join(repoRoot, 'docs', 'cases', 'mco-runtime.architecture.json');
 const artifactPath = path.join(repoRoot, 'docs', 'cases', 'mco-runtime.architecture.html');
 const shareCardPath = path.join(repoRoot, 'docs', 'assets', 'mco-runtime-share-card.png');
+const experimentSourcePath = path.join(repoRoot, 'experiments', 'mco-showcase', 'mco-runtime.architecture.json');
+const experimentArtifactPath = path.join(repoRoot, 'experiments', 'mco-showcase', 'mco-runtime.html');
 const cli = path.join(skillRoot, 'bin', 'archify.mjs');
+const pinnedRepository = JSON.parse(fs.readFileSync(sourcePath, 'utf8')).meta.repository;
+
+function canonicalRepositoryUrl(value) {
+  return value.trim()
+    .replace(/^git@github\.com:/i, 'https://github.com/')
+    .replace(/\.git\/?$/i, '')
+    .replace(/\/$/, '')
+    .toLowerCase();
+}
 
 function evidencePayload(html) {
   const match = html.match(/<script id="archify-source-evidence-data" type="application\/json">([\s\S]*?)<\/script>/);
   assert.ok(match, 'checked-in MCO proof is missing verified repository evidence');
   return JSON.parse(match[1]);
+}
+
+function connectionLabelGeometry(html) {
+  return Object.fromEntries([...html.matchAll(
+    /<g data-detail="context"[^>]*data-edge-id="([^"]+)"[^>]*>[\s\S]*?<text x="([^"]+)" y="([^"]+)"/g,
+  )].map((match) => [match[1], { x: Number(match[2]), y: Number(match[3]) }]));
 }
 
 function localMcoRoot() {
@@ -27,12 +44,107 @@ function localMcoRoot() {
   ].filter(Boolean);
   return candidates.find(candidate => {
     if (!fs.existsSync(path.join(candidate, '.git'))) return false;
-    const revision = spawnSync('git', ['-C', candidate, 'cat-file', '-e', '9f1a1cf1afdc04d7b5406782b40dfec76d9bc798^{commit}']);
+    const revision = spawnSync('git', ['-C', candidate, 'cat-file', '-e', `${pinnedRepository.revision}^{commit}`]);
     if (revision.status !== 0) return false;
     const origin = spawnSync('git', ['-C', candidate, 'remote', 'get-url', 'origin'], { encoding: 'utf8' });
-    return origin.status === 0 && /github\.com[:/]mco-org\/mco(?:\.git)?\/?$/i.test(origin.stdout.trim());
+    return origin.status === 0
+      && canonicalRepositoryUrl(origin.stdout) === canonicalRepositoryUrl(pinnedRepository.url);
   }) || null;
 }
+
+const pinnedMcoRoot = localMcoRoot();
+
+test('MCO showcase preserves checked-in connection-label geometry', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-mco-showcase-layout-'));
+  try {
+    const source = JSON.parse(fs.readFileSync(experimentSourcePath, 'utf8'));
+    assert.deepEqual(
+      source.meta.repository,
+      pinnedRepository,
+      'MCO case and experiment must pin the same repository revision',
+    );
+    delete source.meta.repository;
+    for (const component of source.components) delete component.sources;
+    const input = path.join(tmp, 'mco-runtime.architecture.json');
+    const output = path.join(tmp, 'mco-runtime.html');
+    fs.writeFileSync(input, `${JSON.stringify(source, null, 2)}\n`);
+
+    const rendered = spawnSync(process.execPath, [
+      cli,
+      'render',
+      'architecture',
+      input,
+      output,
+      '--quality',
+      'showcase',
+    ], { encoding: 'utf8' });
+    assert.equal(rendered.status, 0, `${rendered.stdout}\n${rendered.stderr}`);
+
+    const renderedHtml = fs.readFileSync(output, 'utf8');
+    const checkedInHtml = fs.readFileSync(experimentArtifactPath, 'utf8');
+    const renderedLabels = connectionLabelGeometry(renderedHtml);
+    assert.ok(Object.keys(renderedLabels).length >= 8, 'expected the authored MCO connection labels');
+    assert.deepEqual(
+      connectionLabelGeometry(checkedInHtml),
+      renderedLabels,
+      'checked-in MCO connection-label geometry drifted from its typed source',
+    );
+
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('checked-in MCO artifacts are byte-reproducible from the pinned repository revision', {
+  skip: pinnedMcoRoot
+    ? false
+    : `Set ARCHIFY_MCO_REPO_ROOT to a matching ${pinnedRepository.url} clone containing revision ${pinnedRepository.revision.slice(0, 7)}.`,
+}, () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-mco-byte-reproduction-'));
+  try {
+    const experimentOutput = path.join(tmp, 'mco-runtime.experiment.html');
+    const experiment = spawnSync(process.execPath, [
+      cli,
+      'render',
+      'architecture',
+      experimentSourcePath,
+      experimentOutput,
+      '--quality',
+      'showcase',
+      '--repo-root',
+      pinnedMcoRoot,
+    ], { encoding: 'utf8' });
+    assert.equal(experiment.status, 0, `${experiment.stdout}\n${experiment.stderr}`);
+    assert.equal(
+      fs.readFileSync(experimentOutput, 'utf8'),
+      fs.readFileSync(experimentArtifactPath, 'utf8'),
+      'checked-in MCO showcase drifted from its typed source and verified repository',
+    );
+
+    const caseOutput = path.join(tmp, 'mco-runtime.case.html');
+    const delivered = spawnSync(process.execPath, [
+      cli,
+      'deliver',
+      'architecture',
+      sourcePath,
+      caseOutput,
+      '--quality',
+      'showcase',
+      '--repo-root',
+      pinnedMcoRoot,
+      '--json',
+    ], { encoding: 'utf8' });
+    assert.equal(delivered.status, 0, `${delivered.stdout}\n${delivered.stderr}`);
+    assert.equal(JSON.parse(delivered.stdout).ok, true);
+    assert.equal(
+      fs.readFileSync(caseOutput, 'utf8'),
+      fs.readFileSync(artifactPath, 'utf8'),
+      'checked-in MCO case drifted from its typed source and verified repository',
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
 
 test('MCO proof is source-backed, reproducible, and linked from every README', () => {
   const source = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
@@ -48,14 +160,13 @@ test('MCO proof is source-backed, reproducible, and linked from every README', (
   assert.equal(source.connections.length, 12);
   assert.match(source.components.find((component) => component.id === 'router')?.sublabel || '', /\bdoctor\b/);
   assert.match(source.components.find((component) => component.id === 'adapters')?.sublabel || '', /\bdetect\b/);
-  assert.deepEqual(source.meta.repository, {
-    url: 'https://github.com/mco-org/mco',
-    revision: '9f1a1cf1afdc04d7b5406782b40dfec76d9bc798',
-  });
+  assert.match(source.meta.repository.url, /^https:\/\/github\.com\/[^/]+\/[^/]+$/);
+  assert.match(source.meta.repository.revision, /^[0-9a-f]{40}$/);
   const references = source.components.reduce((count, component) => count + (component.sources?.length || 0), 0);
   assert.equal(references, 13);
-  assert.match(JSON.stringify(source.cards), /main @ 9f1a1cf/);
-  assert.match(JSON.stringify(source.cards), /github\.com\/mco-org\/mco/);
+  const cardCopy = JSON.stringify(source.cards);
+  assert.ok(cardCopy.includes(`main @ ${source.meta.repository.revision.slice(0, 7)}`));
+  assert.ok(cardCopy.includes(new URL(source.meta.repository.url).host + new URL(source.meta.repository.url).pathname));
 
   const checkedInHtml = fs.readFileSync(artifactPath, 'utf8');
   const evidence = evidencePayload(checkedInHtml);
@@ -65,52 +176,20 @@ test('MCO proof is source-backed, reproducible, and linked from every README', (
   assert.match(checkedInHtml, /Archify\.sourceEvidence\.installBeacons\(\)/);
   execFileSync(process.execPath, [cli, 'check', artifactPath], { encoding: 'utf8' });
 
-  const mcoRoot = localMcoRoot();
-  if (mcoRoot) {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-mco-proof-'));
-    const regenerated = path.join(tmp, 'mco-runtime.architecture.html');
-    const receipt = JSON.parse(execFileSync(process.execPath, [
-      cli,
-      'deliver',
-      'architecture',
-      sourcePath,
-      regenerated,
-      '--quality',
-      'showcase',
-      '--repo-root',
-      mcoRoot,
-      '--json',
-    ], { encoding: 'utf8' }));
-    assert.equal(receipt.ok, true);
-    assert.equal(receipt.validation.errors, 0);
-    assert.equal(receipt.validation.warnings, 0);
-    assert.deepEqual(receipt.evidence, {
-      verified: true,
-      repository: source.meta.repository.url,
-      revision: source.meta.repository.revision,
-      references,
-    });
-    assert.equal(
-      fs.readFileSync(regenerated, 'utf8'),
-      checkedInHtml,
-      'checked-in MCO artifact drifted from its typed source and verified repository',
-    );
-  } else {
-    const output = path.join(os.tmpdir(), `archify-mco-proof-no-root-${process.pid}.html`);
-    const result = spawnSync(process.execPath, [
-      cli,
-      'deliver',
-      'architecture',
-      sourcePath,
-      output,
-      '--quality',
-      'showcase',
-      '--json',
-    ], { encoding: 'utf8' });
-    assert.equal(result.status, 1);
-    assert.match(JSON.parse(result.stdout).error, /Pass --repo-root/);
-    assert.equal(fs.existsSync(output), false);
-  }
+  const output = path.join(os.tmpdir(), `archify-mco-proof-no-root-${process.pid}.html`);
+  const result = spawnSync(process.execPath, [
+    cli,
+    'deliver',
+    'architecture',
+    sourcePath,
+    output,
+    '--quality',
+    'showcase',
+    '--json',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /Pass --repo-root/);
+  assert.equal(fs.existsSync(output), false);
 
   const png = fs.readFileSync(shareCardPath);
   assert.equal(png.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');

--- a/archify/test/repository-evidence.test.mjs
+++ b/archify/test/repository-evidence.test.mjs
@@ -55,6 +55,20 @@ function evidencePayload(html) {
   return JSON.parse(match[1]);
 }
 
+test('repository evidence accepts canonical HTTPS and common SSH remotes', () => {
+  const data = fixture();
+  const output = path.join(data.root, 'remote-form.html');
+  for (const remote of [
+    'https://github.com/example/evidence-repo.git/',
+    'git@github.com:example/evidence-repo.git',
+    'ssh://git@github.com/example/evidence-repo.git',
+  ]) {
+    git(data.root, 'remote', 'set-url', 'origin', remote);
+    const result = run(['deliver', 'architecture', data.input, output, '--repo-root', data.root, '--json']);
+    assert.equal(result.status, 0, `${remote}: ${result.stderr || result.stdout}`);
+  }
+});
+
 async function waitForState(url, predicate, timeoutMs = 12000) {
   const started = Date.now();
   let latest;

--- a/experiments/mco-showcase/mco-runtime.architecture.json
+++ b/experiments/mco-showcase/mco-runtime.architecture.json
@@ -61,10 +61,10 @@
     }
   ],
   "connections": [
-    { "id": "submit", "from": "callers", "to": "entry", "label": "task + selected agents", "variant": "emphasis", "route": "straight", "labelAt": [186, 276] },
+    { "id": "submit", "from": "callers", "to": "entry", "label": "task + selected agents", "variant": "emphasis", "route": "straight", "labelAt": [186, 244] },
     { "id": "parse", "from": "entry", "to": "router", "variant": "emphasis", "route": "straight" },
     { "id": "resolve", "from": "router", "to": "policy", "variant": "security", "route": "straight" },
-    { "id": "authorize", "from": "policy", "to": "invocation", "label": "validated scope", "variant": "security", "route": "straight", "labelAt": [794, 276] },
+    { "id": "authorize", "from": "policy", "to": "invocation", "label": "validated scope", "variant": "security", "route": "straight", "labelAt": [794, 244] },
     { "id": "schedule", "from": "invocation", "to": "adapters", "variant": "emphasis", "route": "straight" },
     { "id": "adapt", "from": "adapters", "to": "transport", "label": "provider contract", "variant": "emphasis", "route": "straight", "labelAt": [1219, 276] },
     { "id": "execute", "from": "transport", "to": "providers", "label": "native CLI", "variant": "emphasis", "route": "straight" },

--- a/experiments/mco-showcase/mco-runtime.html
+++ b/experiments/mco-showcase/mco-runtime.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="generator" content="archify 2.12.0">
+  <meta name="generator" content="archify 2.16.0-dev.0">
   <title>MCO Runtime Architecture Diagram</title>
   <script>
     // Resolve the theme before first paint so light-preference users don't
@@ -50,7 +50,7 @@
       --text: #ffffff;
       --text-muted: #94a3b8;
       --text-dim: #475569;
-      /* UI chrome (menu hints, footer) needs more contrast than SVG .t-dim accents */
+      /* UI chrome and menu hints need more contrast than SVG .t-dim accents */
       --text-faint: #7d8da1;
 
       --panel: rgba(15, 23, 42, 0.5);
@@ -397,7 +397,6 @@
     html[data-embed="true"] .toolbar,
     html[data-embed="true"] .header,
     html[data-embed="true"] .cards,
-    html[data-embed="true"] .footer,
     html[data-embed="true"] .diagram-nav,
     html[data-embed="true"] .overview-map,
     html[data-embed="true"] .focus-chip,
@@ -587,22 +586,36 @@
       justify-content: center;
       min-height: 0;
       padding: 0.75rem;
+      padding-bottom: calc(0.75rem + var(--archify-nav-reserve));
     }
     html[data-present="true"]:not([data-embed="true"]) .diagram-container > svg {
       width: 100%;
       height: 100%;
       min-width: 0;
     }
-    html[data-present="true"]:not([data-embed="true"]) .cards,
-    html[data-present="true"]:not([data-embed="true"]) .footer { display: none; }
+    html[data-present="true"]:not([data-embed="true"]) .cards { display: none; }
     html[data-present="true"]:not([data-embed="true"]) #btn-present {
       border-color: var(--frontend-stroke);
       color: var(--frontend-stroke);
     }
 
-    .container { max-width: 1200px; margin: 0 auto; }
+    /* The reader owns only the outer scale. Wide diagrams keep one authored
+       SVG/viewBox while the runtime chooses a desktop width from the actual
+       vertical budget. This avoids device-specific files and breakpoint
+       jumps between a laptop and a tall monitor. */
+    .container {
+      width: 100%;
+      max-width: var(--archify-reader-width, 1440px);
+      margin: 0 auto;
+    }
+    @media (min-width: 768px) and (max-height: 920px) {
+      .header { margin-bottom: 1rem; }
+      .diagram-container { padding: 1rem; }
+      .cards { margin-top: 1rem; }
+      .card { padding: 1rem; }
+    }
 
-    .header { margin-bottom: 2rem; padding-right: 29.5rem; }
+    .header { margin-bottom: 1.5rem; padding-right: 29.5rem; }
 
     html[data-preset="signal-flow"] .header,
     html[data-preset="blueprint"] .header,
@@ -643,7 +656,7 @@
     }
 
     html[data-preset="signal-flow"] .header-row::after {
-      content: "SIGNAL FLOW";
+      content: attr(data-preset-badge-signal-flow);
       margin-left: auto;
       color: var(--frontend-stroke);
       border: 1px solid var(--frontend-stroke);
@@ -667,7 +680,7 @@
       animation: none;
     }
     html[data-preset="blueprint"] .header-row::after {
-      content: "BLUEPRINT / REV 01";
+      content: attr(data-preset-badge-blueprint);
       margin-left: auto;
       padding: 0.28rem 0.55rem;
       border-top: 1px solid var(--frontend-stroke);
@@ -696,7 +709,7 @@
       animation: none;
     }
     html[data-preset="editorial"] .header-row::after {
-      content: "EDITORIAL / FIELD NOTE";
+      content: attr(data-preset-badge-editorial);
       margin-left: auto;
       padding: 0.32rem 0 0.24rem;
       border-bottom: 2px solid var(--arrow-emphasis);
@@ -710,10 +723,12 @@
     }
 
     .diagram-container {
+      --archify-nav-reserve: 0px;
       background: var(--panel);
       border-radius: 1rem;
       border: 1px solid var(--panel-border);
       padding: 1.5rem;
+      padding-bottom: calc(1.5rem + var(--archify-nav-reserve));
       overflow: hidden;
       position: relative;
     }
@@ -773,7 +788,7 @@
       border: 1px solid var(--panel-border);
       background: var(--panel);
       color: var(--arrow-emphasis);
-      content: "ARCHIFY / PLATE 04";
+      content: attr(data-preset-badge-editorial-plate);
       font-family: Georgia, 'Times New Roman', serif;
       font-size: 0.52rem;
       font-style: italic;
@@ -903,14 +918,18 @@
       z-index: 12;
       display: inline-flex;
       align-items: center;
-      padding: 0.25rem;
-      gap: 0.2rem;
-      border: 1px solid var(--toolbar-border);
-      border-radius: 0.65rem;
-      background: var(--toolbar-bg);
-      box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+      max-width: calc(100% - 2rem);
+      padding: 0.15rem;
+      gap: 0;
+      overflow-x: auto;
+      border: 1px solid color-mix(in srgb, var(--toolbar-border) 48%, transparent);
+      border-radius: 0.58rem;
+      background: color-mix(in srgb, var(--toolbar-bg) 82%, transparent);
+      box-shadow: 0 5px 14px rgba(0, 0, 0, 0.07);
       backdrop-filter: blur(10px);
+      scrollbar-width: none;
     }
+    .diagram-nav::-webkit-scrollbar { display: none; }
     .diagram-nav button,
     .focus-chip button,
     .guided-views button {
@@ -923,10 +942,13 @@
     .diagram-nav button {
       min-width: 2rem;
       height: 2rem;
-      padding: 0 0.45rem;
-      border-radius: 0.4rem;
-      font-size: 0.75rem;
+      padding: 0 0.35rem;
+      border-radius: 0.35rem;
+      color: color-mix(in srgb, var(--toolbar-text) 68%, transparent);
+      font-size: 0.56rem;
       font-weight: 600;
+      letter-spacing: 0.02em;
+      transition: background 0.15s, color 0.15s;
     }
     .diagram-nav button:hover,
     .diagram-nav button:focus-visible,
@@ -941,11 +963,86 @@
       outline-offset: 1px;
     }
     .diagram-nav button:disabled { opacity: 0.38; cursor: default; }
-    .diagram-nav [data-view="reset"] { min-width: 3.35rem; font-size: 0.625rem; }
-    .diagram-container[data-camera-indicator="true"] .diagram-nav [data-view="reset"] {
-      min-width: 5.2rem;
-      color: var(--frontend-stroke);
+    .diagram-nav button:disabled:hover { background: transparent; }
+    .diagram-nav #btn-route-probe,
+    .diagram-nav #btn-overview-map,
+    .diagram-nav #btn-semantic-lens {
+      min-width: auto;
+      padding-inline: 0.5rem;
+      color: color-mix(in srgb, var(--toolbar-text) 86%, transparent);
+      font-weight: 650;
     }
+    .diagram-nav #btn-node-finder,
+    .diagram-nav [data-view="out"] {
+      position: relative;
+      margin-left: 0.25rem;
+    }
+    .diagram-nav #btn-node-finder::before,
+    .diagram-nav [data-view="out"]::before {
+      position: absolute;
+      top: 0.4rem;
+      bottom: 0.4rem;
+      left: -0.13rem;
+      width: 1px;
+      background: color-mix(in srgb, var(--toolbar-border) 62%, transparent);
+      content: "";
+      pointer-events: none;
+    }
+    .diagram-nav-icon {
+      display: block;
+      width: 0.72rem;
+      height: 0.72rem;
+      margin: auto;
+      background: currentColor;
+      -webkit-mask-position: center;
+      -webkit-mask-repeat: no-repeat;
+      -webkit-mask-size: contain;
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: contain;
+    }
+    .diagram-nav-icon.find {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Ccircle cx='8.5' cy='8.5' r='4.5' fill='none' stroke='black' stroke-width='1.8'/%3E%3Cpath d='m12 12 4 4' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Ccircle cx='8.5' cy='8.5' r='4.5' fill='none' stroke='black' stroke-width='1.8'/%3E%3Cpath d='m12 12 4 4' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round'/%3E%3C/svg%3E");
+    }
+    .diagram-nav-icon.guide {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Ccircle cx='10' cy='10' r='7' fill='none' stroke='black' stroke-width='1.7'/%3E%3Cpath d='M7.8 7.3a2.4 2.4 0 014.6.9c0 1.8-2.4 2-2.4 3.7M10 14.9h.01' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Ccircle cx='10' cy='10' r='7' fill='none' stroke='black' stroke-width='1.7'/%3E%3Cpath d='M7.8 7.3a2.4 2.4 0 014.6.9c0 1.8-2.4 2-2.4 3.7M10 14.9h.01' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'/%3E%3C/svg%3E");
+    }
+    .diagram-nav-icon.minus {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M5 10h10' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M5 10h10' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round'/%3E%3C/svg%3E");
+    }
+    .diagram-nav-icon.plus {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M10 5v10M5 10h10' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M10 5v10M5 10h10' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round'/%3E%3C/svg%3E");
+    }
+    .diagram-nav [data-view="reset"] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.2rem;
+      min-width: 3.1rem;
+      padding-inline: 0.35rem;
+    }
+    .diagram-nav [data-view="reset"][data-detail-visible] {
+      min-width: 3.8rem;
+    }
+    .diagram-nav-detail {
+      color: color-mix(in srgb, var(--toolbar-text) 52%, transparent);
+      font-size: 0.44rem;
+      font-weight: 700;
+      line-height: 1;
+      letter-spacing: 0.07em;
+    }
+    .diagram-nav-percent {
+      color: color-mix(in srgb, var(--toolbar-text) 84%, transparent);
+      font-size: 0.55rem;
+      font-weight: 650;
+      line-height: 1;
+    }
+    .diagram-container[data-camera-indicator="true"] .diagram-nav-detail,
+    .diagram-container[data-camera-indicator="true"] .diagram-nav-percent { color: var(--frontend-stroke); }
     .diagram-nav #btn-diagram-guide[aria-expanded="true"] {
       color: var(--cloud-stroke);
       background: var(--toolbar-hover);
@@ -958,7 +1055,7 @@
     .overview-map {
       position: absolute;
       right: 1rem;
-      bottom: 4.15rem;
+      bottom: calc(4.15rem + var(--archify-nav-reserve));
       z-index: 12;
       width: 11.25rem;
       overflow: hidden;
@@ -991,6 +1088,36 @@
       padding: 0.42rem 0.48rem 0.38rem 0.55rem;
       border-bottom: 1px solid var(--toolbar-border);
       background: linear-gradient(110deg, color-mix(in srgb, var(--frontend-fill) 45%, transparent), transparent 68%);
+      cursor: grab;
+      touch-action: none;
+      user-select: none;
+    }
+    .overview-map[data-panel-dragging="true"] .overview-map-head { cursor: grabbing; }
+    .overview-map[data-placement-invalid="true"] {
+      border-color: var(--security-stroke);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--security-stroke) 34%, transparent), 0 16px 42px rgba(0, 0, 0, 0.3);
+    }
+    .overview-map[data-compact="true"] {
+      width: 7.4rem;
+    }
+    .overview-map[data-compact="true"] .overview-map-head {
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 0.24rem;
+      min-height: 1.5rem;
+      padding: 0.05rem 0.16rem 0.05rem 0.32rem;
+      border-bottom: 0;
+    }
+    .overview-map[data-compact="true"] .overview-map-live,
+    .overview-map[data-compact="true"] .overview-map-copy,
+    .overview-map[data-compact="true"] .overview-map-surface,
+    .overview-map[data-compact="true"] .overview-map-hint {
+      display: none;
+    }
+    .overview-map[data-compact="true"] .overview-map-expand { display: inline-flex; }
+    .overview-map[data-compact="true"] .overview-map-close {
+      width: 1.15rem;
+      height: 1.15rem;
+      font-size: 0.72rem;
     }
     .overview-map-live {
       width: 0.42rem;
@@ -1021,6 +1148,26 @@
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+    .overview-map-expand {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 0;
+      height: 1.2rem;
+      padding: 0 0.34rem;
+      overflow: hidden;
+      border: 0;
+      border-radius: 0.3rem;
+      background: transparent;
+      color: var(--frontend-stroke);
+      font: inherit;
+      font-size: 0.49rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      white-space: nowrap;
+      cursor: pointer;
+    }
     .overview-map-close {
       width: 1.55rem;
       height: 1.55rem;
@@ -1033,8 +1180,11 @@
       font-size: 0.9rem;
       cursor: pointer;
     }
+    .overview-map-expand:hover,
+    .overview-map-expand:focus-visible,
     .overview-map-close:hover,
     .overview-map-close:focus-visible { background: var(--toolbar-hover); }
+    .overview-map-expand:focus-visible,
     .overview-map-close:focus-visible,
     .overview-map-surface:focus-visible,
     .overview-map-node:focus-visible {
@@ -1116,6 +1266,24 @@
       color: var(--frontend-stroke);
       background: var(--toolbar-hover);
     }
+    .overview-map-feedback {
+      position: absolute;
+      right: 1rem;
+      bottom: 4.15rem;
+      z-index: 13;
+      max-width: min(16rem, calc(100% - 2rem));
+      padding: 0.38rem 0.55rem;
+      border: 1px solid color-mix(in srgb, var(--frontend-stroke) 52%, var(--toolbar-border));
+      border-radius: 0.5rem;
+      background: var(--toolbar-menu-bg);
+      color: var(--toolbar-text);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      font-size: 0.52rem;
+      line-height: 1.35;
+      pointer-events: none;
+    }
+    .overview-map-feedback[hidden] { display: none; }
+    .focus-chip[data-radar-yielded="true"] { display: none !important; }
     .diagram-nav #btn-route-probe[aria-pressed="true"] {
       color: var(--backend-stroke);
       background: var(--toolbar-hover);
@@ -1132,7 +1300,7 @@
     .semantic-lens {
       position: absolute;
       right: 1rem;
-      bottom: 4.15rem;
+      bottom: calc(4.15rem + var(--archify-nav-reserve));
       z-index: 24;
       width: min(20rem, calc(100% - 2rem));
       overflow: hidden;
@@ -1307,7 +1475,7 @@
     .route-probe {
       position: absolute;
       left: 1rem;
-      bottom: 1rem;
+      bottom: calc(1rem + var(--archify-nav-reserve));
       z-index: 12;
       width: min(46rem, calc(100% - 25rem));
       min-width: 18rem;
@@ -1589,6 +1757,11 @@
       text-transform: uppercase;
     }
     .semantic-passport-meta [data-passport="tag"] { color: var(--cloud-stroke); }
+    .semantic-passport-meta [data-passport="brand"] {
+      border-color: color-mix(in srgb, var(--messagebus-stroke) 52%, var(--toolbar-border));
+      color: var(--messagebus-stroke);
+      font-weight: 700;
+    }
     .semantic-passport-meta [hidden] { display: none; }
     html[data-preset="blueprint"] .semantic-passport-meta span,
     html[data-preset="blueprint"] .semantic-passport-meta code { border-radius: 0.1rem; }
@@ -2696,6 +2869,24 @@
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82), 0 12px 32px rgba(45, 78, 99, 0.08);
     }
 
+    /* Preserve the one-screen guarantee on ordinary laptop displays. The
+       high-screen expansion above must not trade a fuller canvas for page
+       scrolling at 900–1080px heights. */
+    @media (min-width: 768px) and (max-height: 1100px) {
+      .header { margin-bottom: 1rem; }
+      .diagram-container {
+        padding: 0.875rem;
+        padding-bottom: calc(0.875rem + var(--archify-nav-reserve));
+      }
+      .cards { margin-top: 1rem; }
+      .card { padding: 1rem; }
+    }
+    @media (min-width: 768px) and (max-height: 920px) {
+      body { padding-block: 1.25rem; }
+      .header { margin-bottom: 0.875rem; }
+      .cards { margin-top: 0.75rem; }
+    }
+
     html[data-preset="blueprint"] .card {
       position: relative;
       border-color: var(--panel-border);
@@ -2759,26 +2950,6 @@
 
     .card li { margin-bottom: 0.375rem; }
 
-    .footer {
-      text-align: center;
-      margin-top: 1.5rem;
-      color: var(--text-faint);
-      font-size: 0.75rem;
-    }
-
-    .footer .artifact-start-link {
-      color: var(--text-faint);
-      text-decoration-color: color-mix(in srgb, var(--frontend-stroke) 48%, transparent);
-      text-underline-offset: 0.22em;
-      transition: color 0.15s ease, text-decoration-color 0.15s ease;
-    }
-
-    .footer .artifact-start-link:hover,
-    .footer .artifact-start-link:focus-visible {
-      color: var(--frontend-stroke);
-      text-decoration-color: currentColor;
-    }
-
     /* ==========================================================
        Print stylesheet — hide interactive controls, force light,
        drop the grid so the diagram doesn't waste ink, use landscape
@@ -2828,6 +2999,7 @@
       svg[data-chapter-preview] [data-node-id],
       svg[data-chapter-preview] [data-edge-from] { opacity: 1 !important; filter: none !important; }
       .diagram-container, .card { box-shadow: none; border-color: #e2e8f0; }
+      .diagram-container { --archify-nav-reserve: 0px !important; }
       html[data-preset="signal-flow"] .diagram-container,
       html[data-preset="signal-flow"] .card { background: #ffffff; }
       .cards { grid-template-columns: 1fr 1fr; }
@@ -2876,7 +3048,12 @@
       top: 1rem;
       right: 1rem;
       display: flex;
+      align-items: center;
       gap: 0.5rem;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      box-shadow: none;
       z-index: 100;
     }
     .toolbar button {
@@ -2884,13 +3061,15 @@
       color: var(--toolbar-text);
       border: 1px solid var(--toolbar-border);
       padding: 0.5rem 0.875rem;
-      border-radius: 0.5rem;
+      border-radius: 0.625rem;
       font-family: inherit;
       font-size: 0.75rem;
       font-weight: 500;
       cursor: pointer;
-      backdrop-filter: blur(8px);
-      transition: background 0.15s, border-color 0.15s;
+      white-space: nowrap;
+      backdrop-filter: blur(10px);
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
       display: inline-flex;
       align-items: center;
       gap: 0.375rem;
@@ -2898,7 +3077,22 @@
     }
     .toolbar button:hover {
       background: var(--toolbar-hover);
-      border-color: var(--arrow);
+      border-color: color-mix(in srgb, var(--arrow) 62%, var(--toolbar-border));
+    }
+    .toolbar button[aria-expanded="true"],
+    .toolbar button[aria-pressed="true"]:not(#btn-theme) {
+      background: color-mix(in srgb, var(--frontend-stroke) 10%, var(--toolbar-hover));
+      border-color: color-mix(in srgb, var(--frontend-stroke) 48%, var(--toolbar-border));
+    }
+    .toolbar #btn-export {
+      padding-right: 0.82rem;
+      padding-left: 0.82rem;
+    }
+    .toolbar #btn-export:hover,
+    .toolbar #btn-export[aria-expanded="true"] {
+      color: var(--toolbar-text);
+      background: color-mix(in srgb, var(--frontend-stroke) 10%, var(--toolbar-hover));
+      border-color: color-mix(in srgb, var(--frontend-stroke) 54%, var(--toolbar-border));
     }
     .toolbar button:focus-visible {
       outline: 2px solid var(--frontend-stroke);
@@ -2907,7 +3101,49 @@
     .toolbar #btn-motion[hidden] { display: none !important; }
     .toolbar #btn-motion { min-width: 4.4rem; }
     .toolbar #btn-motion:disabled { cursor: default; opacity: 0.58; }
-    .toolbar .preset-wrap { position: relative; }
+    .toolbar .preset-wrap,
+    .toolbar .export-wrap {
+      position: relative;
+    }
+    .toolbar-icon {
+      display: inline-block;
+      width: 0.95rem;
+      height: 0.95rem;
+      flex: 0 0 auto;
+      background: currentColor;
+      -webkit-mask-position: center;
+      -webkit-mask-repeat: no-repeat;
+      -webkit-mask-size: contain;
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: contain;
+    }
+    .toolbar-chevron {
+      width: 0.65rem;
+      height: 0.65rem;
+      transition: transform 0.15s ease;
+    }
+    [aria-expanded="true"] > .toolbar-chevron { transform: rotate(180deg); }
+    [data-theme="light"] #theme-icon {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cg fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'%3E%3Ccircle cx='10' cy='10' r='3.1'/%3E%3Cpath d='M10 2.2v1.4M10 16.4v1.4M2.2 10h1.4M16.4 10h1.4M4.5 4.5l1 1M14.5 14.5l1 1M15.5 4.5l-1 1M5.5 14.5l-1 1'/%3E%3C/g%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cg fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'%3E%3Ccircle cx='10' cy='10' r='3.1'/%3E%3Cpath d='M10 2.2v1.4M10 16.4v1.4M2.2 10h1.4M16.4 10h1.4M4.5 4.5l1 1M14.5 14.5l1 1M15.5 4.5l-1 1M5.5 14.5l-1 1'/%3E%3C/g%3E%3C/svg%3E");
+    }
+    [data-theme="dark"] #theme-icon {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M15.2 12.7A6.3 6.3 0 017.3 4.8a6.3 6.3 0 107.9 7.9Z' fill='none' stroke='black' stroke-width='1.7' stroke-linejoin='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M15.2 12.7A6.3 6.3 0 017.3 4.8a6.3 6.3 0 107.9 7.9Z' fill='none' stroke='black' stroke-width='1.7' stroke-linejoin='round'/%3E%3C/svg%3E");
+    }
+    #btn-present[aria-pressed="false"] #present-icon {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.2 3.2h-4v4M12.8 3.2h4v4M7.2 16.8h-4v-4M12.8 16.8h4v-4' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.2 3.2h-4v4M12.8 3.2h4v4M7.2 16.8h-4v-4M12.8 16.8h4v-4' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'/%3E%3C/svg%3E");
+    }
+    #btn-present[aria-pressed="true"] #present-icon {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.2 7.2h-4v-4M12.8 7.2h4v-4M7.2 12.8h-4v4M12.8 12.8h4v4' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.2 7.2h-4v-4M12.8 7.2h4v-4M7.2 12.8h-4v4M12.8 12.8h4v4' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round'/%3E%3C/svg%3E");
+    }
+    .toolbar-chevron {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath d='m3 4.5 3 3 3-3' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath d='m3 4.5 3 3 3-3' fill='none' stroke='black' stroke-width='1.7' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    }
     .toolbar #btn-preset { min-width: 5.4rem; }
     .preset-control-mark {
       width: 0.58rem;
@@ -2940,14 +3176,24 @@
       top: calc(100% + 0.375rem);
       right: 0;
       display: none;
-      width: 16.5rem;
-      padding: 0.4rem;
+      width: 18.5rem;
+      max-width: calc(100vw - 2rem);
+      padding: 0.45rem;
       border: 1px solid var(--toolbar-border);
-      border-radius: 0.5rem;
+      border-radius: 0.875rem;
       background: var(--toolbar-menu-bg);
-      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.3);
+      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
     }
     .toolbar .preset-menu.open { display: block; }
+    .toolbar .preset-menu.open,
+    .toolbar .export-menu.open {
+      animation: toolbar-menu-in 0.16s cubic-bezier(0.2, 0.8, 0.2, 1);
+      transform-origin: top right;
+    }
+    @keyframes toolbar-menu-in {
+      from { opacity: 0; transform: translateY(-0.25rem) scale(0.985); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
     .preset-menu-heading {
       display: flex;
       align-items: baseline;
@@ -2973,12 +3219,18 @@
       min-height: 3.35rem;
       padding: 0.5rem 0.62rem;
       border: 0;
-      border-radius: 0.34rem;
+      border-radius: 0.5rem;
       background: transparent;
+      box-shadow: none;
+      backdrop-filter: none;
       text-align: left;
     }
     .toolbar .preset-option:hover,
     .toolbar .preset-option:focus-visible { background: var(--toolbar-hover); }
+    .toolbar .preset-option[aria-checked="true"] {
+      background: color-mix(in srgb, var(--frontend-stroke) 9%, transparent);
+      border-color: color-mix(in srgb, var(--frontend-stroke) 36%, transparent);
+    }
     .preset-option-swatch {
       position: relative;
       width: 2rem;
@@ -3076,8 +3328,19 @@
       text-overflow: ellipsis;
     }
     .preset-option-check {
+      display: inline-block;
+      width: 0.9rem;
+      height: 0.9rem;
       color: var(--frontend-stroke);
-      font-size: 0.78rem;
+      background: currentColor;
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m3 8.5 3 3 7-7' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      -webkit-mask-position: center;
+      -webkit-mask-repeat: no-repeat;
+      -webkit-mask-size: contain;
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m3 8.5 3 3 7-7' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: contain;
       opacity: 0;
     }
     .preset-option[aria-checked="true"] .preset-option-check { opacity: 1; }
@@ -3107,42 +3370,171 @@
       background: transparent;
       box-shadow: none;
     }
-    .toolbar .export-wrap { position: relative; }
     .toolbar .export-menu {
       position: absolute;
       top: calc(100% + 0.375rem);
       right: 0;
       background: var(--toolbar-menu-bg);
       border: 1px solid var(--toolbar-border);
-      border-radius: 0.5rem;
-      padding: 0.375rem;
-      min-width: 160px;
+      width: 19rem;
+      max-width: calc(100vw - 2rem);
+      max-height: calc(100vh - 5.5rem);
+      overflow-y: auto;
+      border-radius: 0.875rem;
+      padding: 0.55rem;
       display: none;
       flex-direction: column;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+      box-shadow: 0 18px 48px rgba(0,0,0,0.24);
     }
     .toolbar .export-menu.open { display: flex; }
-    .toolbar .export-menu button {
-      background: transparent;
-      border: 0;
+    .export-menu-header {
+      display: flex;
+      align-items: flex-start;
       justify-content: space-between;
+      gap: 1rem;
+      padding: 0.5rem 0.55rem 0.72rem;
+    }
+    .export-menu-header strong,
+    .export-menu-header span { display: block; }
+    .export-menu-header strong {
+      color: var(--toolbar-text);
+      font-size: 0.78rem;
+      font-weight: 650;
+      letter-spacing: -0.015em;
+    }
+    .export-menu-header span {
+      margin-top: 0.16rem;
+      color: var(--text-faint);
+      font-size: 0.56rem;
+    }
+    .export-menu-header kbd {
+      padding: 0.16rem 0.36rem;
+      border: 1px solid var(--toolbar-border);
+      border-radius: 0.3rem;
+      color: var(--text-faint);
+      background: color-mix(in srgb, var(--toolbar-border) 16%, transparent);
+      font-family: inherit;
+      font-size: 0.54rem;
+      font-weight: 600;
+    }
+    .export-menu-section {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.18rem;
+    }
+    .export-menu-section + .export-menu-section {
+      margin-top: 0.42rem;
+      padding-top: 0.42rem;
+      border-top: 1px solid color-mix(in srgb, var(--toolbar-border) 68%, transparent);
+    }
+    .export-menu-heading {
+      grid-column: 1 / -1;
+      display: block;
+      padding: 0.24rem 0.55rem 0.2rem;
+      color: var(--text-faint);
+      font-size: 0.54rem;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .toolbar .export-menu button {
+      display: grid;
+      grid-template-columns: 1.15rem minmax(0, 1fr);
+      align-items: center;
+      column-gap: 0.52rem;
+      background: transparent;
+      border: 1px solid transparent;
+      box-shadow: none;
+      backdrop-filter: none;
       width: 100%;
+      min-height: 3rem;
       text-align: left;
-      padding: 0.5rem 0.75rem;
+      padding: 0.48rem 0.55rem;
+      border-radius: 0.5rem;
+      white-space: nowrap;
+    }
+    .export-item-copy {
+      display: block;
+      min-width: 0;
+    }
+    .export-item-copy strong,
+    .export-item-copy small { display: block; }
+    .export-item-copy strong {
+      overflow: hidden;
+      color: inherit;
+      font-size: 0.7rem;
+      font-weight: 550;
+      text-overflow: ellipsis;
+    }
+    .export-item-copy small {
+      margin-top: 0.12rem;
+      overflow: hidden;
+      color: var(--text-faint);
+      font-size: 0.55rem;
+      font-weight: 450;
+      text-overflow: ellipsis;
+    }
+    .toolbar .export-menu button::before {
+      width: 1rem;
+      height: 1rem;
+      background: currentColor;
+      content: "";
+      opacity: 0.72;
+      -webkit-mask-position: center;
+      -webkit-mask-repeat: no-repeat;
+      -webkit-mask-size: contain;
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: contain;
+    }
+    .toolbar .export-menu button[data-format="share-card"]::before,
+    .toolbar .export-menu button[data-action="route-share-card"]::before,
+    .toolbar .export-menu button[data-action="reach-share-card"]::before {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill='none' stroke='black' stroke-width='1.7' d='M3 4.5h14v11H3zM6 12l2.5-2.5 2 2 1.5-1.5 2 2'/%3E%3Ccircle cx='13.8' cy='7.3' r='1.2' fill='black'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill='none' stroke='black' stroke-width='1.7' d='M3 4.5h14v11H3zM6 12l2.5-2.5 2 2 1.5-1.5 2 2'/%3E%3Ccircle cx='13.8' cy='7.3' r='1.2' fill='black'/%3E%3C/svg%3E");
+    }
+    .toolbar .export-menu button[data-action^="copy"]::before {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Crect x='6' y='6' width='10' height='10' rx='1.5' fill='none' stroke='black' stroke-width='1.7'/%3E%3Cpath d='M4 13H3.5A1.5 1.5 0 012 11.5v-8A1.5 1.5 0 013.5 2h8A1.5 1.5 0 0113 3.5V4' fill='none' stroke='black' stroke-width='1.7'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Crect x='6' y='6' width='10' height='10' rx='1.5' fill='none' stroke='black' stroke-width='1.7'/%3E%3Cpath d='M4 13H3.5A1.5 1.5 0 012 11.5v-8A1.5 1.5 0 013.5 2h8A1.5 1.5 0 0113 3.5V4' fill='none' stroke='black' stroke-width='1.7'/%3E%3C/svg%3E");
+    }
+    .toolbar .export-menu button[data-format="png"]::before,
+    .toolbar .export-menu button[data-format="jpeg"]::before,
+    .toolbar .export-menu button[data-format="webp"]::before {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M5 2.5h7l3 3v12H5zM12 2.5v3h3' fill='none' stroke='black' stroke-width='1.7'/%3E%3Cpath d='M7.5 14l2-2 1.5 1.5 1.5-1.5' fill='none' stroke='black' stroke-width='1.7'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M5 2.5h7l3 3v12H5zM12 2.5v3h3' fill='none' stroke='black' stroke-width='1.7'/%3E%3Cpath d='M7.5 14l2-2 1.5 1.5 1.5-1.5' fill='none' stroke='black' stroke-width='1.7'/%3E%3C/svg%3E");
+    }
+    .toolbar .export-menu button[data-format="svg"]::before,
+    .toolbar .export-menu button[data-format="webm"]::before {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M10 2.5l7 4v7l-7 4-7-4v-7zM3 6.5l7 4 7-4M10 10.5v7' fill='none' stroke='black' stroke-width='1.7'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M10 2.5l7 4v7l-7 4-7-4v-7zM3 6.5l7 4 7-4M10 10.5v7' fill='none' stroke='black' stroke-width='1.7'/%3E%3C/svg%3E");
+    }
+    .toolbar .export-menu button[data-format="share-card"],
+    .toolbar .export-menu button[data-action="route-share-card"],
+    .toolbar .export-menu button[data-action="reach-share-card"] {
+      min-height: 3.35rem;
+      color: var(--toolbar-text);
+      background: color-mix(in srgb, var(--frontend-stroke) 8%, transparent);
+      border-color: color-mix(in srgb, var(--frontend-stroke) 24%, var(--toolbar-border));
     }
     .toolbar .export-menu button[hidden] { display: none; }
     .toolbar .export-menu button:hover {
       background: var(--toolbar-hover);
     }
+    .toolbar .export-menu button:focus-visible {
+      background: var(--toolbar-hover);
+      outline-offset: -2px;
+    }
+    .toolbar .export-menu button:disabled {
+      color: var(--text-faint);
+      background: color-mix(in srgb, var(--toolbar-border) 18%, transparent);
+      cursor: not-allowed;
+    }
+    .toolbar .export-menu button:disabled:hover {
+      border-color: transparent;
+    }
     .toolbar .export-menu .hint {
       color: var(--text-faint);
-      font-size: 0.625rem;
-    }
-    .toolbar .export-menu hr {
-      border: 0;
-      border-top: 1px solid var(--toolbar-border);
-      margin: 0.25rem 0.375rem;
-      opacity: 0.5;
+      font-size: 0.55rem;
     }
 
     /* Toast — brief feedback for actions like "copied" */
@@ -3171,16 +3563,21 @@
 
     @media (max-width: 720px) {
       body { padding: 1rem; }
-      .toolbar .preset-menu {
+      .toolbar .preset-menu,
+      .toolbar .export-menu {
         position: fixed;
         top: 4.5rem;
         right: 1rem;
         left: 1rem;
         width: auto;
+        max-width: none;
       }
       .toolbar {
         position: relative;
         justify-content: flex-end;
+        width: max-content;
+        max-width: 100%;
+        margin-left: auto;
         margin-bottom: 1rem;
       }
       .header { margin-bottom: 1.25rem; padding-right: 0; }
@@ -3242,22 +3639,29 @@
         transform: translateX(var(--archify-scroll-x, 0px));
       }
       .diagram-nav { right: 0.5rem; bottom: 0.5rem; }
+      .diagram-nav button {
+        min-width: 2.75rem;
+        height: 2.75rem;
+      }
+      .diagram-nav [data-view="reset"] { min-width: 3.75rem; }
+      .diagram-nav [data-view="reset"][data-detail-visible] { min-width: 4.35rem; }
       .overview-map {
         right: 0.5rem;
         bottom: 3.7rem;
         width: min(10.25rem, calc(100% - 1rem));
       }
       .overview-map[data-docked="true"] {
-        right: 0.5rem;
+        right: var(--archify-radar-right, 0.5rem);
         top: var(--archify-radar-top, 0.5rem);
         bottom: auto;
         transform: none !important;
       }
       .overview-map[data-docked="true"][data-dock-side="left"] {
         right: auto;
-        left: 0.5rem;
+        left: var(--archify-radar-left, 0.5rem);
       }
       .overview-map-surface { height: 4rem; }
+      .overview-map-feedback { right: 0.5rem; bottom: 3.7rem; }
       .semantic-lens {
         right: 0.5rem;
         bottom: 3.7rem;
@@ -3498,8 +3902,19 @@
       }
     }
 
+    @media (max-width: 420px) {
+      .export-menu-section { grid-template-columns: 1fr; }
+      .export-menu-heading,
+      .toolbar .export-menu button[data-format="share-card"],
+      .toolbar .export-menu button[data-action="route-share-card"],
+      .toolbar .export-menu button[data-action="reach-share-card"] { grid-column: 1; }
+    }
+
     @media (prefers-reduced-motion: reduce) {
       .guided-story-caption { animation: none !important; }
+      .toolbar .preset-menu.open,
+      .toolbar .export-menu.open { animation: none; }
+      .toolbar-chevron { transition: none; }
     }
 
     @media (max-width: 360px) {
@@ -3557,6 +3972,27 @@
     svg .s-security   { color: var(--security-stroke); }
     svg .s-messagebus { color: var(--messagebus-stroke); }
     svg .s-external   { color: var(--external-stroke); }
+
+    /* Brand Marks are authored identity badges. Their color is contained
+       inside one neutral plate so vendor color never replaces Archify's
+       semantic node and relationship vocabulary. */
+    svg .brand-mark { pointer-events: none; }
+    svg .brand-mark-badge { fill: #fff; stroke: none; }
+    svg .brand-mark-frame {
+      fill: none;
+      stroke: #cbd5e1;
+      stroke-width: 0.8;
+      vector-effect: non-scaling-stroke;
+    }
+    svg .brand-mark-fallback {
+      fill: none;
+      stroke: #475569;
+      stroke-width: 1.15;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    svg[data-preset="blueprint"] .brand-mark-badge,
+    svg[data-preset="blueprint"] .brand-mark-frame { rx: 1px; }
 
     /* Reading Depth is a viewer-only level-of-detail layer. MAP preserves the
        authored structure and primary labels, READ restores relationship labels
@@ -3688,7 +4124,7 @@
     }
     svg [data-legend-count-badge] text {
       fill: var(--text-muted);
-      font-size: 7px;
+      font-size: 8px;
       font-weight: 700;
       text-anchor: middle;
     }
@@ -3973,6 +4409,9 @@
       opacity: 0.94;
       animation: archify-intent-trace-flow 1.15s linear 1 both;
     }
+    /* Direction names describe each edge relative to the focused node only.
+       The cloned geometry already runs from the authored source to target, so
+       incoming and outgoing signals must share the same playback direction. */
     .intent-trace-flow[data-direction="out"] {
       stroke: var(--frontend-stroke);
       filter: drop-shadow(0 0 4px var(--frontend-stroke));
@@ -3980,7 +4419,7 @@
     .intent-trace-flow[data-direction="in"] {
       stroke: var(--database-stroke);
       filter: drop-shadow(0 0 4px var(--database-stroke));
-      animation-direction: reverse;
+      animation-direction: normal;
     }
     .intent-trace-flow[data-direction="loop"] {
       stroke: var(--security-stroke);
@@ -4411,7 +4850,7 @@
             title="Toggle theme (T)"
             aria-label="Toggle color theme"
             aria-pressed="false">
-      <span id="theme-icon" aria-hidden="true">&#9790;</span>
+      <span id="theme-icon" class="toolbar-icon" aria-hidden="true"></span>
       <span id="theme-label">Dark</span>
     </button>
     <div class="preset-wrap">
@@ -4424,29 +4863,29 @@
               aria-keyshortcuts="S">
         <span class="preset-control-mark" aria-hidden="true"></span>
         <span id="preset-label">Style</span>
-        <span aria-hidden="true">&#9662;</span>
+        <span class="toolbar-icon toolbar-chevron" aria-hidden="true"></span>
       </button>
       <div class="preset-menu" id="preset-menu" role="menu" aria-label="Visual style">
         <div class="preset-menu-heading" role="presentation"><span>Visual identity</span><span>S cycles</span></div>
         <button class="preset-option" data-preset-value="classic" type="button" role="menuitemradio" aria-checked="false" tabindex="-1">
           <span class="preset-option-swatch classic" aria-hidden="true"></span>
           <span class="preset-option-copy"><strong>Classic</strong><small>Stable technical default</small></span>
-          <span class="preset-option-check" aria-hidden="true">&#10003;</span>
+          <span class="preset-option-check" aria-hidden="true"></span>
         </button>
         <button class="preset-option" data-preset-value="signal-flow" type="button" role="menuitemradio" aria-checked="false" tabindex="-1">
           <span class="preset-option-swatch signal-flow" aria-hidden="true"></span>
           <span class="preset-option-copy"><strong>Signal Flow</strong><small>Motion-forward presentation</small></span>
-          <span class="preset-option-check" aria-hidden="true">&#10003;</span>
+          <span class="preset-option-check" aria-hidden="true"></span>
         </button>
         <button class="preset-option" data-preset-value="blueprint" type="button" role="menuitemradio" aria-checked="false" tabindex="-1">
           <span class="preset-option-swatch blueprint" aria-hidden="true"></span>
           <span class="preset-option-copy"><strong>Blueprint</strong><small>Engineering review</small></span>
-          <span class="preset-option-check" aria-hidden="true">&#10003;</span>
+          <span class="preset-option-check" aria-hidden="true"></span>
         </button>
         <button class="preset-option" data-preset-value="editorial" type="button" role="menuitemradio" aria-checked="false" tabindex="-1">
           <span class="preset-option-swatch editorial" aria-hidden="true"></span>
           <span class="preset-option-copy"><strong>Editorial</strong><small>Publication and launch notes</small></span>
-          <span class="preset-option-check" aria-hidden="true">&#10003;</span>
+          <span class="preset-option-check" aria-hidden="true"></span>
         </button>
       </div>
     </div>
@@ -4461,7 +4900,7 @@
             title="Presentation stage (F)"
             aria-label="Enter presentation stage"
             aria-pressed="false">
-      <span id="present-icon" aria-hidden="true">&#9633;</span>
+      <span id="present-icon" class="toolbar-icon" aria-hidden="true"></span>
       <span id="present-label">Present</span>
     </button>
     <div class="export-wrap">
@@ -4471,22 +4910,32 @@
               aria-haspopup="menu"
               aria-expanded="false"
               aria-controls="export-menu">
-        Export <span aria-hidden="true">&#9662;</span>
+        Export <span class="toolbar-icon toolbar-chevron" aria-hidden="true"></span>
       </button>
       <div class="export-menu" id="export-menu" role="menu" aria-label="Export">
-        <button data-format="share-card" type="button" role="menuitem" tabindex="-1">Share Card <span class="hint">1200&times;630 PNG</span></button>
-        <button data-action="route-share-card" type="button" role="menuitem" tabindex="-1" hidden disabled>Route Share Card <span class="hint">1200&times;630 PNG</span></button>
-        <button data-action="reach-share-card" type="button" role="menuitem" tabindex="-1" hidden disabled>Reach Share Card <span class="hint">1200&times;630 PNG</span></button>
-        <button data-action="copy-share-card" type="button" role="menuitem" tabindex="-1">Copy Share Card <span class="hint">PNG</span></button>
-        <hr role="separator">
-        <button data-action="copy"  type="button" role="menuitem" tabindex="-1">Copy to clipboard <span class="hint">PNG</span></button>
-        <hr role="separator">
-        <button data-format="png"   type="button" role="menuitem" tabindex="-1">Download PNG</button>
-        <button data-format="jpeg"  type="button" role="menuitem" tabindex="-1">Download JPEG</button>
-        <button data-format="webp"  type="button" role="menuitem" tabindex="-1">Download WebP</button>
-        <hr role="separator">
-        <button data-format="svg"   type="button" role="menuitem" tabindex="-1">Download SVG <span class="hint">vector</span></button>
-        <button data-format="webm"  type="button" role="menuitem" tabindex="-1">Download WebM <span class="hint">6s motion</span></button>
+        <div class="export-menu-header" role="presentation">
+          <div><strong>Export diagram</strong><span>Portable, clean outputs</span></div>
+          <kbd>E</kbd>
+        </div>
+        <div class="export-menu-section" role="group" aria-label="Share">
+          <span class="export-menu-heading" aria-hidden="true">Share</span>
+          <button data-format="share-card" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>Share Card</strong><small class="hint">1200&times;630 PNG</small></span></button>
+          <button data-action="route-share-card" type="button" role="menuitem" tabindex="-1" hidden disabled><span class="export-item-copy"><strong>Route Share Card</strong><small class="hint">1200&times;630 PNG</small></span></button>
+          <button data-action="reach-share-card" type="button" role="menuitem" tabindex="-1" hidden disabled><span class="export-item-copy"><strong>Reach Share Card</strong><small class="hint">1200&times;630 PNG</small></span></button>
+          <button data-action="copy-share-card" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>Copy Share Card</strong><small class="hint">PNG to clipboard</small></span></button>
+          <button data-action="copy" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>Copy diagram</strong><small class="hint">PNG to clipboard</small></span></button>
+        </div>
+        <div class="export-menu-section" role="group" aria-label="Raster images">
+          <span class="export-menu-heading" aria-hidden="true">Image</span>
+          <button data-format="png" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>PNG</strong><small class="hint">Lossless image</small></span></button>
+          <button data-format="jpeg" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>JPEG</strong><small class="hint">Compact image</small></span></button>
+          <button data-format="webp" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>WebP</strong><small class="hint">Modern image</small></span></button>
+        </div>
+        <div class="export-menu-section" role="group" aria-label="Vector and motion">
+          <span class="export-menu-heading" aria-hidden="true">Vector &amp; motion</span>
+          <button data-format="svg" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>SVG</strong><small class="hint">Editable vector</small></span></button>
+          <button data-format="webm" type="button" role="menuitem" tabindex="-1"><span class="export-item-copy"><strong>WebM</strong><small class="hint">6s motion</small></span></button>
+        </div>
       </div>
     </div>
   </div>
@@ -4494,7 +4943,10 @@
   <div class="container">
     <!-- Header -->
     <div class="header">
-      <div class="header-row">
+      <div class="header-row"
+           data-preset-badge-signal-flow="SIGNAL FLOW"
+           data-preset-badge-blueprint="BLUEPRINT / REV 01"
+           data-preset-badge-editorial="EDITORIAL / FIELD NOTE">
         <div class="pulse-dot"></div>
         <h1>MCO Runtime Architecture</h1>
       </div>
@@ -4503,6 +4955,7 @@
 
     <script id="archify-guided-views-data" type="application/json">[{"id":"dispatch-path","label":"Dispatch one task","focus":["callers","entry","router","policy","invocation","adapters","transport","providers"],"note":"Follow an explicit task from the caller through policy resolution into the selected native provider CLIs."},{"id":"persistent-session","label":"Keep a provider session","focus":["callers","entry","router","session","session_state"],"note":"See how the CLI starts a detached daemon, exchanges requests over a local socket, and persists history."},{"id":"evidence-output","label":"Preserve raw evidence","focus":["invocation","adapters","transport","artifacts","outputs"],"note":"Provider responses stay opaque while MCO records per-invocation answers, status, usage, and run metadata."}]</script>
     <script id="archify-source-evidence-data" type="application/json">{"schemaVersion":1,"verified":true,"repository":{"url":"https://github.com/mco-org/mco","revision":"9f1a1cf1afdc04d7b5406782b40dfec76d9bc798","shortRevision":"9f1a1cf"},"referenceCount":14,"nodes":{"entry":[{"path":"bin/mco.js","line":1,"label":"npm entry","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/bin/mco.js#L1"},{"path":"runtime/mcp_server.py","line":108,"endLine":153,"label":"MCP entry","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/mcp_server.py#L108-L153"}],"router":[{"path":"runtime/cli.py","line":1945,"label":"CLI main","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/cli.py#L1945"}],"policy":[{"path":"runtime/config.py","line":24,"label":"Review policy","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/config.py#L24"},{"path":"runtime/policy.py","line":34,"label":"Provider policy preview","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/policy.py#L34"}],"invocation":[{"path":"runtime/invocation_runtime.py","line":696,"label":"Workflow entry","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/invocation_runtime.py#L696"},{"path":"runtime/invocation_runtime.py","line":156,"label":"Single invocation","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/invocation_runtime.py#L156"}],"adapters":[{"path":"runtime/adapters/__init__.py","line":57,"label":"Adapter registry","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/adapters/__init__.py#L57"},{"path":"runtime/contracts.py","line":77,"label":"Provider contract","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/contracts.py#L77"}],"transport":[{"path":"runtime/adapters/shim.py","line":98,"label":"Shim decode","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/adapters/shim.py#L98"},{"path":"runtime/acp/adapter.py","line":126,"label":"ACP decode","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/acp/adapter.py#L126"}],"session":[{"path":"runtime/session/daemon.py","line":50,"label":"Daemon context","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/session/daemon.py#L50"}],"session_state":[{"path":"runtime/session/state.py","line":25,"label":"Session state","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/session/state.py#L25"}],"artifacts":[{"path":"runtime/invocation_artifacts.py","line":8,"label":"Artifact writer","href":"https://github.com/mco-org/mco/blob/9f1a1cf1afdc04d7b5406782b40dfec76d9bc798/runtime/invocation_artifacts.py#L8"}]}}</script>
+    <script id="archify-i18n-data" type="application/json">{"locale":"en","messages":{"viewer.kind.frontend":"Frontend","viewer.kind.backend":"Backend","viewer.kind.database":"Database","viewer.kind.cloud":"Cloud","viewer.kind.security":"Security","viewer.kind.messagebus":"Message bus","viewer.kind.external":"External","viewer.kind.neutral":"Neutral","viewer.kind.node":"Node","viewer.kind.start":"Start","viewer.kind.active":"Active","viewer.kind.waiting":"Waiting","viewer.kind.decision":"Decision","viewer.kind.success":"Success","viewer.kind.failure":"Failure","viewer.toolbar.actions":"Diagram actions","viewer.theme.toggle.title":"Toggle theme (T)","viewer.theme.toggle":"Toggle color theme","viewer.theme.dark":"Dark","viewer.theme.light":"Light","viewer.preset.choose.title":"Choose visual style (S cycles)","viewer.preset.choose":"Choose visual style","viewer.preset.style":"Style","viewer.preset.menu":"Visual style","viewer.preset.identity":"Visual identity","viewer.preset.cycles":"S cycles","viewer.preset.classic":"Classic","viewer.preset.classic.short":"Classic","viewer.preset.classic.hint":"Stable technical default","viewer.preset.flow":"Signal Flow","viewer.preset.flow.short":"Flow","viewer.preset.flow.hint":"Motion-forward presentation","viewer.preset.blueprint":"Blueprint","viewer.preset.blueprint.hint":"Engineering review","viewer.preset.editorial":"Editorial","viewer.preset.editorial.hint":"Publication and launch notes","viewer.preset.badge.signalFlow":"SIGNAL FLOW","viewer.preset.badge.blueprint":"BLUEPRINT / REV 01","viewer.preset.badge.editorial":"EDITORIAL / FIELD NOTE","viewer.preset.badge.editorialPlate":"ARCHIFY / PLATE 04","viewer.preset.current":"Visual style: {style}. Choose visual style","viewer.motion.live":"Live","viewer.motion.still":"Still","viewer.motion.pause":"Pause motion","viewer.motion.resume":"Resume motion","viewer.motion.reduced":"Motion paused by reduced-motion preference","viewer.motion.hidden":"Motion paused while this page is hidden","viewer.motion.yielding":"Pause motion; currently yielding to {owner}","viewer.motion.yielding.title":"Live preview enabled · yielding to {owner}","viewer.owner.story":"the guided story","viewer.owner.chapter":"the active chapter","viewer.owner.chapterPreview":"the chapter delta preview","viewer.owner.handoff":"the chapter handoff","viewer.owner.route":"Route Probe","viewer.owner.lens":"Semantic Lens","viewer.owner.relationship":"Relationship Preview","viewer.owner.intent":"Intent Trace","viewer.owner.focus":"semantic focus","viewer.owner.legend":"legend preview","viewer.owner.reader":"reader interaction","viewer.present.enter":"Enter presentation stage","viewer.present.enter.title":"Presentation stage (F)","viewer.present.exit":"Exit presentation stage","viewer.present.exit.title":"Exit presentation stage (F or Escape)","viewer.present.present":"Present","viewer.present.exit.label":"Exit","viewer.export.button":"Export","viewer.export.button.title":"Export diagram (E)","viewer.export.diagram":"Export diagram","viewer.export.menu":"Export","viewer.export.subtitle":"Portable, clean outputs","viewer.export.share":"Share","viewer.export.shareCard":"Share Card","viewer.export.routeShareCard":"Route Share Card","viewer.export.reachShareCard":"Reach Share Card","viewer.export.copyShareCard":"Copy Share Card","viewer.export.copyDiagram":"Copy diagram","viewer.export.clipboardPng":"PNG to clipboard","viewer.export.raster":"Raster images","viewer.export.image":"Image","viewer.export.lossless":"Lossless image","viewer.export.compact":"Compact image","viewer.export.modern":"Modern image","viewer.export.vectorMotion":"Vector and motion","viewer.export.vectorMotion.heading":"Vector \u0026 motion","viewer.export.editable":"Editable vector","viewer.export.motion6s":"6s motion","viewer.export.unsupported":"Not supported by this browser","viewer.export.clipboardUnsupported":"Clipboard image write not supported by this browser","viewer.export.clipboardUnsupported.period":"Clipboard image write not supported by this browser.","viewer.export.clipboardUnsupported.short":"Clipboard image write not supported in this browser.","viewer.export.motionUnavailable":"Motion capture unavailable in this browser","viewer.export.webmUnavailable":"WebM unavailable in this browser","viewer.export.failed":"Export failed: {message}","viewer.export.unknownVariant":"Unknown Share Card variant: {variant}","viewer.export.routeRequired":"Trace a route before exporting a Route Share Card","viewer.export.reachRequired":"Trace authored reach before exporting a Reach Share Card","viewer.export.unknown":"unknown","viewer.export.routeFailed":"Route Share Card export failed: {message}","viewer.export.reachFailed":"Reach Share Card export failed: {message}","viewer.export.copyFailed":"Copy failed: {message}","viewer.export.copiedPng":"Copied PNG to clipboard","viewer.export.copiedShare":"Copied Share Card","viewer.export.downloadedShare":"Downloaded Share Card","viewer.export.downloadedRoute":"Downloaded Route Share Card","viewer.export.downloadedReach":"Downloaded Reach Share Card","viewer.export.downloadedWebm":"Downloaded WebM","viewer.export.recording":"Recording 6 seconds of motion…","viewer.export.card.routeSummary.one":"Route: {source} → {target} · {count} directed hop","viewer.export.card.routeSummary.other":"Route: {source} → {target} · {count} directed hops","viewer.export.card.reachSummary":"Authored {direction} from {origin} · {nodes} · {links} · max {hops}","viewer.export.card.node.one":"{count} node","viewer.export.card.node.other":"{count} nodes","viewer.export.card.link.one":"{count} link","viewer.export.card.link.other":"{count} links","viewer.export.card.hop.one":"{count} hop","viewer.export.card.hop.other":"{count} hops","viewer.export.card.routeBadge":"ARCHIFY · ROUTE · {hops}","viewer.export.card.reachBadge":"ARCHIFY · {direction} REACH","viewer.export.card.defaultBadge":"ARCHIFY · {preset} · {theme}","viewer.export.direction.upstream":"Upstream","viewer.export.direction.downstream":"Downstream","viewer.export.error.canvasUnavailable":"Canvas unavailable for {label}","viewer.export.error.contextUnavailable":"2D canvas context unavailable for {label}","viewer.export.error.toBlobUnavailable":"canvas.toBlob unavailable for {label}","viewer.export.error.toBlobNull":"canvas.toBlob returned no data for {label}","viewer.export.error.variantsCombined":"Share Card variants cannot be combined","viewer.export.error.viewerState":"Share Card export could not remove temporary viewer state","viewer.export.error.routeState":"Route Card export could not preserve the resolved route safely","viewer.export.error.reachState":"Reach Card export could not preserve authored reach safely","viewer.export.error.webmRequirements":"WebM motion export requires a trace animation and browser MediaRecorder support","viewer.export.error.mediaRecorder":"MediaRecorder failed","viewer.export.error.emptyWebm":"MediaRecorder produced an empty WebM","viewer.export.error.webmBackground":"SVG background could not be loaded for WebM export","viewer.guided.region":"Guided diagram views","viewer.guided.previous":"Previous guided view","viewer.guided.previous.title":"Previous guided view ([)","viewer.guided.next":"Next guided view","viewer.guided.next.title":"Next guided view (])","viewer.guided.views":"Guided views","viewer.guided.explore":"Explore this system","viewer.guided.intro":"Step through curated paths without changing the source diagram.","viewer.guided.trail":"Story trail","viewer.guided.beat":"Beat","viewer.guided.nextBeat":"Next","viewer.guided.play":"Play guided story","viewer.guided.play.title":"Play guided story (P)","viewer.guided.pause":"Pause guided story","viewer.guided.pause.title":"Pause guided story (P)","viewer.guided.replay":"Replay guided story","viewer.guided.replay.title":"Replay guided story (P)","viewer.guided.playStory":"Play story","viewer.guided.pauseStory":"Pause","viewer.guided.replayStory":"Replay story","viewer.guided.motionUnavailable":"Story playback unavailable while motion is Still","viewer.guided.enableMotion":"Switch motion to Live to play the guided story","viewer.guided.selectBeatLink":"Select a Story Beat to copy its exact link","viewer.guided.copyMoment":"Copy moment","viewer.guided.momentCopied":"Moment link copied","viewer.guided.momentCopyFailed":"Could not copy story moment link","viewer.guided.copied":"Copied","viewer.guided.copyFailed":"Copy failed","viewer.guided.showAll":"Show all","viewer.guided.showAll.aria":"Show entire diagram","viewer.guided.chapters":"Story chapters","viewer.guided.storyTrail":"Story trail for {label}: {count} beats","viewer.guided.chapter.open":"Open chapter {index} of {total}: {label}, {count} stops","viewer.guided.chapter.current":"Current chapter {index} of {total}: {label}, {count} stops","viewer.guided.chapter.selectedNodes":"{count} selected nodes","viewer.guided.chapter.stops":"{count} stops","viewer.guided.chapter.stop.one":"{count} stop","viewer.guided.chapter.stop.other":"{count} stops","viewer.guided.chapter.current.title":"{label} — current chapter, {count} stops","viewer.guided.chapter.delta.expanded":"{stay} stay, {enter} enter, {leave} leave","viewer.guided.chapter.delta.aria":"Open chapter {index} of {total}: {label}. Chapter focus delta: {delta}","viewer.guided.chapter.delta.title":"{label} — {delta} chapter focus","viewer.guided.handoff":"{from} → {to} · via {label}","viewer.guided.share.chapter":"Chapter {index} / {total}","viewer.guided.share.initial":"Chapter 01 / 01","viewer.guided.share.default":"Guided chapter","viewer.guided.state.ready":"Ready","viewer.guided.state.playing":"Playing","viewer.guided.state.settled":"Settled","viewer.guided.state.paused":"Paused","viewer.guided.state.pinned":"Pinned","viewer.guided.state.still":"Still","viewer.guided.share.step":"Step {index} / {total} · {label}","viewer.guided.share.staticMoment":"{step} · Static moment","viewer.guided.share.complete":"{count} steps complete · {note}","viewer.guided.share.settled":"Path settled for reading.","viewer.guided.share.staticPath":"{count} steps · Static path","viewer.guided.share.ready":"{count} steps · Ready","viewer.guided.share.aria":"{state} chapter {index} of {total}: {label}. {beat}. {route}","viewer.guided.beat.start":"Beat {index} / {total} · {label} · starting point","viewer.guided.beat.forward":"Beat {index} / {total} · {from} → {to}","viewer.guided.beat.reverse":"Beat {index} / {total} · {from} → {to} · reverse authored link","viewer.guided.beat.multiple":"Beat {index} / {total} · {from} ⇄ {to} · {count} authored links","viewer.guided.beat.group":"Beat {index} / {total} · {from} · {to} · grouped · no direct link","viewer.guided.beat.aria.prefix":"Story beat {index} of {total}: {label}. ","viewer.guided.beat.aria.start":"Starting point.","viewer.guided.beat.aria.forward":"From {from} through one authored forward relationship.","viewer.guided.beat.aria.reverse":"From {from}; the authored relationship points from {to} to {from}.","viewer.guided.beat.aria.multiple":"From {from} through {count} authored relationships; shown without arbitrary motion.","viewer.guided.beat.aria.group":"Grouped from {from} with no direct authored relationship.","viewer.guided.caption.start":"Starting point","viewer.guided.caption.grouped":"Grouped transition · no direct authored link","viewer.guided.caption.more":" +{count} more","viewer.guided.caption.reverse":"Reverse authored relationship","viewer.guided.caption.relationships":"{count} authored relationships","viewer.guided.caption.relationship":"Authored relationship","viewer.guided.caption.direction":"authored direction: {from} → {to}","viewer.guided.caption.starting":"Authored starting point","viewer.guided.beatLink":"Copy link to current story moment: Beat {index} of {total}: {label}","viewer.guided.noStory":"This diagram has no authored guided story.","viewer.guide.eyebrow":"Diagram guide","viewer.guide.close":"Close diagram guide","viewer.guide.inspecting":"Inspecting compiled semantics","viewer.guide.actions":"Diagram exploration actions","viewer.guide.find":"Find any node","viewer.guide.find.hint":"Search labels, responsibilities, kinds, and stable IDs.","viewer.guide.route":"Trace a route","viewer.guide.route.aria":"Trace a directed route","viewer.guide.route.hint":"Ask how two semantic nodes connect in authored direction.","viewer.guide.map":"See the whole system","viewer.guide.map.hint":"Open Semantic Radar with a live viewport and stable nodes.","viewer.guide.lens":"Compare semantic kinds","viewer.guide.lens.hint":"Count roles, reveal their traffic, and compare direct authored links.","viewer.guide.story":"Play the guided story","viewer.guide.story.hint":"Walk the authored chapters and real relationships.","viewer.guide.present":"Enter Presentation Stage","viewer.guide.present.hint":"Give the live diagram the viewport without changing export.","viewer.guide.shortcuts":"Additional keyboard shortcuts","viewer.guide.shortcut.export":"Export","viewer.guide.shortcut.theme":"Theme","viewer.guide.shortcut.style":"Style","viewer.guide.shortcut.reset":"Reset","viewer.guide.shortcut.zoomIn":"Zoom in","viewer.guide.shortcut.zoomOut":"Zoom out","viewer.guide.shortcut.close":"Close","viewer.guide.facts":"{nodes} · {relationships} · {views}","viewer.guide.fact.node.one":"{count} semantic node","viewer.guide.fact.node.other":"{count} semantic nodes","viewer.guide.fact.relationship.one":"{count} relationship","viewer.guide.fact.relationship.other":"{count} relationships","viewer.guide.fact.view.one":"{count} guided view","viewer.guide.fact.view.other":"{count} guided views","viewer.guide.story.available.one":"Walk {count} authored chapter and its real relationships.","viewer.guide.story.available.other":"Walk {count} authored chapters and their real relationships.","viewer.guide.story.unavailable":"No authored guided story in this diagram.","viewer.guide.open":"Open diagram guide","viewer.guide.noStory":"This diagram has no authored guided story.","viewer.finder.title":"Find a node","viewer.finder.close":"Close node finder","viewer.finder.placeholder":"Search labels or IDs","viewer.finder.search":"Search diagram nodes","viewer.finder.results":"Diagram nodes","viewer.finder.empty":"No matching nodes","viewer.finder.result.focus":"Focus {label}","viewer.finder.result.routeStart":"Choose {label} as route start","viewer.finder.result.routeTarget":"Choose {label} as route destination, {links}","viewer.finder.status.empty":"No matching nodes","viewer.finder.status.count.one":"{count} matching node","viewer.finder.status.count.other":"{count} matching nodes","viewer.finder.noun.nodes":"nodes","viewer.finder.link.one":"{count} link","viewer.finder.link.other":"{count} links","viewer.finder.result.focus.one":"Focus {label}, {count} related connection","viewer.finder.result.focus.other":"Focus {label}, {count} related connections","viewer.finder.status.filtered":"{visible} of {available} {noun}","viewer.finder.status.all":"{available} {noun}","viewer.passport.eyebrow":"Semantic passport","viewer.passport.metadata":"Node metadata","viewer.passport.evidence":"Verified source evidence","viewer.passport.verified":"Verified source","viewer.passport.reach":"Authored reach","viewer.passport.reach.trace":"Trace authored reachability","viewer.passport.upstream":"Upstream","viewer.passport.downstream":"Downstream","viewer.passport.upstream.trace":"Trace upstream authored reachability","viewer.passport.downstream.trace":"Trace downstream authored reachability","viewer.passport.close":"Close semantic passport","viewer.passport.copy":"Copy link","viewer.passport.copy.focus":"Copy link to focused node","viewer.passport.relations":"Relations","viewer.passport.relations.show":"Show connected relationships","viewer.passport.relations.hide":"Hide connected relationships","viewer.passport.relations.list":"Connected relationships","viewer.passport.copyRelation":"Copy relation","viewer.passport.copyNode":"Copy node","viewer.passport.copyPinned":"Copy link to pinned relationship","viewer.passport.copySource":"Copy link to source node","viewer.passport.copy.focused.success":"Focused node link copied","viewer.passport.copy.pinned.success":"Pinned relationship link copied","viewer.passport.copy.focused.failed":"Could not copy focused node link","viewer.passport.copy.pinned.failed":"Could not copy pinned relationship link","viewer.passport.relationship.none":"No connected relationships","viewer.passport.relationship.count.one":"{count} relation","viewer.passport.relationship.count.other":"{count} relations","viewer.passport.relationship.show.one":"Show {count} connected relationship","viewer.passport.relationship.show.other":"Show {count} connected relationships","viewer.passport.relationship.summary":"{out} outgoing · {in} incoming{loops}","viewer.passport.relationship.loops":" · {count} loop","viewer.passport.relationship.explorer":"Direct relationship explorer","viewer.passport.relationship.help":"Use arrow keys to explore relationships. Press Enter or Space to pin details; Escape clears.","viewer.passport.relationship.loopsBack":"loops back","viewer.passport.relationship.connectsTo":"connects to","viewer.passport.relationship.connectsFrom":"connects from","viewer.passport.relationship.pinned":"Pinned relationship · {from} → {to} · {label}","viewer.passport.relationship.inspect":"Inspect relationship {index} of {total}: {from} to {to}, {label}. Press Enter for details.","viewer.passport.relationship.group.out":"Outgoing","viewer.passport.relationship.group.in":"Incoming","viewer.passport.relationship.group.loop":"Self loops","viewer.passport.relationship.row":"{group}: {relationship}, {neighbor}","viewer.passport.relationship.direction.out":"OUT →","viewer.passport.relationship.direction.in":"← IN","viewer.passport.relationship.direction.loop":"LOOP","viewer.passport.sourceCount.one":"{count} verified source reference","viewer.passport.sourceCount.other":"{count} verified source references","viewer.passport.sourceMarker":"SRC","viewer.passport.beacon.one":"{count} verified source; focus this node to inspect","viewer.passport.beacon.other":"{count} verified sources; focus this node to inspect","viewer.passport.repository.open":"Open verified repository revision {revision}","viewer.passport.source.open":"Open verified source {path} at revision {revision}","viewer.passport.source.openLink":"Open ↗","viewer.passport.reach.upstream.one":"Trace {count} upstream authored node","viewer.passport.reach.upstream.other":"Trace {count} upstream authored nodes","viewer.passport.reach.downstream.one":"Trace {count} downstream authored node","viewer.passport.reach.downstream.other":"Trace {count} downstream authored nodes","viewer.passport.reach.noUpstream":"No upstream authored nodes","viewer.passport.reach.noDownstream":"No downstream authored nodes","viewer.passport.reach.status":"{direction} · {nodes} nodes · {links} links · max {hops} hops","viewer.route.eyebrow":"Route probe","viewer.route.start":"Choose a start node","viewer.route.start.find":"Find start","viewer.route.start.find.aria":"Find a route start","viewer.route.copy":"Copy link","viewer.route.copy.aria":"Copy link to traced route","viewer.route.clear":"Clear","viewer.route.clear.aria":"Clear route probe","viewer.route.traced":"Traced route","viewer.route.pickTwo":"Pick two semantic nodes on the diagram","viewer.route.pickOne":"Pick a semantic node on the diagram","viewer.route.controls":"Route journey controls","viewer.route.previous":"Previous route position","viewer.route.play":"Play route journey","viewer.route.pause":"Pause route journey","viewer.route.replay":"Replay route journey","viewer.route.next":"Next route position","viewer.route.journey":"Journey","viewer.route.pause.label":"Pause","viewer.route.replay.label":"Replay","viewer.route.overview":"Overview","viewer.route.overview.aria":"Show complete route overview","viewer.route.instructions":"Choose the source, then the destination. Direction matters.","viewer.route.destination":"Choose a destination from {label}","viewer.route.destination.find":"Find target","viewer.route.destination.find.aria":"Find a reachable route destination","viewer.route.differentDestination":"Choose a different destination","viewer.route.distinct":"A route needs two distinct semantic nodes.","viewer.route.unreachable":"No directed route to {label}","viewer.route.unreachable.detail":"{target} is not reachable from {source}. Pick a highlighted destination.","viewer.route.start.instructions":"Select the source. The next step will reveal only directed destinations.","viewer.route.copy.success":"Traced route link copied","viewer.route.copy.failed":"Could not copy traced route link","viewer.route.position":"Route position {index} of {total}: {label}","viewer.route.step":"Step {index} of {total} · {phase} · {label}","viewer.route.motionRequired":"Automatic journey requires Live motion","viewer.route.trigger.clear":"Clear traced route","viewer.route.overview.status":"{nodes} · {hops} · shortest authored route","viewer.route.overview.node.one":"{count} node","viewer.route.overview.node.other":"{count} nodes","viewer.route.overview.hop.one":"{count} directed hop","viewer.route.overview.hop.other":"{count} directed hops","viewer.route.phase.playing":"Playing","viewer.route.phase.complete":"Complete","viewer.route.phase.inspecting":"Inspecting","viewer.route.destination.count.one":"{count} directed destination available. Pick a highlighted node.","viewer.route.destination.count.other":"{count} directed destinations available. Pick a highlighted node.","viewer.route.noOutgoing":"No outgoing route starts here. Clear and choose another source.","viewer.route.result.title":"{source} to {target}","viewer.route.finder.source.title":"Choose route start","viewer.route.finder.source.placeholder":"Search route sources","viewer.route.finder.source.empty":"No matching route sources","viewer.route.finder.source.results":"Nodes that can start a route","viewer.route.finder.source.noun":"route sources","viewer.route.finder.source.badge":"start","viewer.route.finder.target.title":"Destination from {label}","viewer.route.finder.target.placeholder":"Search reachable destinations","viewer.route.finder.target.empty":"No matching reachable destinations","viewer.route.finder.target.results":"Reachable route destinations","viewer.route.finder.target.noun":"reachable destinations","viewer.route.hop.one":"{count} hop","viewer.route.hop.other":"{count} hops","viewer.lens.eyebrow":"Semantic lens","viewer.lens.title":"Compare system roles","viewer.lens.close":"Close semantic lens","viewer.lens.instruction":"Choose up to two semantic kinds. One reveals its real traffic; two compare only direct authored relationships.","viewer.lens.kinds":"Semantic kinds","viewer.lens.choose":"Choose a kind to inspect its nodes and touching relationships.","viewer.lens.copy":"Copy link to semantic lens","viewer.lens.clear":"Clear semantic lens","viewer.lens.open":"Open semantic lens","viewer.lens.openActive":"Open active semantic lens","viewer.lens.legend":"Semantic legend","viewer.lens.legend.inspect.one":"Inspect {label}, {count} node","viewer.lens.legend.inspect.other":"Inspect {label}, {count} nodes","viewer.lens.kind.count.one":"{label}, {count} node","viewer.lens.kind.count.other":"{label}, {count} nodes","viewer.lens.compare.one":"{first} → {second}: {forward} · {second} → {first}: {reverse} · {count} direct relationship","viewer.lens.compare.other":"{first} → {second}: {forward} · {second} → {first}: {reverse} · {count} direct relationships","viewer.lens.single":"{nodes} · {relationships} · connected peers remain visible","viewer.lens.node.one":"{count} {label} node","viewer.lens.node.other":"{count} {label} nodes","viewer.lens.relationship.one":"{count} touching relationship","viewer.lens.relationship.other":"{count} touching relationships","viewer.radar.title":"Semantic radar","viewer.radar.building":"Building overview","viewer.radar.openFull":"Open full semantic radar","viewer.radar.open":"Open radar","viewer.radar.close":"Close semantic radar","viewer.radar.surface":"Diagram overview. Click a node to focus it, or use arrow keys to pan.","viewer.radar.click":"Click node","viewer.radar.drag":"Drag to pan","viewer.radar.space":"Semantic radar needs more MAP space.","viewer.radar.nodes":"Semantic diagram radar nodes","viewer.radar.focus":"Focus {label} from Semantic Radar","viewer.radar.status":"{count} nodes · {viewport}","viewer.radar.fullMap":"{count} nodes · full map","viewer.radar.compacted":"Radar compacted to avoid covering the Semantic Passport or MAP controls.","viewer.radar.cancelWaiting":"Cancel semantic radar waiting for more MAP space","viewer.radar.needsSpace":"Semantic radar needs more visible MAP space","viewer.radar.viewport.full":"full map","viewer.radar.viewport.width":"{percent}% width","viewer.radar.viewport.scale":"{percent}% viewport","viewer.nav.controls":"Diagram view controls","viewer.nav.route":"Trace a directed route","viewer.nav.route.title":"Trace route (R)","viewer.nav.route.short":"PATH","viewer.nav.radar":"Open semantic radar","viewer.nav.radar.title":"Semantic radar (M)","viewer.nav.radar.short":"MAP","viewer.nav.lens":"Open semantic lens","viewer.nav.lens.title":"Semantic lens (L)","viewer.nav.lens.short":"LENS","viewer.nav.find":"Find a node","viewer.nav.find.title":"Find a node (/)","viewer.nav.guide":"Open diagram guide","viewer.nav.guide.title":"Diagram guide (?)","viewer.nav.zoomOut":"Zoom out","viewer.nav.zoomOut.title":"Zoom out (-)","viewer.nav.reset":"Reset diagram view","viewer.nav.reset.title":"Reset view (0)","viewer.nav.read":"READ","viewer.nav.zoomIn":"Zoom in","viewer.nav.zoomIn.title":"Zoom in (+)","viewer.nav.camera":"{hint}. Reset diagram view","viewer.nav.camera.title":"{semantic}{hint} · reset view (0)","viewer.nav.camera.semantic":"Semantic camera active · ","viewer.nav.level.map":"MAP","viewer.nav.level.read":"READ","viewer.nav.level.full":"FULL","viewer.nav.level.auto":"AUTO","viewer.nav.detail.map":"Zoom in to reveal relationship labels and node context","viewer.nav.detail.read":"Zoom in again to reveal tags and annotations","viewer.nav.detail.full":"Full diagram detail","viewer.intent.summary":"{label}. {out} outgoing, {in} incoming{loops}. {total} connections. Press Enter for details.","viewer.intent.loops":", {count} self loop","viewer.common.copied":"Copied","viewer.common.copyFailed":"Copy failed","viewer.common.copyLink":"Copy link","viewer.common.clear":"Clear","viewer.common.close":"Close"}}</script>
     <div class="guided-views no-print" id="guided-views" hidden aria-label="Guided diagram views">
       <button id="guided-view-prev" type="button" aria-label="Previous guided view" title="Previous guided view ([)">&#8592;</button>
       <div class="guided-view-copy">
@@ -4543,8 +4996,9 @@
     </div>
 
     <!-- Main Diagram -->
-    <div class="diagram-container" data-detail-level="map">
-      <svg viewBox="0 0 1680 720" role="img" aria-labelledby="archify-diagram-title archify-diagram-description" data-animation="trace" data-preset="signal-flow" data-quality-profile="showcase">
+    <div class="diagram-container" data-detail-level="read"
+         data-preset-badge-editorial-plate="ARCHIFY / PLATE 04">
+      <svg viewBox="0 0 1680 720" role="img" lang="en" aria-labelledby="archify-diagram-title archify-diagram-description" data-animation="trace" data-preset="signal-flow" data-quality-profile="showcase">
         <title id="archify-diagram-title">MCO Runtime Architecture</title>
         <desc id="archify-diagram-description">Explicit provider selection, policy-bound execution, parallel orchestration, and raw-answer evidence</desc>
         <!-- Definitions -->
@@ -4570,11 +5024,9 @@
         <rect width="100%" height="100%" fill="url(#grid)" />
 
         <!-- Boundaries (behind everything) -->
-        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="0" x="180" y="250" width="1256" height="336" rx="12" class="c-region" stroke-width="1"/>
-        <text x="188" y="268" class="t-cloud" font-size="9" font-weight="600">MCO local package / Python runtime</text>
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="0" data-composition-frame-label="MCO local package / Python runtime" x="180" y="250" width="1256" height="336" rx="12" class="c-region" stroke-width="1"/>
 
-        <rect data-graph-role="structural-frame" data-composition-frame-kind="security-group" data-composition-frame-id="1" x="580" y="250" width="856" height="116" rx="8" class="c-security-group" stroke-width="1"/>
-        <text x="588" y="268" class="t-security" font-size="9" font-weight="600">explicit execution-policy boundary</text>
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="security-group" data-composition-frame-id="1" data-composition-frame-label="explicit execution-policy boundary" x="580" y="250" width="856" height="116" rx="8" class="c-security-group" stroke-width="1"/>
 
         <!-- Connection paths (before components for correct z-order) -->
         <path data-edge-from="callers" data-edge-to="entry" data-edge-label="task + selected agents" data-edge-key="0" data-edge-id="submit" data-composition-points="162,313;210,313" d="M 162 313 L 210 313" class="a-emphasis" data-animate="edge" style="--step:0" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
@@ -4598,7 +5050,7 @@
             <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
             <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
           </g>
-          <text data-detail-anchor="" x="96" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Callers</text>
+          <text data-node-label="" data-detail-anchor="" x="96" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Callers</text>
         <text data-detail="context" x="96" y="327" class="t-muted" font-size="9" text-anchor="middle">human · coding agent</text>
         </g>
 
@@ -4612,7 +5064,7 @@
             <circle cx="4.1" cy="4.8" r=".7" class="sigil-fill"/>
             <circle cx="6.3" cy="4.8" r=".7" class="sigil-fill"/>
           </g>
-          <text data-detail-anchor="" x="285" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Entry Surfaces</text>
+          <text data-node-label="" data-detail-anchor="" x="285" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Entry Surfaces</text>
         <text data-detail="context" x="285" y="327" class="t-muted" font-size="9" text-anchor="middle">npm · Python CLI · MCP</text>
         <text data-detail="fine" x="285" y="338" class="t-frontend" font-size="7" text-anchor="middle">bin/mco.js · mco</text>
         </g>
@@ -4624,7 +5076,7 @@
           <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(416 286) scale(0.6875)">
             <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
           </g>
-          <text data-detail-anchor="" x="485" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Command Router</text>
+          <text data-node-label="" data-detail-anchor="" x="485" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Command Router</text>
         <text data-detail="context" x="485" y="327" class="t-muted" font-size="9" text-anchor="middle">run · review · doctor</text>
         <text data-detail="fine" x="485" y="338" class="t-backend" font-size="7" text-anchor="middle">runtime.cli</text>
         </g>
@@ -4637,7 +5089,7 @@
             <path d="M8 2.2 13 4v3.5c0 3.1-1.8 5.4-5 6.5-3.2-1.1-5-3.4-5-6.5V4Z"/>
             <path d="m5.8 8 1.5 1.5 3-3"/>
           </g>
-          <text data-detail-anchor="" x="689" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Config + Policy</text>
+          <text data-node-label="" data-detail-anchor="" x="689" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Config + Policy</text>
         <text data-detail="context" x="689" y="327" class="t-muted" font-size="9" text-anchor="middle">scope · permissions · risk</text>
         <text data-detail="fine" x="689" y="338" class="t-security" font-size="7" text-anchor="middle">read_only · write · yolo</text>
         </g>
@@ -4649,7 +5101,7 @@
           <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(826 286) scale(0.6875)">
             <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
           </g>
-          <text data-detail-anchor="" x="905" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Invocation Workflow</text>
+          <text data-node-label="" data-detail-anchor="" x="905" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Invocation Workflow</text>
         <text data-detail="context" x="905" y="327" class="t-muted" font-size="9" text-anchor="middle">parallel · chain · debate</text>
         <text data-detail="fine" x="905" y="338" class="t-backend" font-size="7" text-anchor="middle">timeouts · cancellation</text>
         </g>
@@ -4661,8 +5113,8 @@
           <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(1046 286) scale(0.6875)">
             <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
           </g>
-          <text data-detail-anchor="" x="1119" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Adapter Registry</text>
-        <text data-detail="context" x="1119" y="327" class="t-muted" font-size="9" text-anchor="middle">detect · run · poll · cancel</text>
+          <text data-node-label="" data-detail-anchor="" x="1119" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Adapter Registry</text>
+        <text data-detail="context" x="1119" y="327" class="t-muted" font-size="8.9" text-anchor="middle">detect · run · poll · cancel</text>
         <text data-detail="fine" x="1119" y="338" class="t-backend" font-size="7" text-anchor="middle">ProviderAdapter contract</text>
         </g>
 
@@ -4676,7 +5128,7 @@
             <circle cx="10.5" cy="8" r="1" class="sigil-fill"/>
             <circle cx="7" cy="11.5" r="1" class="sigil-fill"/>
           </g>
-          <text data-detail-anchor="" x="1323" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Transport Layer</text>
+          <text data-node-label="" data-detail-anchor="" x="1323" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Transport Layer</text>
         <text data-detail="context" x="1323" y="327" class="t-muted" font-size="9" text-anchor="middle">shim stdout · ACP JSON-RPC</text>
         <text data-detail="fine" x="1323" y="338" class="t-messagebus" font-size="7" text-anchor="middle">decode_transport</text>
         </g>
@@ -4689,7 +5141,7 @@
             <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
             <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
           </g>
-          <text data-detail-anchor="" x="1548" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Provider CLIs</text>
+          <text data-node-label="" data-detail-anchor="" x="1548" y="311" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Provider CLIs</text>
         <text data-detail="context" x="1548" y="327" class="t-muted" font-size="9" text-anchor="middle">Claude · Codex · Pi · 7 more</text>
         <text data-detail="fine" x="1548" y="338" class="t-external" font-size="7" text-anchor="middle">native auth + sandbox</text>
         </g>
@@ -4701,7 +5153,7 @@
           <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(411 506) scale(0.6875)">
             <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
           </g>
-          <text data-detail-anchor="" x="485" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Session Daemon</text>
+          <text data-node-label="" data-detail-anchor="" x="485" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Session Daemon</text>
         <text data-detail="context" x="485" y="547" class="t-muted" font-size="9" text-anchor="middle">detached worker + socket</text>
         <text data-detail="fine" x="485" y="558" class="t-backend" font-size="7" text-anchor="middle">queue · retry · cancel</text>
         </g>
@@ -4714,7 +5166,7 @@
             <ellipse cx="8" cy="4" rx="5" ry="2"/>
             <path d="M3 4v8c0 1.1 2.2 2 5 2s5-.9 5-2V4M3 8c0 1.1 2.2 2 5 2s5-.9 5-2"/>
           </g>
-          <text data-detail-anchor="" x="715" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Session State</text>
+          <text data-node-label="" data-detail-anchor="" x="715" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Session State</text>
         <text data-detail="context" x="715" y="547" class="t-muted" font-size="9" text-anchor="middle">.mco/sessions</text>
         <text data-detail="fine" x="715" y="558" class="t-database" font-size="7" text-anchor="middle">state · history · logs</text>
         </g>
@@ -4727,8 +5179,8 @@
             <ellipse cx="8" cy="4" rx="5" ry="2"/>
             <path d="M3 4v8c0 1.1 2.2 2 5 2s5-.9 5-2V4M3 8c0 1.1 2.2 2 5 2s5-.9 5-2"/>
           </g>
-          <text data-detail-anchor="" x="1323" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Invocation Artifacts</text>
-        <text data-detail="context" x="1323" y="547" class="t-muted" font-size="9" text-anchor="middle">answers · result.md · run.json</text>
+          <text data-node-label="" data-detail-anchor="" x="1323" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Invocation Artifacts</text>
+        <text data-detail="context" x="1323" y="547" class="t-muted" font-size="8.7" text-anchor="middle">answers · result.md · run.json</text>
         <text data-detail="fine" x="1323" y="558" class="t-database" font-size="7" text-anchor="middle">per-stage evidence</text>
         </g>
 
@@ -4740,21 +5192,21 @@
             <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
             <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
           </g>
-          <text data-detail-anchor="" x="1548" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Output Consumers</text>
+          <text data-node-label="" data-detail-anchor="" x="1548" y="531" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Output Consumers</text>
         <text data-detail="context" x="1548" y="547" class="t-muted" font-size="9" text-anchor="middle">terminal · agent · CI</text>
         <text data-detail="fine" x="1548" y="558" class="t-external" font-size="7" text-anchor="middle">text · JSON · JSONL</text>
         </g>
 
         <!-- Connection labels -->
         <g data-detail="context" data-edge-from="callers" data-edge-to="entry" data-edge-label="task + selected agents" data-edge-key="0" data-edge-id="submit">
-          <rect x="128.2" y="266" width="115.6" height="14" rx="3" class="c-mask"/>
-          <text x="186" y="276" class="t-backend" font-size="8" text-anchor="middle">task + selected agents</text>
+          <rect x="128.2" y="234" width="115.6" height="14" rx="3" class="c-mask"/>
+          <text x="186" y="244" class="t-backend" font-size="8" text-anchor="middle">task + selected agents</text>
         </g>
 
 
         <g data-detail="context" data-edge-from="policy" data-edge-to="invocation" data-edge-label="validated scope" data-edge-key="3" data-edge-id="authorize">
-          <rect x="753" y="266" width="82" height="14" rx="3" class="c-mask"/>
-          <text x="794" y="276" class="t-security" font-size="8" text-anchor="middle">validated scope</text>
+          <rect x="753" y="234" width="82" height="14" rx="3" class="c-mask"/>
+          <text x="794" y="244" class="t-security" font-size="8" text-anchor="middle">validated scope</text>
         </g>
 
         <g data-detail="context" data-edge-from="adapters" data-edge-to="transport" data-edge-label="provider contract" data-edge-key="5" data-edge-id="adapt">
@@ -4782,32 +5234,43 @@
           <text x="1433" y="580" class="t-backend" font-size="8" text-anchor="middle">raw evidence</text>
         </g>
 
+        <!-- Boundary labels (foreground masks keep routes out of titles) -->
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="0" data-composition-frame-kind="region" data-composition-frame-label="MCO local package / Python runtime">
+          <rect data-graph-role="structural-frame-label-mask" x="184" y="258" width="231.1096978193548" height="18" rx="3" class="c-mask"/>
+          <text data-boundary-label="" x="188" y="272.83871067741933" class="t-cloud" font-size="10.838710677419353" font-weight="600">MCO local package / Python runtime</text>
+        </g>
+
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="1" data-composition-frame-kind="security-group" data-composition-frame-label="explicit execution-policy boundary">
+          <rect data-graph-role="structural-frame-label-mask" x="584" y="258" width="231.1096978193548" height="18" rx="3" class="c-mask"/>
+          <text data-boundary-label="" x="588" y="272.83871067741933" class="t-security" font-size="10.838710677419353" font-weight="600">explicit execution-policy boundary</text>
+        </g>
+
         <!-- Legend -->
-        <g data-legend-bridge="">
-          <text x="40" y="691" class="t-primary" font-size="9" font-weight="600">Legend</text>
-          <g data-legend-kind="external">
-            <rect x="40" y="696" width="14" height="9" rx="2" class="c-external" stroke-width="1"/>
-            <text x="60" y="704" class="t-muted" font-size="8">External</text>
+        <g data-legend="" data-legend-bridge="">
+          <text x="40" y="684" class="t-primary" font-size="12" font-weight="650">Legend</text>
+          <g data-legend-semantic-kind="frontend" data-legend-kind="frontend" data-legend-label="Frontend" data-legend-x="40" data-legend-baseline="704" data-legend-width="83">
+            <rect x="40" y="695" width="16" height="10" rx="2.5" class="c-frontend" stroke-width="1"/>
+            <text x="62" y="704" class="t-muted" font-size="10" font-weight="500">Frontend</text>
           </g>
-          <g data-legend-kind="frontend">
-            <rect x="144" y="696" width="14" height="9" rx="2" class="c-frontend" stroke-width="1"/>
-            <text x="164" y="704" class="t-muted" font-size="8">Frontend</text>
+          <g data-legend-semantic-kind="backend" data-legend-kind="backend" data-legend-label="Backend" data-legend-x="145" data-legend-baseline="704" data-legend-width="78">
+            <rect x="145" y="695" width="16" height="10" rx="2.5" class="c-backend" stroke-width="1"/>
+            <text x="167" y="704" class="t-muted" font-size="10" font-weight="500">Backend</text>
           </g>
-          <g data-legend-kind="backend">
-            <rect x="248" y="696" width="14" height="9" rx="2" class="c-backend" stroke-width="1"/>
-            <text x="268" y="704" class="t-muted" font-size="8">Backend</text>
+          <g data-legend-semantic-kind="database" data-legend-kind="database" data-legend-label="Database" data-legend-x="245" data-legend-baseline="704" data-legend-width="83">
+            <rect x="245" y="695" width="16" height="10" rx="2.5" class="c-database" stroke-width="1"/>
+            <text x="267" y="704" class="t-muted" font-size="10" font-weight="500">Database</text>
           </g>
-          <g data-legend-kind="security">
-            <rect x="347" y="696" width="14" height="9" rx="2" class="c-security" stroke-width="1"/>
-            <text x="367" y="704" class="t-muted" font-size="8">Security</text>
+          <g data-legend-semantic-kind="security" data-legend-kind="security" data-legend-label="Security" data-legend-x="350" data-legend-baseline="704" data-legend-width="83">
+            <rect x="350" y="695" width="16" height="10" rx="2.5" class="c-security" stroke-width="1"/>
+            <text x="372" y="704" class="t-muted" font-size="10" font-weight="500">Security</text>
           </g>
-          <g data-legend-kind="messagebus">
-            <rect x="451" y="696" width="14" height="9" rx="2" class="c-messagebus" stroke-width="1"/>
-            <text x="471" y="704" class="t-muted" font-size="8">Message bus</text>
+          <g data-legend-semantic-kind="messagebus" data-legend-kind="messagebus" data-legend-label="Message bus" data-legend-x="455" data-legend-baseline="704" data-legend-width="98">
+            <rect x="455" y="695" width="16" height="10" rx="2.5" class="c-messagebus" stroke-width="1"/>
+            <text x="477" y="704" class="t-muted" font-size="10" font-weight="500">Message bus</text>
           </g>
-          <g data-legend-kind="database">
-            <rect x="570" y="696" width="14" height="9" rx="2" class="c-database" stroke-width="1"/>
-            <text x="590" y="704" class="t-muted" font-size="8">Database</text>
+          <g data-legend-semantic-kind="external" data-legend-kind="external" data-legend-label="External" data-legend-x="575" data-legend-baseline="704" data-legend-width="83">
+            <rect x="575" y="695" width="16" height="10" rx="2.5" class="c-external" stroke-width="1"/>
+            <text x="597" y="704" class="t-muted" font-size="10" font-weight="500">External</text>
           </g>
         </g>
       </svg>
@@ -4894,6 +5357,7 @@
               <span id="focus-kind" data-passport="kind"></span>
               <span id="focus-context" data-passport="context" hidden></span>
               <span id="focus-tag" data-passport="tag" hidden></span>
+              <span id="focus-brand" data-passport="brand" hidden></span>
               <code id="focus-id" data-passport="id"></code>
             </div>
             <div class="semantic-passport-evidence" id="focus-evidence" hidden aria-label="Verified source evidence">
@@ -4974,20 +5438,22 @@
             <strong id="overview-map-title">Semantic radar</strong>
             <small id="overview-map-status" aria-live="polite">Building overview</small>
           </span>
+          <button class="overview-map-expand" id="overview-map-expand" type="button" aria-label="Open full semantic radar">Open radar</button>
           <button class="overview-map-close" id="overview-map-close" type="button" aria-label="Close semantic radar">&#215;</button>
         </div>
         <div class="overview-map-surface" id="overview-map-surface" tabindex="0" role="group" aria-label="Diagram overview. Click a node to focus it, or use arrow keys to pan."></div>
         <div class="overview-map-hint" aria-hidden="true"><span>Click node</span><span>Drag to pan</span></div>
       </div>
+      <p class="overview-map-feedback no-print" id="overview-map-feedback" role="status" aria-live="polite" hidden>Semantic radar needs more MAP space.</p>
       <div class="diagram-nav no-print" role="toolbar" aria-label="Diagram view controls">
         <button id="btn-route-probe" type="button" aria-label="Trace a directed route" aria-pressed="false" aria-controls="route-probe" title="Trace route (R)">PATH</button>
         <button id="btn-overview-map" type="button" aria-label="Open semantic radar" aria-expanded="false" aria-controls="overview-map" title="Semantic radar (M)">MAP</button>
         <button id="btn-semantic-lens" type="button" aria-label="Open semantic lens" aria-haspopup="dialog" aria-expanded="false" aria-pressed="false" aria-controls="semantic-lens" title="Semantic lens (L)">LENS</button>
-        <button id="btn-node-finder" type="button" aria-label="Find a node" aria-haspopup="dialog" aria-expanded="false" aria-controls="node-finder" title="Find a node (/)" data-node-finder-trigger>&#8981;</button>
-        <button id="btn-diagram-guide" type="button" aria-label="Open diagram guide" aria-haspopup="dialog" aria-expanded="false" aria-controls="diagram-guide" title="Diagram guide (?)">?</button>
-        <button data-view="out" type="button" aria-label="Zoom out" title="Zoom out (-)">&#8722;</button>
-        <button data-view="reset" type="button" aria-label="Reset diagram view" title="Reset view (0)">100%</button>
-        <button data-view="in" type="button" aria-label="Zoom in" title="Zoom in (+)">+</button>
+        <button id="btn-node-finder" type="button" aria-label="Find a node" aria-haspopup="dialog" aria-expanded="false" aria-controls="node-finder" title="Find a node (/)" data-node-finder-trigger><span class="diagram-nav-icon find" aria-hidden="true"></span></button>
+        <button id="btn-diagram-guide" type="button" aria-label="Open diagram guide" aria-haspopup="dialog" aria-expanded="false" aria-controls="diagram-guide" title="Diagram guide (?)"><span class="diagram-nav-icon guide" aria-hidden="true"></span></button>
+        <button data-view="out" type="button" aria-label="Zoom out" title="Zoom out (-)"><span class="diagram-nav-icon minus" aria-hidden="true"></span></button>
+        <button data-view="reset" type="button" aria-label="Reset diagram view" title="Reset view (0)"><span class="diagram-nav-detail" data-view-detail hidden>READ</span><span class="diagram-nav-percent" data-view-percent>100%</span></button>
+        <button data-view="in" type="button" aria-label="Zoom in" title="Zoom in (+)"><span class="diagram-nav-icon plus" aria-hidden="true"></span></button>
       </div>
     </div>
 
@@ -5030,14 +5496,41 @@
       </div>
     </div>
 
-    <!-- Footer -->
-    <p class="footer">
-      Architecture diagram &bull; Built with Archify<span class="no-print"> &bull; <a class="artifact-start-link" href="https://tt-a1i.github.io/archify/start.html?type=architecture" target="_blank" rel="noopener noreferrer">Create yours &nearr;</a> &bull; Hover to trace &bull; <kbd>R</kbd> route &bull; Click to focus &bull; <kbd>+</kbd>/<kbd>&minus;</kbd> zoom &bull; <kbd>M</kbd> radar &bull; <kbd>[</kbd>/<kbd>]</kbd> views &bull; <kbd>P</kbd> play story &bull; <kbd>T</kbd> theme &bull; <kbd>E</kbd> export</span>
-    </p>
   </div>
 
   <script>
     var Archify = {};
+    var archifyI18nData = (function () {
+      var node = document.getElementById('archify-i18n-data');
+      try { return JSON.parse(node ? node.textContent : '{}'); }
+      catch (_) { return { locale: 'en', messages: {} }; }
+    })();
+    Archify.locale = archifyI18nData.locale || 'en';
+
+    function viewerText(key, values) {
+      var messages = archifyI18nData.messages || {};
+      var template = Object.prototype.hasOwnProperty.call(messages, key) ? messages[key] : key;
+      return String(template).replace(/\{([a-zA-Z0-9_]+)\}/g, function (match, name) {
+        return values && Object.prototype.hasOwnProperty.call(values, name) ? String(values[name]) : match;
+      });
+    }
+
+    function viewerCount(key, count, values) {
+      var suffix = Number(count) === 1 ? '.one' : '.other';
+      var payload = Object.assign({}, values || {}, { count: count });
+      return viewerText(key + suffix, payload);
+    }
+
+    function viewerKindLabel(value) {
+      var normalized = String(value || 'node').toLowerCase();
+      var knownKey = 'viewer.kind.' + normalized;
+      var known = viewerText(knownKey);
+      if (known !== knownKey) return known;
+      return normalized
+        .replace(/messagebus/gi, 'message bus')
+        .replace(/[-_]+/g, ' ')
+        .replace(/\b\w/g, function (letter) { return letter.toUpperCase(); });
+    }
 
     function hasDrawableGeometry(element) {
       if (!element) return false;
@@ -5068,7 +5561,12 @@
        ============================================================ */
     Archify.preset = (function () {
       var PRESETS = ['classic', 'signal-flow', 'blueprint', 'editorial'];
-      var LABELS = { classic: 'Classic', 'signal-flow': 'Flow', blueprint: 'Blueprint', editorial: 'Editorial' };
+      var LABELS = {
+        classic: viewerText('viewer.preset.classic.short'),
+        'signal-flow': viewerText('viewer.preset.flow.short'),
+        blueprint: viewerText('viewer.preset.blueprint'),
+        editorial: viewerText('viewer.preset.editorial')
+      };
       var html = document.documentElement;
       var svg = document.querySelector('.diagram-container svg');
       var btn = document.getElementById('btn-preset');
@@ -5095,8 +5593,8 @@
         svg.setAttribute('data-preset', preset);
         btn.setAttribute('data-preset-option', preset);
         label.textContent = LABELS[preset];
-        btn.setAttribute('aria-label', 'Visual style: ' + LABELS[preset] + '. Choose visual style');
-        btn.title = 'Choose visual style (S cycles)';
+        btn.setAttribute('aria-label', viewerText('viewer.preset.current', { style: LABELS[preset] }));
+        btn.title = viewerText('viewer.preset.choose.title');
         options().forEach(function (option) {
           var selected = option.getAttribute('data-preset-value') === preset;
           option.setAttribute('aria-checked', String(selected));
@@ -5179,7 +5677,6 @@
       var STORAGE_KEY = 'archify-theme';
       var html = document.documentElement;
       var btn = document.getElementById('btn-theme');
-      var icon = document.getElementById('theme-icon');
       var label = document.getElementById('theme-label');
 
       // localStorage can throw (blocked cookies, sandboxed iframes); the whole
@@ -5209,8 +5706,7 @@
 
       function apply(theme) {
         html.setAttribute('data-theme', theme);
-        icon.textContent = theme === 'dark' ? '\u263E' : '\u263C';
-        label.textContent = theme === 'dark' ? 'Dark' : 'Light';
+        label.textContent = viewerText(theme === 'dark' ? 'viewer.theme.dark' : 'viewer.theme.light');
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
@@ -5258,6 +5754,18 @@
       var SHARE_CARD_HEIGHT = 630;
       var SHARE_CARD_PADDING = 36;
       var SHARE_CARD_HEADER = 112;
+
+      function exportError(key, values) {
+        var error = new Error(viewerText(key, values));
+        error.archifyViewerMessage = true;
+        return error;
+      }
+
+      function exportMessage(error) {
+        return error && error.archifyViewerMessage
+          ? error.message
+          : viewerText('viewer.export.unknown');
+      }
 
       function diagramFilename() {
         var title = (document.title || 'diagram')
@@ -5514,6 +6022,7 @@
         });
         Array.prototype.forEach.call(clone.querySelectorAll('[data-legend-kind]'), function (el) {
           el.removeAttribute('data-legend-kind');
+          el.removeAttribute('data-legend-label');
           el.removeAttribute('data-legend-count');
           el.removeAttribute('data-legend-zero');
           el.removeAttribute('data-legend-selected');
@@ -5853,7 +6362,7 @@
                          format === 'webp' ? 'image/webp' : 'image/png';
               var quality = format === 'png' ? undefined : 0.95;
               canvas.toBlob(function (blob) {
-                if (!blob) reject(new Error('toBlob returned null for ' + format));
+                if (!blob) reject(exportError('viewer.export.error.toBlobNull', { label: format }));
                 else resolve(blob);
               }, mime, quality);
             } catch (error) {
@@ -5889,11 +6398,11 @@
 
       function canvas2dOrThrow(canvas, label) {
         if (!canvas || typeof canvas.getContext !== 'function') {
-          throw new Error('Canvas unavailable for ' + label);
+          throw exportError('viewer.export.error.canvasUnavailable', { label: label });
         }
         var ctx = canvas.getContext('2d');
-        if (!ctx) throw new Error('2D canvas context unavailable for ' + label);
-        if (typeof canvas.toBlob !== 'function') throw new Error('canvas.toBlob unavailable for ' + label);
+        if (!ctx) throw exportError('viewer.export.error.contextUnavailable', { label: label });
+        if (typeof canvas.toBlob !== 'function') throw exportError('viewer.export.error.toBlobUnavailable', { label: label });
         return ctx;
       }
 
@@ -5901,14 +6410,14 @@
         options = options || {};
         var routeSnapshot = options.routeSnapshot || null;
         var reachSnapshot = options.reachSnapshot || null;
-        if (routeSnapshot && reachSnapshot) return Promise.reject(new Error('Share Card variants cannot be combined'));
+        if (routeSnapshot && reachSnapshot) return Promise.reject(exportError('viewer.export.error.variantsCombined'));
         var svg = document.querySelector('.diagram-container svg');
         var vb = svg.viewBox.baseVal;
         var sourceScale = Math.min(2, pickSafeScale(vb.width, vb.height));
         var data = serializeSvg(sourceScale, { routeSnapshot: routeSnapshot, reachSnapshot: reachSnapshot });
-        if (!data.canonicalStateClean) return Promise.reject(new Error('Share Card export could not remove temporary viewer state'));
-        if (routeSnapshot && !data.routeStateClean) return Promise.reject(new Error('Route Card export could not preserve the resolved route safely'));
-        if (reachSnapshot && !data.reachStateClean) return Promise.reject(new Error('Reach Card export could not preserve authored reach safely'));
+        if (!data.canonicalStateClean) return Promise.reject(exportError('viewer.export.error.viewerState'));
+        if (routeSnapshot && !data.routeStateClean) return Promise.reject(exportError('viewer.export.error.routeState'));
+        if (reachSnapshot && !data.reachStateClean) return Promise.reject(exportError('viewer.export.error.reachState'));
         var svgBlob = new Blob([data.svgString], { type: 'image/svg+xml;charset=utf-8' });
         var svgUrl = URL.createObjectURL(svgBlob);
 
@@ -5919,7 +6428,7 @@
               var canvas = document.createElement('canvas');
               canvas.width = SHARE_CARD_WIDTH;
               canvas.height = SHARE_CARD_HEIGHT;
-              var ctx = canvas2dOrThrow(canvas, 'Share Card');
+              var ctx = canvas2dOrThrow(canvas, viewerText('viewer.export.shareCard'));
               var computed = getComputedStyle(document.documentElement);
               var bg = computed.getPropertyValue('--bg').trim() || currentBg();
               var text = computed.getPropertyValue('--text').trim() || '#ffffff';
@@ -5932,21 +6441,37 @@
               var titleNode = document.querySelector('.header h1');
               var subtitleNode = document.querySelector('.header .subtitle');
               var title = titleNode ? titleNode.textContent : document.title;
+              var directionLabel = reachSnapshot
+                ? viewerText('viewer.export.direction.' + reachSnapshot.direction)
+                : '';
               var subtitle = routeSnapshot
-                ? 'Route: ' + routeSnapshot.source.label + ' → ' + routeSnapshot.target.label + ' · ' + routeSnapshot.hops + ' directed hops'
+                ? viewerCount('viewer.export.card.routeSummary', routeSnapshot.hops, {
+                    source: routeSnapshot.source.label,
+                    target: routeSnapshot.target.label
+                  })
                 : reachSnapshot
-                  ? 'Authored ' + reachSnapshot.direction + ' from ' + reachSnapshot.origin.label + ' · ' +
-                    (reachSnapshot.nodeIds.length - 1) + ' nodes · ' + reachSnapshot.edges.length +
-                    ' links · max ' + reachSnapshot.maxDepth + ' hops'
+                  ? viewerText('viewer.export.card.reachSummary', {
+                      direction: directionLabel,
+                      origin: reachSnapshot.origin.label,
+                      nodes: viewerCount('viewer.export.card.node', reachSnapshot.nodeIds.length - 1),
+                      links: viewerCount('viewer.export.card.link', reachSnapshot.edges.length),
+                      hops: viewerCount('viewer.export.card.hop', reachSnapshot.maxDepth)
+                    })
                   : subtitleNode ? subtitleNode.textContent : '';
               var preset = document.documentElement.getAttribute('data-preset') || 'classic';
               var theme = document.documentElement.getAttribute('data-theme') || 'dark';
-              var presetLabel = preset === 'signal-flow' ? 'FLOW' : preset.toUpperCase();
+              var presetKey = preset === 'signal-flow'
+                ? 'viewer.preset.flow.short'
+                : 'viewer.preset.' + preset;
+              var presetLabel = viewerText(presetKey).toUpperCase();
+              var themeLabel = viewerText('viewer.theme.' + theme).toUpperCase();
               var cardLabel = routeSnapshot
-                ? 'ARCHIFY · ROUTE · ' + routeSnapshot.hops + ' HOPS'
+                ? viewerText('viewer.export.card.routeBadge', {
+                    hops: viewerCount('viewer.export.card.hop', routeSnapshot.hops).toUpperCase()
+                  })
                 : reachSnapshot
-                  ? 'ARCHIFY · ' + reachSnapshot.direction.toUpperCase() + ' REACH'
-                  : 'ARCHIFY · ' + presetLabel + ' · ' + theme.toUpperCase();
+                  ? viewerText('viewer.export.card.reachBadge', { direction: directionLabel.toUpperCase() })
+                  : viewerText('viewer.export.card.defaultBadge', { preset: presetLabel, theme: themeLabel });
 
               ctx.fillStyle = bg;
               ctx.fillRect(0, 0, SHARE_CARD_WIDTH, SHARE_CARD_HEIGHT);
@@ -5984,7 +6509,7 @@
               URL.revokeObjectURL(svgUrl);
 
               canvas.toBlob(function (blob) {
-                if (!blob) reject(new Error('toBlob returned null for Share Card'));
+                if (!blob) reject(exportError('viewer.export.error.toBlobNull', { label: viewerText('viewer.export.shareCard') }));
                 else resolve(blob);
               }, 'image/png');
             } catch (error) {
@@ -6004,17 +6529,17 @@
         options = options || {};
         if (!options.variant) return renderShareCard();
         if (options.variant !== 'route' && options.variant !== 'reach') {
-          return Promise.reject(new Error('Unknown Share Card variant: ' + options.variant));
+          return Promise.reject(exportError('viewer.export.unknownVariant', { variant: options.variant }));
         }
         if (options.variant === 'route') {
           var routeSnapshot = Archify.routeProbe && Archify.routeProbe.exportSnapshot();
-          if (!routeSnapshot) return Promise.reject(new Error('Trace a route before exporting a Route Share Card'));
+          if (!routeSnapshot) return Promise.reject(exportError('viewer.export.routeRequired'));
           return renderShareCard({ routeSnapshot: routeSnapshot });
         }
         var snapshot = Archify.focus && typeof Archify.focus.reachabilitySnapshot === 'function'
           ? Archify.focus.reachabilitySnapshot()
           : null;
-        if (!snapshot) return Promise.reject(new Error('Trace authored reach before exporting a Reach Share Card'));
+        if (!snapshot) return Promise.reject(exportError('viewer.export.reachRequired'));
         return renderShareCard({ reachSnapshot: snapshot });
       }
 
@@ -6048,7 +6573,7 @@
       function recordWebm(options) {
         options = options || {};
         if (!canRecordMotion()) {
-          return Promise.reject(new Error('WebM motion export requires a trace animation and browser MediaRecorder support'));
+          return Promise.reject(exportError('viewer.export.error.webmRequirements'));
         }
         var duration = Math.max(250, Number(options.duration) || MOTION_DURATION);
         var fps = Math.max(1, Number(options.fps) || MOTION_FPS);
@@ -6246,12 +6771,12 @@
             };
             recorder.onerror = function (event) {
               cleanup();
-              reject(event.error || new Error('MediaRecorder failed'));
+              reject(event.error || exportError('viewer.export.error.mediaRecorder'));
             };
             recorder.onstop = function () {
               cleanup();
               var blob = new Blob(chunks, { type: recorder.mimeType || mime });
-              if (!blob.size) reject(new Error('MediaRecorder produced an empty WebM'));
+              if (!blob.size) reject(exportError('viewer.export.error.emptyWebm'));
               else resolve(blob);
             };
             drawMotionFrame(ctx, backgroundImage, motionScene, 0);
@@ -6272,7 +6797,7 @@
           };
           backgroundImage.onerror = function () {
             URL.revokeObjectURL(sourceUrl);
-            reject(new Error('SVG background could not be loaded for WebM export'));
+            reject(exportError('viewer.export.error.webmBackground'));
           };
           backgroundImage.src = sourceUrl;
         });
@@ -6330,13 +6855,11 @@
       items().forEach(function (it) {
         if (it.dataset.format && !supports(it.dataset.format)) {
           it.disabled = true;
-          it.title = 'Not supported by this browser';
-          it.style.opacity = '0.5';
+          it.title = viewerText('viewer.export.unsupported');
         }
         if ((it.dataset.action === 'copy' || it.dataset.action === 'copy-share-card') && !canCopyImage()) {
           it.disabled = true;
-          it.title = 'Clipboard image write not supported by this browser';
-          it.style.opacity = '0.5';
+          it.title = viewerText('viewer.export.clipboardUnsupported');
         }
       });
 
@@ -6427,12 +6950,12 @@
         var base = diagramFilename();
         close(true);
         clearExportReceipt();
-        if (format === 'webm') toast('Recording 6 seconds of motion…');
+        if (format === 'webm') toast(viewerText('viewer.export.recording'));
         return (format === 'share-card'
           ? rasterizeShareCard().then(function (blob) {
               recordExportReceipt('share-card', blob, true, { width: SHARE_CARD_WIDTH, height: SHARE_CARD_HEIGHT });
               download(blob, base + '-share-card.png');
-              toast('Downloaded Share Card');
+              toast(viewerText('viewer.export.downloadedShare'));
             })
           : format === 'svg'
           ? Promise.resolve(serializeSvg(1, { autoTheme: true })).then(function (d) {
@@ -6445,7 +6968,7 @@
                 document.documentElement.setAttribute('data-last-motion-bytes', String(blob.size));
                 recordExportReceipt('webm', blob, true);
                 download(blob, base + '.webm');
-                toast('Downloaded WebM');
+                toast(viewerText('viewer.export.downloadedWebm'));
               })
           : rasterize(format).then(function (blob) {
               recordExportReceipt(format, blob, true);
@@ -6453,20 +6976,21 @@
             })
         ).catch(function (err) {
           console.error(err);
-          var message = err && err.message ? err.message : format;
+          var technicalMessage = err && err.message ? err.message : format;
+          var message = exportMessage(err);
           document.documentElement.setAttribute('data-last-export-error-format', format);
-          document.documentElement.setAttribute('data-last-export-error', message);
-          if (format === 'webm' && /MediaRecorder|WebM motion export|empty WebM/i.test(message)) {
+          document.documentElement.setAttribute('data-last-export-error', technicalMessage);
+          if (format === 'webm') {
             var motionItem = menu.querySelector('button[data-format="webm"]');
             if (motionItem) {
               motionItem.disabled = true;
-              motionItem.title = 'Motion capture unavailable in this browser';
+              motionItem.title = viewerText('viewer.export.motionUnavailable');
               motionItem.style.opacity = '0.5';
             }
-            toast('WebM unavailable in this browser');
+            toast(viewerText('viewer.export.webmUnavailable'));
             return;
           }
-          alert('Export failed: ' + message);
+          alert(viewerText('viewer.export.failed', { message: message }));
         });
       }
 
@@ -6476,18 +7000,19 @@
         var snapshot = Archify.routeProbe && Archify.routeProbe.exportSnapshot();
         var blobPromise = snapshot
           ? renderShareCard({ routeSnapshot: snapshot })
-          : Promise.reject(new Error('Trace a route before exporting a Route Share Card'));
+          : Promise.reject(exportError('viewer.export.routeRequired'));
         return blobPromise.then(function (blob) {
           recordExportReceipt('share-card', blob, false, { width: SHARE_CARD_WIDTH, height: SHARE_CARD_HEIGHT }, 'route', true);
           download(blob, diagramFilename() + '-route-share-card.png');
-          toast('Downloaded Route Share Card');
+          toast(viewerText('viewer.export.downloadedRoute'));
           return blob;
         }).catch(function (err) {
           console.error(err);
-          var message = err && err.message ? err.message : 'share-card';
+          var technicalMessage = err && err.message ? err.message : 'share-card';
+          var message = exportMessage(err);
           document.documentElement.setAttribute('data-last-export-error-format', 'share-card');
-          document.documentElement.setAttribute('data-last-export-error', message);
-          alert('Route Share Card export failed: ' + message);
+          document.documentElement.setAttribute('data-last-export-error', technicalMessage);
+          alert(viewerText('viewer.export.routeFailed', { message: message }));
         });
       }
 
@@ -6499,18 +7024,19 @@
           : null;
         var blobPromise = snapshot
           ? renderShareCard({ reachSnapshot: snapshot })
-          : Promise.reject(new Error('Trace authored reach before exporting a Reach Share Card'));
+          : Promise.reject(exportError('viewer.export.reachRequired'));
         return blobPromise.then(function (blob) {
           recordExportReceipt('share-card', blob, false, { width: SHARE_CARD_WIDTH, height: SHARE_CARD_HEIGHT }, 'reach', false, true);
           download(blob, diagramFilename() + '-' + snapshot.direction + '-reach-share-card.png');
-          toast('Downloaded Reach Share Card');
+          toast(viewerText('viewer.export.downloadedReach'));
           return blob;
         }).catch(function (err) {
           console.error(err);
-          var message = err && err.message ? err.message : 'share-card';
+          var technicalMessage = err && err.message ? err.message : 'share-card';
+          var message = exportMessage(err);
           document.documentElement.setAttribute('data-last-export-error-format', 'share-card');
-          document.documentElement.setAttribute('data-last-export-error', message);
-          alert('Reach Share Card export failed: ' + message);
+          document.documentElement.setAttribute('data-last-export-error', technicalMessage);
+          alert(viewerText('viewer.export.reachFailed', { message: message }));
         });
       }
 
@@ -6575,21 +7101,22 @@
         close(true);
         clearExportReceipt();
         if (!canCopyImage()) {
-          alert('Clipboard image write not supported by this browser.');
+          alert(viewerText('viewer.export.clipboardUnsupported.period'));
           return;
         }
         var blobPromise = rasterizeShareCard();
         return writePngToClipboard(blobPromise).then(function () {
           return blobPromise.then(function (blob) {
             recordExportReceipt('share-card', blob, true, { width: SHARE_CARD_WIDTH, height: SHARE_CARD_HEIGHT });
-            toast('Copied Share Card');
+            toast(viewerText('viewer.export.copiedShare'));
           });
         }).catch(function (err) {
           console.error(err);
-          var message = err && err.message ? err.message : 'unknown';
+          var technicalMessage = err && err.message ? err.message : 'share-card';
+          var message = exportMessage(err);
           document.documentElement.setAttribute('data-last-export-error-format', 'share-card');
-          document.documentElement.setAttribute('data-last-export-error', message);
-          alert('Copy failed: ' + message);
+          document.documentElement.setAttribute('data-last-export-error', technicalMessage);
+          alert(viewerText('viewer.export.copyFailed', { message: message }));
         });
       }
 
@@ -6597,15 +7124,17 @@
         close(true);
         clearExportReceipt();
         if (!canCopyImage()) {
-          alert('Clipboard image write not supported in this browser.');
+          alert(viewerText('viewer.export.clipboardUnsupported.short'));
           return;
         }
         var blobPromise = rasterize('png');
         return writePngToClipboard(blobPromise).then(function () {
-          toast('Copied PNG to clipboard');
+          toast(viewerText('viewer.export.copiedPng'));
         }).catch(function (err) {
           console.error(err);
-          alert('Copy failed: ' + (err && err.message ? err.message : 'unknown'));
+          alert(viewerText('viewer.export.copyFailed', {
+            message: exportMessage(err)
+          }));
         });
       }
 
@@ -6731,17 +7260,17 @@
         return readerPaused || reducedMotion() || hasSuspension();
       }
       function ownerLabel(value) {
-        if (value === 'story') return 'the guided story';
-        if (value === 'chapter') return 'the active chapter';
-        if (value === 'chapter-preview') return 'the chapter delta preview';
-        if (value === 'handoff') return 'the chapter handoff';
-        if (value === 'route') return 'Route Probe';
-        if (value === 'lens') return 'Semantic Lens';
-        if (value === 'relationship') return 'Relationship Preview';
-        if (value === 'intent') return 'Intent Trace';
-        if (value === 'focus') return 'semantic focus';
-        if (value === 'legend') return 'legend preview';
-        return 'reader interaction';
+        if (value === 'story') return viewerText('viewer.owner.story');
+        if (value === 'chapter') return viewerText('viewer.owner.chapter');
+        if (value === 'chapter-preview') return viewerText('viewer.owner.chapterPreview');
+        if (value === 'handoff') return viewerText('viewer.owner.handoff');
+        if (value === 'route') return viewerText('viewer.owner.route');
+        if (value === 'lens') return viewerText('viewer.owner.lens');
+        if (value === 'relationship') return viewerText('viewer.owner.relationship');
+        if (value === 'intent') return viewerText('viewer.owner.intent');
+        if (value === 'focus') return viewerText('viewer.owner.focus');
+        if (value === 'legend') return viewerText('viewer.owner.legend');
+        return viewerText('viewer.owner.reader');
       }
       function render() {
         if (!capable) return;
@@ -6755,7 +7284,7 @@
         }
         btn.setAttribute('aria-pressed', paused ? 'false' : 'true');
         btn.disabled = systemPaused;
-        label.textContent = paused ? 'Still' : 'Live';
+        label.textContent = viewerText(paused ? 'viewer.motion.still' : 'viewer.motion.live');
         if (paused && lastEffectivePaused !== true && Archify.guidedViews && Archify.guidedViews.isPlaying()) {
           Archify.guidedViews.pause();
         }
@@ -6768,20 +7297,20 @@
         lastEffectivePaused = paused;
         if (Archify.routeProbe && typeof Archify.routeProbe.syncMotion === 'function') Archify.routeProbe.syncMotion();
         if (systemPaused) {
-          btn.setAttribute('aria-label', 'Motion paused by reduced-motion preference');
-          btn.title = 'Motion paused by reduced-motion preference';
+          btn.setAttribute('aria-label', viewerText('viewer.motion.reduced'));
+          btn.title = viewerText('viewer.motion.reduced');
         } else if (hasSuspension()) {
-          btn.setAttribute('aria-label', 'Motion paused while this page is hidden');
-          btn.title = 'Motion paused while this page is hidden';
+          btn.setAttribute('aria-label', viewerText('viewer.motion.hidden'));
+          btn.title = viewerText('viewer.motion.hidden');
         } else if (paused) {
-          btn.setAttribute('aria-label', 'Resume motion');
-          btn.title = 'Resume motion';
+          btn.setAttribute('aria-label', viewerText('viewer.motion.resume'));
+          btn.title = viewerText('viewer.motion.resume');
         } else if (owner) {
-          btn.setAttribute('aria-label', 'Pause motion; currently yielding to ' + ownerLabel(owner));
-          btn.title = 'Live preview enabled · yielding to ' + ownerLabel(owner);
+          btn.setAttribute('aria-label', viewerText('viewer.motion.yielding', { owner: ownerLabel(owner) }));
+          btn.title = viewerText('viewer.motion.yielding.title', { owner: ownerLabel(owner) });
         } else {
-          btn.setAttribute('aria-label', 'Pause motion');
-          btn.title = 'Pause motion';
+          btn.setAttribute('aria-label', viewerText('viewer.motion.pause'));
+          btn.title = viewerText('viewer.motion.pause');
         }
       }
       function setPaused(next, options) {
@@ -6952,12 +7481,13 @@
           if (!box || !Number.isFinite(box.x) || !Number.isFinite(box.y) || !Number.isFinite(box.width) || box.width < 36) return;
 
           var count = sources.length;
-          var label = count + ' verified source' + (count === 1 ? '' : 's') + '; focus this node to inspect';
+          var label = viewerCount('viewer.passport.beacon', count);
           var beacon = document.createElementNS(svgNamespace, 'g');
           beacon.classList.add('source-evidence-beacon');
           beacon.setAttribute('data-source-evidence-beacon', '');
           beacon.setAttribute('aria-hidden', 'true');
-          beacon.setAttribute('transform', 'translate(' + (box.x + box.width - 35) + ' ' + (box.y + 5) + ')');
+          var brandOffset = node.hasAttribute('data-node-brand') ? 24 : 0;
+          beacon.setAttribute('transform', 'translate(' + (box.x + box.width - 35 - brandOffset) + ' ' + (box.y + 5) + ')');
           var title = document.createElementNS(svgNamespace, 'title');
           title.textContent = label;
           var plate = document.createElementNS(svgNamespace, 'rect');
@@ -6967,7 +7497,7 @@
           var text = document.createElementNS(svgNamespace, 'text');
           text.setAttribute('x', '15');
           text.setAttribute('y', '8.25');
-          text.textContent = 'SRC ' + count;
+          text.textContent = viewerText('viewer.passport.sourceMarker') + ' ' + count;
           beacon.appendChild(title);
           beacon.appendChild(plate);
           beacon.appendChild(text);
@@ -6976,7 +7506,7 @@
           var originalLabel = node.getAttribute('aria-label') || '';
           node.setAttribute('data-source-evidence-count', String(count));
           node.setAttribute('data-source-evidence-original-label', originalLabel);
-          node.setAttribute('aria-label', (originalLabel ? originalLabel + ', ' : '') + count + ' verified source reference' + (count === 1 ? '' : 's'));
+          node.setAttribute('aria-label', (originalLabel ? originalLabel + ', ' : '') + viewerCount('viewer.passport.sourceCount', count));
           installed += 1;
         });
         return installed;
@@ -7154,11 +7684,11 @@
         upstreamBtn.disabled = upstreamReach === 0;
         downstreamBtn.disabled = downstreamReach === 0;
         upstreamBtn.setAttribute('aria-label', upstreamReach
-          ? 'Trace ' + upstreamReach + ' upstream authored node' + (upstreamReach === 1 ? '' : 's')
-          : 'No upstream authored nodes');
+          ? viewerCount('viewer.passport.reach.upstream', upstreamReach)
+          : viewerText('viewer.passport.reach.noUpstream'));
         downstreamBtn.setAttribute('aria-label', downstreamReach
-          ? 'Trace ' + downstreamReach + ' downstream authored node' + (downstreamReach === 1 ? '' : 's')
-          : 'No downstream authored nodes');
+          ? viewerCount('viewer.passport.reach.downstream', downstreamReach)
+          : viewerText('viewer.passport.reach.noDownstream'));
         reachSection.hidden = false;
       }
       function applyReachability(direction, options) {
@@ -7204,11 +7734,15 @@
         var activeButton = direction === 'upstream' ? upstreamBtn : downstreamBtn;
         activeButton.setAttribute('aria-pressed', 'true');
         var reachableCount = result.nodeIds.length - 1;
-        var directionLabel = direction === 'upstream' ? 'Upstream' : 'Downstream';
-        reachStatus.textContent = directionLabel + ' · ' + reachableCount + ' node' +
-          (reachableCount === 1 ? '' : 's') + ' · ' + result.edgeKeys.length + ' link' +
-          (result.edgeKeys.length === 1 ? '' : 's') + ' · max ' + result.maxDepth + ' hop' +
-          (result.maxDepth === 1 ? '' : 's');
+        var directionLabel = viewerText(direction === 'upstream'
+          ? 'viewer.passport.upstream'
+          : 'viewer.passport.downstream');
+        reachStatus.textContent = viewerText('viewer.passport.reach.status', {
+          direction: directionLabel,
+          nodes: reachableCount,
+          links: result.edgeKeys.length,
+          hops: result.maxDepth
+        });
         reachStatus.hidden = false;
         if (Archify.exportMenu && typeof Archify.exportMenu.syncReachShare === 'function') {
           Archify.exportMenu.syncReachShare();
@@ -7335,7 +7869,7 @@
         var slug = repository.url.replace(/^https:\/\/github\.com\//, '').replace(/\/$/, '');
         repositoryLink.href = repository.url + '/tree/' + repository.revision;
         repositoryLink.textContent = slug + ' @ ' + repository.shortRevision;
-        repositoryLink.setAttribute('aria-label', 'Open verified repository revision ' + repository.revision);
+        repositoryLink.setAttribute('aria-label', viewerText('viewer.passport.repository.open', { revision: repository.revision }));
         sources.forEach(function (source) {
           var link = document.createElement('a');
           link.className = 'semantic-passport-source';
@@ -7343,13 +7877,13 @@
           link.target = '_blank';
           link.rel = 'noopener noreferrer';
           link.referrerPolicy = 'no-referrer';
-          link.setAttribute('aria-label', 'Open verified source ' + source.path + ' at revision ' + repository.shortRevision);
+          link.setAttribute('aria-label', viewerText('viewer.passport.source.open', { path: source.path, revision: repository.shortRevision }));
           var name = document.createElement('strong');
           name.textContent = source.label || source.path.split('/').pop() || source.path;
           var location = document.createElement('code');
           location.textContent = source.line
             ? 'L' + source.line + (source.endLine && source.endLine !== source.line ? '–' + source.endLine : '') + ' ↗'
-            : 'Open ↗';
+            : viewerText('viewer.passport.source.openLink');
           var sourcePath = document.createElement('small');
           sourcePath.textContent = source.path;
           link.appendChild(name);
@@ -7361,9 +7895,10 @@
       }
       function renderPassport(id, node) {
         setPassportValue(detail, node.getAttribute('data-node-sublabel'));
-        setPassportValue(kind, node.getAttribute('data-node-kind') || 'node');
+        setPassportValue(kind, viewerKindLabel(node.getAttribute('data-node-kind') || 'node'));
         setPassportValue(context, node.getAttribute('data-node-context'));
         setPassportValue(tag, node.getAttribute('data-node-tag'));
+        setPassportValue(document.getElementById('focus-brand'), node.getAttribute('data-node-brand'));
         semanticId.textContent = id;
         semanticId.hidden = false;
         renderSourceEvidence(id);
@@ -7391,7 +7926,11 @@
             direction: direction,
             neighborId: neighborId,
             neighborLabel: neighbor ? nodeLabel(neighbor, neighborId) : neighborId,
-            label: edgeLabel || (direction === 'loop' ? 'loops back' : direction === 'out' ? 'connects to' : 'connects from')
+            label: edgeLabel || viewerText(direction === 'loop'
+              ? 'viewer.passport.relationship.loopsBack'
+              : direction === 'out'
+                ? 'viewer.passport.relationship.connectsTo'
+                : 'viewer.passport.relationship.connectsFrom')
           });
         });
         return relationships;
@@ -7434,7 +7973,9 @@
             fromLabel: byId[from] ? nodeLabel(byId[from], from) : from,
             toLabel: byId[to] ? nodeLabel(byId[to], to) : to,
             labelValue: labelValue,
-            label: labelValue || (from === to ? 'loops back' : 'connects to'),
+            label: labelValue || viewerText(from === to
+              ? 'viewer.passport.relationship.loopsBack'
+              : 'viewer.passport.relationship.connectsTo'),
             edge: edge,
             shapes: shapes,
             invalid: false
@@ -7461,14 +8002,14 @@
       function renderRelationshipCopyAction() {
         var record = pinnedRelationshipRecord();
         if (record && record.id) {
-          copyBtn.textContent = 'Copy relation';
-          copyBtn.setAttribute('aria-label', 'Copy link to pinned relationship');
+          copyBtn.textContent = viewerText('viewer.passport.copyRelation');
+          copyBtn.setAttribute('aria-label', viewerText('viewer.passport.copyPinned'));
         } else if (pinnedRelationshipKey) {
-          copyBtn.textContent = 'Copy node';
-          copyBtn.setAttribute('aria-label', 'Copy link to source node');
+          copyBtn.textContent = viewerText('viewer.passport.copyNode');
+          copyBtn.setAttribute('aria-label', viewerText('viewer.passport.copySource'));
         } else {
-          copyBtn.textContent = 'Copy link';
-          copyBtn.setAttribute('aria-label', 'Copy link to focused node');
+          copyBtn.textContent = viewerText('viewer.passport.copy');
+          copyBtn.setAttribute('aria-label', viewerText('viewer.passport.copy.focus'));
         }
       }
       function relationshipHitGeometry(shape, className) {
@@ -7787,7 +8328,11 @@
         var target = relationshipHitTarget(key);
         if (target) target.setAttribute('aria-pressed', 'true');
         renderRelationshipCopyAction();
-        summary.textContent = 'Pinned relationship · ' + record.fromLabel + ' → ' + record.toLabel + ' · ' + record.label;
+        summary.textContent = viewerText('viewer.passport.relationship.pinned', {
+          from: record.fromLabel,
+          to: record.toLabel,
+          label: record.label
+        });
         revealPinnedRelationship(record);
         if (options.updateUrl !== false && record.id) {
           try { history.replaceState(null, '', location.pathname + location.search + '#relation=' + encodeURIComponent(record.id)); } catch (_) {}
@@ -7806,10 +8351,10 @@
         relationshipHitOverlay.setAttribute('class', 'relationship-hit-overlay');
         relationshipHitOverlay.setAttribute('data-relationship-hit-overlay', '');
         relationshipHitOverlay.setAttribute('role', 'group');
-        relationshipHitOverlay.setAttribute('aria-label', 'Direct relationship explorer');
+        relationshipHitOverlay.setAttribute('aria-label', viewerText('viewer.passport.relationship.explorer'));
         var relationshipHelp = document.createElementNS(svgNamespace, 'desc');
         relationshipHelp.id = 'archify-relationship-help';
-        relationshipHelp.textContent = 'Use arrow keys to explore relationships. Press Enter or Space to pin details; Escape clears.';
+        relationshipHelp.textContent = viewerText('viewer.passport.relationship.help');
         relationshipHitOverlay.appendChild(relationshipHelp);
         records.forEach(function (record, index) {
           var target = document.createElementNS(svgNamespace, 'g');
@@ -7823,7 +8368,13 @@
           target.setAttribute('tabindex', index === 0 ? '0' : '-1');
           target.setAttribute('aria-pressed', 'false');
           target.setAttribute('aria-describedby', relationshipHelp.id);
-          var description = 'Inspect relationship ' + (index + 1) + ' of ' + records.length + ': ' + record.fromLabel + ' to ' + record.toLabel + ', ' + record.label + '. Press Enter for details.';
+          var description = viewerText('viewer.passport.relationship.inspect', {
+            index: index + 1,
+            total: records.length,
+            from: record.fromLabel,
+            to: record.toLabel,
+            label: record.label
+          });
           target.setAttribute('aria-label', description);
           var title = document.createElementNS(svgNamespace, 'title');
           title.textContent = record.fromLabel + ' \u2192 ' + record.toLabel + ' \u00b7 ' + record.label;
@@ -7919,25 +8470,29 @@
         var relationships = relationshipsFor(id, byId);
         chip.removeAttribute('data-relations-expanded');
         relationsBtn.setAttribute('aria-expanded', 'false');
-        relationsBtn.textContent = relationships.length + ' relation' + (relationships.length === 1 ? '' : 's');
-        relationsBtn.setAttribute('aria-label', 'Show ' + relationships.length + ' connected relationship' + (relationships.length === 1 ? '' : 's'));
+        relationsBtn.textContent = viewerCount('viewer.passport.relationship.count', relationships.length);
+        relationsBtn.setAttribute('aria-label', viewerCount('viewer.passport.relationship.show', relationships.length));
         var counts = { out: 0, in: 0, loop: 0 };
         relationships.forEach(function (relationship) { counts[relationship.direction] += 1; });
-        summary.textContent = counts.out + ' outgoing · ' + counts.in + ' incoming' + (counts.loop ? ' · ' + counts.loop + ' loop' : '');
+        summary.textContent = viewerText('viewer.passport.relationship.summary', {
+          out: counts.out,
+          in: counts.in,
+          loops: counts.loop ? viewerText('viewer.passport.relationship.loops', { count: counts.loop }) : ''
+        });
         renderReachabilityControls(id);
         relationshipList.textContent = '';
         if (!relationships.length) {
           var empty = document.createElement('p');
           empty.className = 'relationship-lens-empty';
-          empty.textContent = 'No connected relationships';
+          empty.textContent = viewerText('viewer.passport.relationship.none');
           relationshipList.appendChild(empty);
           return;
         }
 
         [
-          { id: 'out', label: 'Outgoing' },
-          { id: 'in', label: 'Incoming' },
-          { id: 'loop', label: 'Self loops' }
+          { id: 'out', label: viewerText('viewer.passport.relationship.group.out') },
+          { id: 'in', label: viewerText('viewer.passport.relationship.group.in') },
+          { id: 'loop', label: viewerText('viewer.passport.relationship.group.loop') }
         ].forEach(function (group) {
           var items = relationships.filter(function (relationship) { return relationship.direction === group.id; });
           if (!items.length) return;
@@ -7957,11 +8512,19 @@
             button.setAttribute('data-relationship-from', relationship.from);
             button.setAttribute('data-relationship-to', relationship.to);
             if (relationship.id) button.setAttribute('data-relationship-id', relationship.id);
-            button.setAttribute('aria-label', group.label + ': ' + relationship.label + ', ' + relationship.neighborLabel);
+            button.setAttribute('aria-label', viewerText('viewer.passport.relationship.row', {
+              group: group.label,
+              relationship: relationship.label,
+              neighbor: relationship.neighborLabel
+            }));
             var direction = document.createElement('span');
             direction.className = 'relationship-lens-direction';
             direction.setAttribute('aria-hidden', 'true');
-            direction.textContent = relationship.direction === 'out' ? 'OUT →' : relationship.direction === 'in' ? '← IN' : 'LOOP';
+            direction.textContent = viewerText(relationship.direction === 'out'
+              ? 'viewer.passport.relationship.direction.out'
+              : relationship.direction === 'in'
+                ? 'viewer.passport.relationship.direction.in'
+                : 'viewer.passport.relationship.direction.loop');
             var target = document.createElement('strong');
             target.textContent = relationship.neighborLabel;
             var relation = document.createElement('small');
@@ -8012,6 +8575,45 @@
           preferred = nodeCenter - chip.offsetHeight / 2;
         }
         var top = Math.max(minTop, Math.min(maxTop, preferred));
+        var chipRect = chip.getBoundingClientRect();
+        var safeGap = 10;
+        var protectViewerChrome = !mobile || compactOnMobile || previewingOnMobile;
+        var protectedRects = (protectViewerChrome
+          ? [svg.querySelector('[data-legend]'), container.querySelector('.diagram-nav')]
+          : [])
+          .filter(function (element) {
+            if (!element || element.hidden) return false;
+            var style = window.getComputedStyle(element);
+            return style.display !== 'none' && style.visibility !== 'hidden';
+          })
+          .map(function (element) { return element.getBoundingClientRect(); })
+          .filter(function (rect) {
+            return rect.width > 0 && rect.height > 0 &&
+              chipRect.left < rect.right + safeGap && chipRect.right > rect.left - safeGap;
+          });
+        if (protectedRects.length) {
+          var candidates = [top, minTop, maxTop];
+          protectedRects.forEach(function (rect) {
+            candidates.push(
+              rect.top - containerRect.top - chip.offsetHeight - safeGap,
+              rect.bottom - containerRect.top + safeGap
+            );
+          });
+          var valid = candidates.map(function (candidate) {
+            return Math.max(minTop, Math.min(maxTop, candidate));
+          }).filter(function (candidate, index, all) {
+            if (all.indexOf(candidate) !== index) return false;
+            var candidateTop = containerRect.top + candidate;
+            var candidateBottom = candidateTop + chip.offsetHeight;
+            return protectedRects.every(function (rect) {
+              return candidateBottom <= rect.top - safeGap || candidateTop >= rect.bottom + safeGap;
+            });
+          });
+          valid.sort(function (first, second) {
+            return Math.abs(first - preferred) - Math.abs(second - preferred);
+          });
+          if (valid.length) top = valid[0];
+        }
         chip.style.top = Math.round(top) + 'px';
         if (Archify.radar && typeof Archify.radar.sync === 'function') Archify.radar.sync();
       }
@@ -8062,10 +8664,10 @@
         upstreamBtn.disabled = true;
         downstreamBtn.disabled = true;
         relationshipList.textContent = '';
-        copyBtn.textContent = 'Copy link';
-        copyBtn.setAttribute('aria-label', 'Copy link to focused node');
-        relationsBtn.textContent = 'Relations';
-        relationsBtn.setAttribute('aria-label', 'Show connected relationships');
+        copyBtn.textContent = viewerText('viewer.passport.copy');
+        copyBtn.setAttribute('aria-label', viewerText('viewer.passport.copy.focus'));
+        relationsBtn.textContent = viewerText('viewer.passport.relations');
+        relationsBtn.setAttribute('aria-label', viewerText('viewer.passport.relations.show'));
         relationsBtn.setAttribute('aria-expanded', 'false');
         chip.removeAttribute('data-relations-expanded');
         chip.style.removeProperty('top');
@@ -8133,7 +8735,7 @@
         svg.setAttribute('data-focus-active', normalized.join(' '));
         var defaultLabel = normalized.length === 1
           ? nodeLabel(byId[normalized[0]], normalized[0])
-          : normalized.length + ' selected nodes';
+          : viewerText('viewer.guided.chapter.selectedNodes', { count: normalized.length });
         label.textContent = options.label || defaultLabel;
         chip.hidden = options.hideChip === true || normalized.length !== 1 || selectionMode;
         if (!chip.hidden) {
@@ -8179,10 +8781,10 @@
           ? navigator.clipboard.writeText(value).then(function () { return true; }).catch(function () { return fallbackCopy(value); })
           : Promise.resolve(fallbackCopy(value));
         return copy.then(function (copied) {
-          copyBtn.textContent = copied ? 'Copied' : 'Copy failed';
+          copyBtn.textContent = viewerText(copied ? 'viewer.common.copied' : 'viewer.common.copyFailed');
           copyBtn.setAttribute('aria-label', copied
-            ? (relationId ? 'Pinned relationship link copied' : 'Focused node link copied')
-            : (relationId ? 'Could not copy pinned relationship link' : 'Could not copy focused node link'));
+            ? viewerText(relationId ? 'viewer.passport.copy.pinned.success' : 'viewer.passport.copy.focused.success')
+            : viewerText(relationId ? 'viewer.passport.copy.pinned.failed' : 'viewer.passport.copy.focused.failed'));
           window.setTimeout(function () {
             renderRelationshipCopyAction();
           }, 1600);
@@ -8221,7 +8823,9 @@
         if (expanded) chip.removeAttribute('data-relations-expanded');
         else chip.setAttribute('data-relations-expanded', 'true');
         relationsBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-        relationsBtn.setAttribute('aria-label', expanded ? 'Show connected relationships' : 'Hide connected relationships');
+        relationsBtn.setAttribute('aria-label', viewerText(expanded
+          ? 'viewer.passport.relations.show'
+          : 'viewer.passport.relations.hide'));
         requestLensPlacement();
       });
       relationshipList.addEventListener('click', function (event) {
@@ -8283,7 +8887,7 @@
         var target = event.target;
         if (chip.hidden || !target || typeof target.closest !== 'function' || chip.contains(target)) return;
         if (container.getAttribute('data-just-panned') === 'true') return;
-        if (target.closest('[data-node-id], [data-relationship-hit-key]')) return;
+        if (target.closest('[data-node-id], [data-relationship-hit-key], .overview-map')) return;
         clear();
       }, true);
       window.addEventListener('scroll', requestLensPlacement, { passive: true });
@@ -8507,9 +9111,13 @@
         svg.setAttribute('data-intent-trace-active', id);
         if (options.announce === true) {
           var total = counts.out + counts.in + counts.loop;
-          status.textContent = nodeLabel(selected, id) + '. ' + counts.out + ' outgoing, ' +
-            counts.in + ' incoming' + (counts.loop ? ', ' + counts.loop + ' self loop' : '') +
-            '. ' + total + ' connection' + (total === 1 ? '' : 's') + '. Press Enter for details.';
+          status.textContent = viewerText('viewer.intent.summary', {
+            label: nodeLabel(selected, id),
+            out: counts.out,
+            in: counts.in,
+            loops: counts.loop ? viewerText('viewer.intent.loops', { count: counts.loop }) : '',
+            total: total
+          });
         }
         return true;
       }
@@ -8812,8 +9420,11 @@
           drawHandoffAnchor(anchor);
           var node = findNode(anchor);
           var nodeLabel = node ? (node.getAttribute('data-node-label') || anchor) : anchor;
-          handoffReceipt.textContent = (previousIndex + 1 < 10 ? '0' : '') + (previousIndex + 1) +
-            ' \u2192 ' + (nextIndex + 1 < 10 ? '0' : '') + (nextIndex + 1) + ' \u00b7 via ' + nodeLabel;
+          handoffReceipt.textContent = viewerText('viewer.guided.handoff', {
+            from: (previousIndex + 1 < 10 ? '0' : '') + (previousIndex + 1),
+            to: (nextIndex + 1 < 10 ? '0' : '') + (nextIndex + 1),
+            label: nodeLabel
+          });
           handoffReceipt.hidden = false;
         }
         if (Archify.motionGovernor) {
@@ -8870,8 +9481,13 @@
           button.setAttribute('data-guided-view-id', view.id);
           button.setAttribute('aria-pressed', 'false');
           button.setAttribute('tabindex', index === 0 ? '0' : '-1');
-          button.setAttribute('aria-label', 'Open chapter ' + (index + 1) + ' of ' + views.length + ': ' + view.label + ', ' + view.focus.length + ' stops');
-          button.title = view.label + ' — ' + (view.note || view.focus.length + ' selected nodes');
+          button.setAttribute('aria-label', viewerText('viewer.guided.chapter.open', {
+            index: index + 1,
+            total: views.length,
+            label: view.label,
+            count: view.focus.length
+          }));
+          button.title = view.label + ' — ' + (view.note || viewerText('viewer.guided.chapter.selectedNodes', { count: view.focus.length }));
           var position = document.createElement('span');
           position.className = 'guided-view-chapter-index';
           position.setAttribute('aria-hidden', 'true');
@@ -8881,7 +9497,7 @@
           title.textContent = view.label;
           var stops = document.createElement('em');
           stops.className = 'guided-view-chapter-count';
-          stops.textContent = view.focus.length + ' stop' + (view.focus.length === 1 ? '' : 's');
+          stops.textContent = viewerCount('viewer.guided.chapter.stop', view.focus.length);
           var delta = document.createElement('span');
           delta.className = 'guided-view-chapter-delta';
           delta.hidden = true;
@@ -8914,20 +9530,40 @@
             stops.hidden = false;
             deltaLabel.hidden = true;
             button.removeAttribute('data-chapter-delta');
-            button.setAttribute('aria-label', 'Current chapter ' + (index + 1) + ' of ' + views.length + ': ' + views[index].label + ', ' + views[index].focus.length + ' stops');
-            button.title = views[index].label + ' — current chapter, ' + views[index].focus.length + ' stops';
+            button.setAttribute('aria-label', viewerText('viewer.guided.chapter.current', {
+              index: index + 1,
+              total: views.length,
+              label: views[index].label,
+              count: views[index].focus.length
+            }));
+            button.title = viewerText('viewer.guided.chapter.current.title', {
+              label: views[index].label,
+              count: views[index].focus.length
+            });
           } else {
             var delta = chapterDelta(activeIndex >= 0 ? views[activeIndex] : null, views[index]);
             var compact = '=' + delta.stay.length + ' +' + delta.enter.length + ' \u2212' + delta.leave.length;
-            var expanded = delta.stay.length + ' stay, ' + delta.enter.length + ' enter, ' + delta.leave.length + ' leave';
+            var expanded = viewerText('viewer.guided.chapter.delta.expanded', {
+              stay: delta.stay.length,
+              enter: delta.enter.length,
+              leave: delta.leave.length
+            });
             stops.hidden = true;
             deltaLabel.hidden = false;
             deltaLabel.querySelector('[data-delta-kind="stay"]').textContent = '=' + delta.stay.length;
             deltaLabel.querySelector('[data-delta-kind="enter"]').textContent = '+' + delta.enter.length;
             deltaLabel.querySelector('[data-delta-kind="leave"]').textContent = '\u2212' + delta.leave.length;
             button.setAttribute('data-chapter-delta', compact);
-            button.setAttribute('aria-label', 'Open chapter ' + (index + 1) + ' of ' + views.length + ': ' + views[index].label + '. Chapter focus delta: ' + expanded);
-            button.title = views[index].label + ' — ' + compact + ' chapter focus';
+            button.setAttribute('aria-label', viewerText('viewer.guided.chapter.delta.aria', {
+              index: index + 1,
+              total: views.length,
+              label: views[index].label,
+              delta: expanded
+            }));
+            button.title = viewerText('viewer.guided.chapter.delta.title', {
+              label: views[index].label,
+              delta: compact
+            });
           }
           if (current) button.setAttribute('aria-current', 'step');
           else button.removeAttribute('aria-current');
@@ -9055,33 +9691,44 @@
 
       function shareCueStatus(state) {
         return {
-          pending: 'Ready',
-          playing: 'Playing',
-          complete: 'Settled',
-          interrupted: 'Paused',
-          pinned: 'Pinned',
-          'reduced-motion': 'Still'
-        }[state] || 'Ready';
+          pending: viewerText('viewer.guided.state.ready'),
+          playing: viewerText('viewer.guided.state.playing'),
+          complete: viewerText('viewer.guided.state.settled'),
+          interrupted: viewerText('viewer.guided.state.paused'),
+          pinned: viewerText('viewer.guided.state.pinned'),
+          'reduced-motion': viewerText('viewer.guided.state.still')
+        }[state] || viewerText('viewer.guided.state.ready');
       }
 
       function shareCueBeatCopy(state, view, stops) {
         var total = stops.length;
         var activeStop = storyBeatIndex >= 0 ? stops[storyBeatIndex] : null;
         if ((state === 'playing' || state === 'interrupted') && activeStop) {
-          return 'Step ' + (storyBeatIndex + 1 < 10 ? '0' : '') + (storyBeatIndex + 1) + ' / ' +
-            (total < 10 ? '0' : '') + total + ' · ' + activeStop.textContent;
+          return viewerText('viewer.guided.share.step', {
+            index: (storyBeatIndex + 1 < 10 ? '0' : '') + (storyBeatIndex + 1),
+            total: (total < 10 ? '0' : '') + total,
+            label: activeStop.textContent
+          });
         }
         if (state === 'pinned' && activeStop) {
           return storyBeatCopy(storySteps[storyBeatIndex], total);
         }
         if (state === 'reduced-motion' && activeStop && hashBeatMatchesCurrent()) {
-          return 'Step ' + (storyBeatIndex + 1 < 10 ? '0' : '') + (storyBeatIndex + 1) + ' / ' +
-            (total < 10 ? '0' : '') + total + ' · ' + activeStop.textContent + ' · Static moment';
+          return viewerText('viewer.guided.share.staticMoment', {
+            step: viewerText('viewer.guided.share.step', {
+              index: (storyBeatIndex + 1 < 10 ? '0' : '') + (storyBeatIndex + 1),
+              total: (total < 10 ? '0' : '') + total,
+              label: activeStop.textContent
+            })
+          });
         }
-        if (state === 'complete') return total + ' steps complete · ' + (view.note || 'Path settled for reading.');
-        if (state === 'reduced-motion') return total + ' steps · Static path';
-        if (state === 'pending') return total + ' steps · Ready';
-        return view.note || view.focus.length + ' selected nodes';
+        if (state === 'complete') return viewerText('viewer.guided.share.complete', {
+          count: total,
+          note: view.note || viewerText('viewer.guided.share.settled')
+        });
+        if (state === 'reduced-motion') return viewerText('viewer.guided.share.staticPath', { count: total });
+        if (state === 'pending') return viewerText('viewer.guided.share.ready', { count: total });
+        return view.note || viewerText('viewer.guided.chapter.selectedNodes', { count: view.focus.length });
       }
 
       function renderShareCue() {
@@ -9106,11 +9753,21 @@
         shareCue.setAttribute('data-state', state);
         shareCue.setAttribute('aria-live', state === 'playing' ? 'off' : 'polite');
         shareCueState.textContent = shareCueStatus(state);
-        shareCueCount.textContent = 'Chapter ' + (activeIndex + 1 < 10 ? '0' : '') + (activeIndex + 1) + ' / ' + (views.length < 10 ? '0' : '') + views.length;
+        shareCueCount.textContent = viewerText('viewer.guided.share.chapter', {
+          index: (activeIndex + 1 < 10 ? '0' : '') + (activeIndex + 1),
+          total: (views.length < 10 ? '0' : '') + views.length
+        });
         shareCueLabel.textContent = view.label;
         shareCueNote.textContent = beatCopy;
         shareCueRoute.textContent = route;
-        shareCue.setAttribute('aria-label', shareCueStatus(state) + ' chapter ' + (activeIndex + 1) + ' of ' + views.length + ': ' + view.label + '. ' + beatCopy + '. ' + route);
+        shareCue.setAttribute('aria-label', viewerText('viewer.guided.share.aria', {
+          state: shareCueStatus(state),
+          index: activeIndex + 1,
+          total: views.length,
+          label: view.label,
+          beat: beatCopy,
+          route: route
+        }));
       }
 
       function setShareCueProgress(fraction) {
@@ -9201,24 +9858,24 @@
         if (!step) return '';
         var position = (step.index + 1 < 10 ? '0' : '') + (step.index + 1);
         var countValue = (total < 10 ? '0' : '') + total;
-        if (step.relation === 'start') return 'Beat ' + position + ' / ' + countValue + ' \u00b7 ' + step.nodeLabel + ' \u00b7 starting point';
-        if (step.relation === 'forward') return 'Beat ' + position + ' / ' + countValue + ' \u00b7 ' + step.previousLabel + ' \u2192 ' + step.nodeLabel;
-        if (step.relation === 'reverse') return 'Beat ' + position + ' / ' + countValue + ' \u00b7 ' + step.nodeLabel + ' \u2192 ' + step.previousLabel + ' \u00b7 reverse authored link';
-        if (step.relation === 'multiple') return 'Beat ' + position + ' / ' + countValue + ' \u00b7 ' + step.previousLabel + ' \u21c4 ' + step.nodeLabel + ' \u00b7 ' + step.edges.length + ' authored links';
-        return 'Beat ' + position + ' / ' + countValue + ' \u00b7 ' + step.previousLabel + ' \u00b7 ' + step.nodeLabel + ' \u00b7 grouped \u00b7 no direct link';
+        if (step.relation === 'start') return viewerText('viewer.guided.beat.start', { index: position, total: countValue, label: step.nodeLabel });
+        if (step.relation === 'forward') return viewerText('viewer.guided.beat.forward', { index: position, total: countValue, from: step.previousLabel, to: step.nodeLabel });
+        if (step.relation === 'reverse') return viewerText('viewer.guided.beat.reverse', { index: position, total: countValue, from: step.nodeLabel, to: step.previousLabel });
+        if (step.relation === 'multiple') return viewerText('viewer.guided.beat.multiple', { index: position, total: countValue, from: step.previousLabel, to: step.nodeLabel, count: step.edges.length });
+        return viewerText('viewer.guided.beat.group', { index: position, total: countValue, from: step.previousLabel, to: step.nodeLabel });
       }
 
       function storyBeatAria(step, total) {
-        var prefix = 'Story beat ' + (step.index + 1) + ' of ' + total + ': ' + step.nodeLabel + '. ';
-        if (step.relation === 'start') return prefix + 'Starting point.';
-        if (step.relation === 'forward') return prefix + 'From ' + step.previousLabel + ' through one authored forward relationship.';
-        if (step.relation === 'reverse') return prefix + 'From ' + step.previousLabel + '; the authored relationship points from ' + step.nodeLabel + ' to ' + step.previousLabel + '.';
-        if (step.relation === 'multiple') return prefix + 'From ' + step.previousLabel + ' through ' + step.edges.length + ' authored relationships; shown without arbitrary motion.';
-        return prefix + 'Grouped from ' + step.previousLabel + ' with no direct authored relationship.';
+        var prefix = viewerText('viewer.guided.beat.aria.prefix', { index: step.index + 1, total: total, label: step.nodeLabel });
+        if (step.relation === 'start') return prefix + viewerText('viewer.guided.beat.aria.start');
+        if (step.relation === 'forward') return prefix + viewerText('viewer.guided.beat.aria.forward', { from: step.previousLabel });
+        if (step.relation === 'reverse') return prefix + viewerText('viewer.guided.beat.aria.reverse', { from: step.previousLabel, to: step.nodeLabel });
+        if (step.relation === 'multiple') return prefix + viewerText('viewer.guided.beat.aria.multiple', { from: step.previousLabel, count: step.edges.length });
+        return prefix + viewerText('viewer.guided.beat.aria.group', { from: step.previousLabel });
       }
 
       function storyCaptionRouteCopy(step) {
-        if (step.relation === 'start') return step.nodeLabel + ' · Starting point';
+        if (step.relation === 'start') return step.nodeLabel + ' · ' + viewerText('viewer.guided.caption.start');
         if (step.relation === 'reverse') return step.previousLabel + ' ← ' + step.nodeLabel;
         if (step.relation === 'multiple') return step.previousLabel + ' ⇄ ' + step.nodeLabel;
         if (step.relation === 'group') return step.previousLabel + ' · ' + step.nodeLabel;
@@ -9227,15 +9884,15 @@
 
       function storyCaptionDetailCopy(step) {
         var facts = [];
-        if (step.relation === 'group') facts.push('Grouped transition · no direct authored link');
-        else if (step.edgeLabels.length) facts.push(step.edgeLabels.slice(0, 3).join(' + ') + (step.edgeLabels.length > 3 ? ' +' + (step.edgeLabels.length - 3) + ' more' : ''));
-        else if (step.relation === 'reverse') facts.push('Reverse authored relationship');
-        else if (step.relation === 'multiple') facts.push(step.edges.length + ' authored relationships');
-        else if (step.relation !== 'start') facts.push('Authored relationship');
-        if (step.relation === 'reverse') facts.push('authored direction: ' + step.nodeLabel + ' → ' + step.previousLabel);
+        if (step.relation === 'group') facts.push(viewerText('viewer.guided.caption.grouped'));
+        else if (step.edgeLabels.length) facts.push(step.edgeLabels.slice(0, 3).join(' + ') + (step.edgeLabels.length > 3 ? viewerText('viewer.guided.caption.more', { count: step.edgeLabels.length - 3 }) : ''));
+        else if (step.relation === 'reverse') facts.push(viewerText('viewer.guided.caption.reverse'));
+        else if (step.relation === 'multiple') facts.push(viewerText('viewer.guided.caption.relationships', { count: step.edges.length }));
+        else if (step.relation !== 'start') facts.push(viewerText('viewer.guided.caption.relationship'));
+        if (step.relation === 'reverse') facts.push(viewerText('viewer.guided.caption.direction', { from: step.nodeLabel, to: step.previousLabel }));
         if (step.responsibility) facts.push(step.responsibility);
         if (step.context) facts.push(step.context);
-        if (!facts.length) facts.push('Authored starting point');
+        if (!facts.length) facts.push(viewerText('viewer.guided.caption.starting'));
         return facts.join(' · ');
       }
 
@@ -9291,17 +9948,17 @@
         if (beatLinkFeedbackTimer) clearTimeout(beatLinkFeedbackTimer);
         beatLinkFeedbackTimer = null;
         beatLink.removeAttribute('data-copy-state');
-        beatLinkLabel.textContent = 'Copy moment';
+        beatLinkLabel.textContent = viewerText('viewer.guided.copyMoment');
       }
 
       function syncBeatLink() {
         var step = storyBeatIndex >= 0 ? storySteps[storyBeatIndex] : null;
         var available = !!(activeIndex >= 0 && step && !currentHandoff);
         beatLink.disabled = !available;
-        if (!beatLink.hasAttribute('data-copy-state')) beatLinkLabel.textContent = 'Copy moment';
+        if (!beatLink.hasAttribute('data-copy-state')) beatLinkLabel.textContent = viewerText('viewer.guided.copyMoment');
         var description = available
-          ? 'Copy link to current story moment: Beat ' + (step.index + 1) + ' of ' + storySteps.length + ': ' + step.nodeLabel
-          : 'Select a Story Beat to copy its exact link';
+          ? viewerText('viewer.guided.beatLink', { index: step.index + 1, total: storySteps.length, label: step.nodeLabel })
+          : viewerText('viewer.guided.selectBeatLink');
         beatLink.setAttribute('aria-label', description);
         beatLink.title = description;
       }
@@ -9309,8 +9966,8 @@
       function setBeatLinkFeedback(copied) {
         resetBeatLinkFeedback();
         beatLink.setAttribute('data-copy-state', copied ? 'copied' : 'failed');
-        beatLinkLabel.textContent = copied ? 'Copied' : 'Copy failed';
-        beatLink.setAttribute('aria-label', copied ? 'Moment link copied' : 'Could not copy story moment link');
+        beatLinkLabel.textContent = viewerText(copied ? 'viewer.guided.copied' : 'viewer.guided.copyFailed');
+        beatLink.setAttribute('aria-label', viewerText(copied ? 'viewer.guided.momentCopied' : 'viewer.guided.momentCopyFailed'));
         beatLinkFeedbackTimer = setTimeout(function () {
           resetBeatLinkFeedback();
           syncBeatLink();
@@ -9564,7 +10221,7 @@
           stop.removeAttribute('aria-current');
         });
         note.setAttribute('aria-live', 'polite');
-        if (activeIndex >= 0) note.textContent = views[activeIndex].note || views[activeIndex].focus.length + ' selected nodes';
+        if (activeIndex >= 0) note.textContent = views[activeIndex].note || viewerText('viewer.guided.chapter.selectedNodes', { count: views[activeIndex].focus.length });
         renderStoryCaption(null, 0);
         renderShareCue();
         syncBeatLink();
@@ -9643,7 +10300,7 @@
           trail.appendChild(stop);
         });
         trail.hidden = labels.length === 0;
-        trail.setAttribute('aria-label', 'Story trail for ' + view.label + ': ' + labels.length + ' beats');
+        trail.setAttribute('aria-label', viewerText('viewer.guided.storyTrail', { label: view.label, count: labels.length }));
         trail.scrollLeft = 0;
         svg.setAttribute('data-story-active', view.id);
 
@@ -9722,21 +10379,39 @@
         syncStoryPlayback();
         play.disabled = !playing && !automaticPlaybackAllowed;
         play.setAttribute('aria-pressed', playing ? 'true' : 'false');
-        play.setAttribute('aria-label', playing ? 'Pause guided story' : (!automaticPlaybackAllowed ? 'Story playback unavailable while motion is Still' : (storyPlaybackComplete ? 'Replay guided story' : 'Play guided story')));
-        play.title = playing ? 'Pause guided story (P)' : (!automaticPlaybackAllowed ? 'Switch motion to Live to play the guided story' : (storyPlaybackComplete ? 'Replay guided story (P)' : 'Play guided story (P)'));
+        play.setAttribute('aria-label', viewerText(playing
+          ? 'viewer.guided.pause'
+          : !automaticPlaybackAllowed
+            ? 'viewer.guided.motionUnavailable'
+            : storyPlaybackComplete
+              ? 'viewer.guided.replay'
+              : 'viewer.guided.play'));
+        play.title = viewerText(playing
+          ? 'viewer.guided.pause.title'
+          : !automaticPlaybackAllowed
+            ? 'viewer.guided.enableMotion'
+            : storyPlaybackComplete
+              ? 'viewer.guided.replay.title'
+              : 'viewer.guided.play.title');
         playIcon.textContent = playing ? '\u2016' : '\u25b6';
-        playLabel.textContent = playing ? 'Pause' : (storyPlaybackComplete ? 'Replay story' : 'Play story');
+        playLabel.textContent = viewerText(playing
+          ? 'viewer.guided.pauseStory'
+          : storyPlaybackComplete
+            ? 'viewer.guided.replayStory'
+            : 'viewer.guided.playStory');
         if (storyCaption && !storyCaption.hidden) storyCaption.setAttribute('aria-live', playing ? 'off' : 'polite');
       }
 
       function render() {
         var view = views[activeIndex];
         count.textContent = activeIndex < 0 ? '0 / ' + views.length : (activeIndex + 1) + ' / ' + views.length;
-        label.textContent = view ? view.label : 'Explore this system';
+        label.textContent = view ? view.label : viewerText('viewer.guided.explore');
         note.setAttribute('aria-live', storyBeatIndex >= 0 ? 'off' : 'polite');
         note.textContent = storyBeatIndex >= 0
           ? storyBeatCopy(storySteps[storyBeatIndex], storySteps.length)
-          : (view ? (view.note || view.focus.length + ' selected nodes') : 'Step through curated paths without changing the source diagram.');
+          : (view
+            ? (view.note || viewerText('viewer.guided.chapter.selectedNodes', { count: view.focus.length }))
+            : viewerText('viewer.guided.intro'));
         prev.disabled = activeIndex < 0;
         next.disabled = activeIndex >= views.length - 1;
         all.disabled = activeIndex < 0;
@@ -10212,11 +10887,433 @@
       };
     })();
 
+    /* ============================================================
+       Adaptive Reader Shell — one diagram across laptop and monitor.
+       The canonical SVG and viewBox never change. On ordinary desktop pages,
+       wide diagrams receive only enough outer width to use the available
+       height without pushing summary cards below the viewport. Mobile,
+       embed, presentation, print, and non-wide diagrams retain their own
+       established layout contracts.
+       ============================================================ */
+    Archify.waitForStableLayout = function (options) {
+      options = options || {};
+      var maximumFrames = Math.max(1, Number(options.maximumFrames) || 240);
+      var fontsReady = document.fonts && document.fonts.ready
+        ? document.fonts.ready.catch(function () {})
+        : Promise.resolve();
+      return fontsReady.then(function () {
+        if (typeof options.schedule === 'function') options.schedule();
+        return new Promise(function (resolve, reject) {
+          var previous = '';
+          var stableFrames = 0;
+          var sampledFrames = 0;
+          function sample() {
+            sampledFrames += 1;
+            if (typeof options.pending === 'function' && options.pending()) {
+              previous = '';
+              stableFrames = 0;
+            } else {
+              var current = typeof options.snapshot === 'function' ? options.snapshot() : '';
+              if (current === previous) stableFrames += 1;
+              else {
+                previous = current;
+                stableFrames = 0;
+              }
+              if (stableFrames >= 3) {
+                resolve({ stable: true, snapshot: current, sampledFrames: sampledFrames });
+                return;
+              }
+            }
+            if (sampledFrames >= maximumFrames) {
+              reject(new Error(options.timeoutMessage || 'Layout did not reach stable dimensions.'));
+              return;
+            }
+            requestAnimationFrame(sample);
+          }
+          requestAnimationFrame(sample);
+        });
+      });
+    };
+
+    Archify.readerLayout = (function () {
+      var html = document.documentElement;
+      var body = document.body;
+      var shell = document.querySelector('.container');
+      var diagram = document.querySelector('.diagram-container');
+      var svg = diagram && diagram.querySelector(':scope > svg');
+      var header = shell && shell.querySelector('.header');
+      var guided = shell && shell.querySelector('.guided-views');
+      var cards = shell && shell.querySelector('.cards');
+      var viewBox = svg && svg.viewBox && svg.viewBox.baseVal;
+      var ratio = viewBox && viewBox.height > 0 ? viewBox.width / viewBox.height : 0;
+      var frame = 0;
+      var settleFrame = 0;
+      var lastWidth = 0;
+      var WIDE_RATIO = 1.55;
+      var MIN_DESKTOP_WIDTH = 1024;
+      var MIN_READER_WIDTH = 960;
+      var MAX_READER_WIDTH = 1920;
+      var SAFE_BOTTOM_GAP = 12;
+
+      if (diagram && ratio >= WIDE_RATIO) {
+        diagram.setAttribute('data-wide-diagram', 'true');
+        html.setAttribute('data-diagram-shape', 'wide');
+      }
+
+      function number(value) {
+        var parsed = parseFloat(value);
+        return Number.isFinite(parsed) ? parsed : 0;
+      }
+      function visible(element) {
+        return Boolean(element && !element.hidden && window.getComputedStyle(element).display !== 'none');
+      }
+      function outerHeight(element) {
+        if (!visible(element)) return 0;
+        var style = window.getComputedStyle(element);
+        return element.getBoundingClientRect().height + number(style.marginTop) + number(style.marginBottom);
+      }
+      function eligible() {
+        return Boolean(
+          shell && diagram && svg && ratio >= WIDE_RATIO &&
+          window.innerWidth >= MIN_DESKTOP_WIDTH &&
+          html.getAttribute('data-embed') !== 'true' &&
+          html.getAttribute('data-present') !== 'true' &&
+          (!window.matchMedia || !window.matchMedia('print').matches)
+        );
+      }
+      function clear() {
+        html.style.removeProperty('--archify-reader-width');
+        html.removeAttribute('data-reader-layout');
+        html.removeAttribute('data-reader-overflow');
+        lastWidth = 0;
+      }
+      function chromeMetrics() {
+        var bodyStyle = window.getComputedStyle(body);
+        var diagramStyle = window.getComputedStyle(diagram);
+        return {
+          bodyX: number(bodyStyle.paddingLeft) + number(bodyStyle.paddingRight),
+          bodyY: number(bodyStyle.paddingTop) + number(bodyStyle.paddingBottom),
+          diagramX: number(diagramStyle.paddingLeft) + number(diagramStyle.paddingRight) +
+            number(diagramStyle.borderLeftWidth) + number(diagramStyle.borderRightWidth),
+          diagramY: number(diagramStyle.paddingTop) + number(diagramStyle.paddingBottom) +
+            number(diagramStyle.borderTopWidth) + number(diagramStyle.borderBottomWidth)
+        };
+      }
+      function applyWidth(width) {
+        var rounded = Math.round(width);
+        if (Math.abs(rounded - lastWidth) < 1) return false;
+        lastWidth = rounded;
+        html.style.setProperty('--archify-reader-width', rounded + 'px');
+        html.setAttribute('data-reader-layout', 'adaptive');
+        return true;
+      }
+      function settleOverflow(minWidth) {
+        if (settleFrame) cancelAnimationFrame(settleFrame);
+        settleFrame = requestAnimationFrame(function () {
+          settleFrame = 0;
+          if (!eligible() || !lastWidth) return;
+          var overflow = Math.max(
+            document.documentElement.scrollHeight,
+            document.body.scrollHeight
+          ) - window.innerHeight;
+          if (overflow > 1 && lastWidth > minWidth) {
+            applyWidth(Math.max(minWidth, lastWidth - overflow * ratio - 4));
+            html.setAttribute('data-reader-overflow', 'reduced');
+          } else if (overflow > 1) {
+            html.setAttribute('data-reader-overflow', 'authored');
+          } else {
+            html.removeAttribute('data-reader-overflow');
+          }
+        });
+      }
+      function measure() {
+        frame = 0;
+        if (!eligible()) {
+          clear();
+          return null;
+        }
+        var chrome = chromeMetrics();
+        var viewportCap = Math.max(0, window.innerWidth - chrome.bodyX);
+        var minWidth = Math.min(MIN_READER_WIDTH, viewportCap);
+        var maxWidth = Math.min(MAX_READER_WIDTH, viewportCap);
+        var fixedHeight = chrome.bodyY + chrome.diagramY + SAFE_BOTTOM_GAP +
+          outerHeight(header) + outerHeight(guided) + outerHeight(cards);
+        var availableSvgHeight = Math.max(1, window.innerHeight - fixedHeight);
+        var desiredWidth = availableSvgHeight * ratio + chrome.diagramX;
+        var width = Math.max(minWidth, Math.min(maxWidth, desiredWidth));
+        applyWidth(width);
+        settleOverflow(minWidth);
+        return {
+          ratio: ratio,
+          width: Math.round(width),
+          availableSvgHeight: Math.round(availableSvgHeight),
+          fixedHeight: Math.round(fixedHeight)
+        };
+      }
+      function schedule() {
+        if (frame) return;
+        frame = requestAnimationFrame(measure);
+      }
+      function stableSnapshot() {
+        var shellRect = shell ? shell.getBoundingClientRect() : { width: 0, height: 0 };
+        var diagramRect = diagram ? diagram.getBoundingClientRect() : { width: 0, height: 0 };
+        return [
+          lastWidth,
+          html.getAttribute('data-reader-layout') || '',
+          html.getAttribute('data-reader-overflow') || '',
+          Math.ceil(document.documentElement.scrollWidth),
+          Math.ceil(document.documentElement.scrollHeight),
+          Math.ceil(document.body.scrollWidth),
+          Math.ceil(document.body.scrollHeight),
+          Math.round(shellRect.width * 100) / 100,
+          Math.round(shellRect.height * 100) / 100,
+          Math.round(diagramRect.width * 100) / 100,
+          Math.round(diagramRect.height * 100) / 100
+        ].join('|');
+      }
+      function whenStable() {
+        return Archify.waitForStableLayout({
+          schedule: schedule,
+          pending: function () { return Boolean(frame || settleFrame); },
+          snapshot: stableSnapshot,
+          timeoutMessage: 'Adaptive reader layout did not reach stable dimensions.'
+        });
+      }
+
+      window.addEventListener('resize', schedule, { passive: true });
+      window.addEventListener('load', schedule, { once: true });
+      if (document.fonts && document.fonts.ready) document.fonts.ready.then(schedule).catch(function () {});
+      if (typeof ResizeObserver === 'function') {
+        var resizeObserver = new ResizeObserver(schedule);
+        [header, guided, cards].forEach(function (element) { if (element) resizeObserver.observe(element); });
+      }
+      if (typeof MutationObserver === 'function') {
+        var contentObserver = new MutationObserver(schedule);
+        if (guided) contentObserver.observe(guided, { attributes: true, childList: true, subtree: true });
+        if (cards) contentObserver.observe(cards, { attributes: true, childList: true, subtree: true });
+        contentObserver.observe(html, { attributes: true, attributeFilter: ['data-embed', 'data-present'] });
+      }
+      schedule();
+
+      return {
+        measure: measure,
+        schedule: schedule,
+        whenStable: whenStable,
+        active: function () { return html.getAttribute('data-reader-layout') === 'adaptive'; },
+        receipt: function () { return { ratio: ratio, width: lastWidth }; }
+      };
+    })();
+
+    /* ============================================================
+       Viewer Chrome Layout — keep HTML controls clear of the canonical SVG
+       legend without changing authored geometry. The dock keeps its existing
+       position unless its zero-reserve position would cover the legend; only
+       then does a small bottom safe rail become part of the reader budget.
+       ============================================================ */
+    Archify.viewerChromeLayout = (function () {
+      var html = document.documentElement;
+      var container = document.querySelector('.diagram-container');
+      var svg = container && container.querySelector(':scope > svg');
+      var nav = container && container.querySelector('.diagram-nav');
+      var legend = svg && svg.querySelector('[data-legend]');
+      var frame = 0;
+      var settleFrame = 0;
+      var reserve = 0;
+      var collisionLatched = false;
+      var probingBaseline = false;
+      var probePromise = null;
+      var baselineIntersectionArea = 0;
+      var lastReceipt = null;
+      var SAFE_GAP = 10;
+
+      function visible(element) {
+        if (!element || element.hidden) return false;
+        var style = window.getComputedStyle(element);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      }
+      function usable(rect) {
+        return Boolean(rect && rect.width > 0 && rect.height > 0);
+      }
+      function intersectionArea(a, b) {
+        var width = Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left));
+        var height = Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
+        return width * height;
+      }
+      function eligible() {
+        return Boolean(
+          container && svg && nav && legend &&
+          window.innerWidth > 720 &&
+          html.getAttribute('data-embed') !== 'true' &&
+          (!window.matchMedia || !window.matchMedia('print').matches) &&
+          visible(nav) && visible(legend)
+        );
+      }
+      function writeReserve(next, options) {
+        options = options || {};
+        next = Math.max(0, Math.ceil(next));
+        if (Math.abs(next - reserve) < 1) return false;
+        reserve = next;
+        if (reserve) {
+          container.style.setProperty('--archify-nav-reserve', reserve + 'px');
+          container.setAttribute('data-nav-safe-rail', 'true');
+        } else {
+          container.style.removeProperty('--archify-nav-reserve');
+          container.removeAttribute('data-nav-safe-rail');
+        }
+        if (Archify.readerLayout && typeof Archify.readerLayout.schedule === 'function') {
+          Archify.readerLayout.schedule();
+        }
+        if (options.quiet !== true) {
+          if (settleFrame) cancelAnimationFrame(settleFrame);
+          settleFrame = requestAnimationFrame(function () {
+            settleFrame = 0;
+            schedule();
+          });
+        }
+        return true;
+      }
+      function clear() {
+        collisionLatched = false;
+        baselineIntersectionArea = 0;
+        writeReserve(0, { quiet: probingBaseline });
+        lastReceipt = {
+          eligible: false,
+          active: false,
+          reserve: 0,
+          gap: SAFE_GAP,
+          baselineIntersectionArea: 0,
+          intersectionArea: 0
+        };
+        return lastReceipt;
+      }
+      function measure() {
+        frame = 0;
+        if (probingBaseline) return null;
+        if (!eligible()) return clear();
+
+        var navRect = nav.getBoundingClientRect();
+        var legendRect = legend.getBoundingClientRect();
+        var svgRect = svg.getBoundingClientRect();
+        if (!usable(navRect) || !usable(legendRect) || !usable(svgRect)) return clear();
+
+        var actualIntersectionArea = intersectionArea(navRect, legendRect);
+        if (!collisionLatched && reserve === 0) {
+          baselineIntersectionArea = actualIntersectionArea;
+          if (actualIntersectionArea > 0) {
+            collisionLatched = true;
+            if (writeReserve(Math.max(0, svgRect.bottom + SAFE_GAP - navRect.top))) return null;
+          }
+        } else if (collisionLatched && reserve > 0 && actualIntersectionArea > 0) {
+          /* Once zero-reserve geometry proves a collision, keep that decision
+             latched while Adaptive Reader incorporates the rail. If the first
+             rail is not quite tall enough (notably in Presentation flex
+             layout), grow only by the remaining vertical overlap. */
+          var remaining = Math.max(1, legendRect.bottom + SAFE_GAP - navRect.top);
+          if (writeReserve(reserve + remaining)) return null;
+        }
+
+        navRect = nav.getBoundingClientRect();
+        legendRect = legend.getBoundingClientRect();
+        lastReceipt = {
+          eligible: true,
+          active: reserve > 0,
+          reserve: reserve,
+          gap: SAFE_GAP,
+          baselineIntersectionArea: Math.round(baselineIntersectionArea * 100) / 100,
+          intersectionArea: Math.round(intersectionArea(navRect, legendRect) * 100) / 100
+        };
+        return lastReceipt;
+      }
+      function reprobe() {
+        if (probingBaseline) return probePromise || Promise.resolve(false);
+        if (!reserve && !collisionLatched) {
+          schedule();
+          return Promise.resolve(false);
+        }
+        probingBaseline = true;
+        collisionLatched = false;
+        baselineIntersectionArea = 0;
+        writeReserve(0, { quiet: true });
+        var readerReady = Archify.readerLayout && typeof Archify.readerLayout.whenStable === 'function'
+          ? Archify.readerLayout.whenStable().catch(function () {})
+          : Promise.resolve();
+        probePromise = readerReady.then(function () {
+          probingBaseline = false;
+          probePromise = null;
+          schedule();
+          return true;
+        });
+        return probePromise;
+      }
+      function schedule() {
+        if (frame) return;
+        frame = requestAnimationFrame(measure);
+      }
+      function stableSnapshot() {
+        var containerRect = container ? container.getBoundingClientRect() : { width: 0, height: 0 };
+        var navRect = nav ? nav.getBoundingClientRect() : { top: 0, left: 0 };
+        var legendRect = legend ? legend.getBoundingClientRect() : { top: 0, left: 0 };
+        return [
+          reserve,
+          Math.round(containerRect.width * 100) / 100,
+          Math.round(containerRect.height * 100) / 100,
+          Math.round(navRect.left * 100) / 100,
+          Math.round(navRect.top * 100) / 100,
+          Math.round(legendRect.left * 100) / 100,
+          Math.round(legendRect.top * 100) / 100,
+          collisionLatched ? 'latched' : 'clear',
+          lastReceipt ? lastReceipt.intersectionArea : ''
+        ].join('|');
+      }
+      function whenStable() {
+        return Archify.waitForStableLayout({
+          schedule: schedule,
+          pending: function () { return Boolean(frame || settleFrame || probingBaseline); },
+          snapshot: stableSnapshot,
+          timeoutMessage: 'Viewer chrome layout did not reach stable dimensions.'
+        });
+      }
+
+      window.addEventListener('resize', reprobe, { passive: true });
+      window.addEventListener('load', schedule, { once: true });
+      window.addEventListener('beforeprint', schedule);
+      window.addEventListener('afterprint', reprobe);
+      if (document.fonts && document.fonts.ready) document.fonts.ready.then(reprobe).catch(function () {});
+      if (typeof ResizeObserver === 'function') {
+        var resizeObserver = new ResizeObserver(schedule);
+        [nav, legend].forEach(function (element) { if (element) resizeObserver.observe(element); });
+      }
+      if (typeof MutationObserver === 'function') {
+        var contentObserver = new MutationObserver(function (records) {
+          var viewerModeChanged = records.some(function (record) { return record.target === html; });
+          if (viewerModeChanged) reprobe();
+          else schedule();
+        });
+        if (legend) contentObserver.observe(legend, { attributes: true, childList: true, subtree: true });
+        contentObserver.observe(html, {
+          attributes: true,
+          attributeFilter: ['data-embed', 'data-present', 'data-preset', 'data-theme']
+        });
+      }
+      schedule();
+
+      return {
+        measure: measure,
+        schedule: schedule,
+        reprobe: reprobe,
+        whenStable: whenStable,
+        active: function () { return reserve > 0; },
+        receipt: function () { return lastReceipt || measure(); }
+      };
+    })();
+
     Archify.view = (function () {
       var container = document.querySelector('.diagram-container');
       var svg = container.querySelector('svg');
       var outBtn = container.querySelector('[data-view="out"]');
       var resetBtn = container.querySelector('[data-view="reset"]');
+      var resetDetailLabel = resetBtn.querySelector('[data-view-detail]');
+      var resetPercentLabel = resetBtn.querySelector('[data-view-percent]');
       var inBtn = container.querySelector('[data-view="in"]');
       var state = { scale: 1, x: 0, y: 0, mode: 'overview' };
       var drag = null;
@@ -10228,9 +11325,6 @@
       var autoScrollUntil = 0;
 
       var viewBox = svg.viewBox && svg.viewBox.baseVal;
-      if (viewBox && viewBox.height > 0 && viewBox.width / viewBox.height >= 1.55) {
-        container.setAttribute('data-wide-diagram', 'true');
-      }
 
       function clamp() {
         var width = svg.clientWidth || 1;
@@ -10281,22 +11375,32 @@
       function detailLevel() {
         if (state.mode === 'semantic') return 'full';
         if (state.scale >= 1.75) return 'full';
-        if (state.scale >= 1.25) return 'read';
+        if (state.scale >= 1) return 'read';
         return 'map';
       }
       function renderControls() {
         var semantic = state.mode === 'semantic' && state.scale > 1.01;
         var detail = detailLevel();
         var percent = Math.round(state.scale * 100) + '%';
-        var levelLabel = detail === 'map' ? 'MAP ' : detail === 'read' ? 'READ ' : 'FULL ';
+        var levelLabel = viewerText('viewer.nav.level.' + detail);
         var detailHint = detail === 'map'
-          ? 'Zoom in to reveal relationship labels and node context'
+          ? viewerText('viewer.nav.detail.map')
           : detail === 'read'
-            ? 'Zoom in again to reveal tags and annotations'
-            : 'Full diagram detail';
-        resetBtn.textContent = (semantic ? 'AUTO ' : levelLabel) + percent;
-        resetBtn.title = (semantic ? 'Semantic camera active · ' : '') + detailHint + ' · reset view (0)';
-        resetBtn.setAttribute('aria-label', detailHint + '. Reset diagram view');
+            ? viewerText('viewer.nav.detail.read')
+            : viewerText('viewer.nav.detail.full');
+        var resolvedLevel = semantic ? viewerText('viewer.nav.level.auto') : levelLabel;
+        var showDetailLevel = semantic || detail !== 'read';
+        if (resetDetailLabel) {
+          resetDetailLabel.textContent = resolvedLevel;
+          resetDetailLabel.hidden = !showDetailLevel;
+        }
+        if (resetPercentLabel) resetPercentLabel.textContent = percent;
+        resetBtn.toggleAttribute('data-detail-visible', showDetailLevel);
+        resetBtn.title = viewerText('viewer.nav.camera.title', {
+          semantic: semantic ? viewerText('viewer.nav.camera.semantic') : '',
+          hint: detailHint
+        });
+        resetBtn.setAttribute('aria-label', viewerText('viewer.nav.camera', { hint: detailHint }));
         resetBtn.setAttribute('data-detail-level', detail);
         container.setAttribute('data-detail-level', detail);
         container.setAttribute('data-camera-mode', state.mode);
@@ -10311,6 +11415,9 @@
         container.classList.toggle('is-pannable', state.scale > 1);
         svg.setAttribute('data-view-scale', String(state.scale));
         if (Archify.radar && typeof Archify.radar.sync === 'function') Archify.radar.sync();
+        if (Archify.viewerChromeLayout && typeof Archify.viewerChromeLayout.schedule === 'function') {
+          Archify.viewerChromeLayout.schedule();
+        }
       }
       function sampleRenderedState() {
         var transform = '';
@@ -10423,6 +11530,9 @@
         else stopCameraMotion('reset', false);
         state = { scale: 1, x: 0, y: 0, mode: 'overview' };
         apply();
+        if (Archify.viewerChromeLayout && typeof Archify.viewerChromeLayout.reprobe === 'function') {
+          Archify.viewerChromeLayout.reprobe();
+        }
       }
       function centerAt(logicalX, logicalY, options) {
         options = options || {};
@@ -10701,21 +11811,35 @@
       var container = document.querySelector('.diagram-container');
       var diagram = container.querySelector(':scope > svg');
       var panel = document.getElementById('overview-map');
+      var panelHead = panel.querySelector('.overview-map-head');
       var surface = document.getElementById('overview-map-surface');
       var status = document.getElementById('overview-map-status');
       var trigger = document.getElementById('btn-overview-map');
       var closeBtn = document.getElementById('overview-map-close');
+      var expandBtn = document.getElementById('overview-map-expand');
+      var feedback = document.getElementById('overview-map-feedback');
+      var navigation = container.querySelector('.diagram-nav');
+      var passport = document.getElementById('focus-chip');
       var namespace = 'http://www.w3.org/2000/svg';
       var viewBox = diagram.viewBox && diagram.viewBox.baseVal;
       var mapSvg = document.createElementNS(namespace, 'svg');
       var nodeLayer = document.createElementNS(namespace, 'g');
       var viewport = document.createElementNS(namespace, 'rect');
       var nodes = [];
-      var drag = null;
+      var viewportDrag = null;
+      var panelDrag = null;
+      var manualPosition = null;
+      var lastPlacement = null;
+      var requestedOpen = false;
+      var passportYielded = false;
+      var passportPreviousAriaHidden = null;
       var syncFrame = 0;
+      var spaceRetryTimer = 0;
+      var spaceRetryCount = 0;
+      var placementGap = 16;
 
       mapSvg.setAttribute('role', 'group');
-      mapSvg.setAttribute('aria-label', 'Semantic diagram radar nodes');
+      mapSvg.setAttribute('aria-label', viewerText('viewer.radar.nodes'));
       mapSvg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
       nodeLayer.setAttribute('class', 'overview-map-nodes');
       viewport.setAttribute('class', 'overview-map-viewport');
@@ -10750,63 +11874,301 @@
           rect.setAttribute('data-kind', node.getAttribute('data-node-kind') || 'neutral');
           rect.setAttribute('tabindex', '0');
           rect.setAttribute('role', 'button');
-          rect.setAttribute('aria-label', 'Focus ' + nodeLabel(node, id) + ' from Semantic Radar');
+          rect.setAttribute('aria-label', viewerText('viewer.radar.focus', { label: nodeLabel(node, id) }));
           nodeLayer.appendChild(rect);
           nodes.push({ id: id, node: node, rect: rect });
         });
-        status.textContent = nodes.length + ' nodes · full map';
+        status.textContent = viewerText('viewer.radar.fullMap', { count: nodes.length });
         return true;
       }
-      function updateDocking() {
-        if (panel.hidden) return;
-        var containerRect = container.getBoundingClientRect();
-        var intersectsWindow = containerRect.bottom > 12 && containerRect.top < window.innerHeight - 12;
-        if (!intersectsWindow) {
-          panel.removeAttribute('data-docked');
-          panel.removeAttribute('data-dock-side');
-          panel.style.removeProperty('--archify-radar-right');
-          panel.style.removeProperty('--archify-radar-left');
-          panel.style.removeProperty('--archify-radar-top');
-          return;
-        }
-        var active = diagram.querySelector('[data-focus-selected]');
-        var activeRect = active ? active.getBoundingClientRect() : null;
-        var dockLeft = !!(activeRect && activeRect.left + activeRect.width / 2 > window.innerWidth / 2);
-        var right = Math.max(16, window.innerWidth - Math.min(containerRect.right - 16, window.innerWidth - 16));
-        var left = Math.max(16, Math.min(containerRect.left + 16, window.innerWidth - panel.offsetWidth - 16));
-        var topLimit = Math.max(16, containerRect.top + 16);
-        var bottomLimit = Math.min(window.innerHeight - 16, containerRect.bottom - 16);
-        var panelLeft = dockLeft ? left : window.innerWidth - right - panel.offsetWidth;
-        var panelRight = panelLeft + panel.offsetWidth;
+      function visibleRect(element) {
+        if (!element || element.hidden) return null;
+        var rect = element.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0 || rect.right <= 0 || rect.bottom <= 0 || rect.left >= window.innerWidth || rect.top >= window.innerHeight) return null;
+        return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom, width: rect.width, height: rect.height };
+      }
+      function panelRectAt(position) {
+        return {
+          left: position.left,
+          top: position.top,
+          right: position.left + panel.offsetWidth,
+          bottom: position.top + panel.offsetHeight,
+          width: panel.offsetWidth,
+          height: panel.offsetHeight
+        };
+      }
+      function rectsIntersect(first, second, gap) {
+        gap = Number(gap) || 0;
+        return first.left < second.right + gap &&
+          first.right > second.left - gap &&
+          first.top < second.bottom + gap &&
+          first.bottom > second.top - gap;
+      }
+      function intersectionArea(first, second) {
+        var width = Math.max(0, Math.min(first.right, second.right) - Math.max(first.left, second.left));
+        var height = Math.max(0, Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top));
+        return width * height;
+      }
+      function clamp(value, minimum, maximum) {
+        if (maximum < minimum) return minimum;
+        return Math.max(minimum, Math.min(maximum, value));
+      }
+      function placementContext() {
+        var containerRect = visibleRect(container);
+        if (!containerRect) return null;
+        var controlRect = visibleRect(navigation);
+        var left = Math.max(placementGap, containerRect.left + placementGap);
+        var top = Math.max(placementGap, containerRect.top + placementGap);
+        var right = Math.min(window.innerWidth - placementGap, containerRect.right - placementGap);
+        var bottom = Math.min(window.innerHeight - placementGap, containerRect.bottom - placementGap);
+        if (controlRect) bottom = Math.min(bottom, controlRect.top - placementGap);
         var lens = document.getElementById('focus-chip');
-        var lensRect = lens && !lens.hidden ? lens.getBoundingClientRect() : null;
-        var blockers = [activeRect, lensRect].filter(function (rect) {
-          return rect && rect.right > panelLeft && rect.left < panelRight;
+        var lensRect = visibleRect(lens);
+        var legendRect = visibleRect(diagram.querySelector('[data-legend]'));
+        var active = diagram.querySelector('[data-focus-selected]');
+        var activeRect = visibleRect(active);
+        return {
+          bounds: { left: left, top: top, right: right, bottom: bottom },
+          hardBlockers: [lensRect, controlRect, legendRect].filter(Boolean),
+          softBlockers: [activeRect].filter(Boolean),
+          preferredSide: !activeRect || activeRect.left + activeRect.width / 2 > window.innerWidth / 2 ? 'left' : 'right'
+        };
+      }
+      function positionIsValid(position, context) {
+        if (!position || !context) return false;
+        var rect = panelRectAt(position);
+        var bounds = context.bounds;
+        if (rect.left < bounds.left || rect.top < bounds.top || rect.right > bounds.right || rect.bottom > bounds.bottom) return false;
+        return context.hardBlockers.every(function (blocker) { return !rectsIntersect(rect, blocker, placementGap); });
+      }
+      function cornerCandidates(context) {
+        var bounds = context.bounds;
+        var left = bounds.left;
+        var right = Math.max(left, bounds.right - panel.offsetWidth);
+        var top = bounds.top;
+        var bottom = Math.max(top, bounds.bottom - panel.offsetHeight);
+        var preferredLeft = context.preferredSide === 'left' ? left : right;
+        var alternateLeft = context.preferredSide === 'left' ? right : left;
+        return [
+          { left: preferredLeft, top: bottom },
+          { left: alternateLeft, top: bottom },
+          { left: preferredLeft, top: top },
+          { left: alternateLeft, top: top }
+        ].filter(function (candidate, index, all) {
+          return all.findIndex(function (other) { return other.left === candidate.left && other.top === candidate.top; }) === index;
         });
-        var desiredTop = bottomLimit - panel.offsetHeight;
-        var candidates = [desiredTop, topLimit];
-        blockers.forEach(function (rect) {
-          candidates.push(rect.top - 10 - panel.offsetHeight, rect.bottom + 10);
+      }
+      function nearbyCandidates(context, reference) {
+        var bounds = context.bounds;
+        var maximumLeft = bounds.right - panel.offsetWidth;
+        var maximumTop = bounds.bottom - panel.offsetHeight;
+        var requested = reference ? {
+          left: clamp(reference.left, bounds.left, maximumLeft),
+          top: clamp(reference.top, bounds.top, maximumTop)
+        } : null;
+        var horizontal = [bounds.left, maximumLeft];
+        var vertical = [bounds.top, maximumTop];
+        if (requested) {
+          horizontal.push(requested.left);
+          vertical.push(requested.top);
+        }
+        context.hardBlockers.forEach(function (blocker) {
+          horizontal.push(
+            blocker.left - placementGap - panel.offsetWidth,
+            blocker.right + placementGap
+          );
+          vertical.push(
+            blocker.top - placementGap - panel.offsetHeight,
+            blocker.bottom + placementGap
+          );
         });
-        var valid = candidates.filter(function (candidate) {
-          if (candidate < topLimit || candidate + panel.offsetHeight > bottomLimit) return false;
-          return blockers.every(function (rect) {
-            return candidate + panel.offsetHeight <= rect.top - 10 || candidate >= rect.bottom + 10;
-          });
+        horizontal = horizontal.map(function (left) { return clamp(left, bounds.left, maximumLeft); });
+        vertical = vertical.map(function (top) { return clamp(top, bounds.top, maximumTop); });
+        var candidates = [];
+        horizontal.forEach(function (left) {
+          vertical.forEach(function (top) { candidates.push({ left: left, top: top }); });
         });
-        valid.sort(function (a, b) { return Math.abs(a - desiredTop) - Math.abs(b - desiredTop); });
-        var top = valid.length ? valid[0] : Math.max(topLimit, desiredTop);
-        top = Math.min(window.innerHeight - panel.offsetHeight - 16, top);
+        return candidates.filter(function (candidate, index, all) {
+          return all.findIndex(function (other) { return other.left === candidate.left && other.top === candidate.top; }) === index;
+        });
+      }
+      function placementScore(position, context, reference, softWeight) {
+        var rect = panelRectAt(position);
+        var referenceLeft = reference ? reference.left : (context.preferredSide === 'left' ? context.bounds.left : context.bounds.right - panel.offsetWidth);
+        var referenceTop = reference ? reference.top : context.bounds.bottom - panel.offsetHeight;
+        var distance = Math.pow(position.left - referenceLeft, 2) + Math.pow(position.top - referenceTop, 2);
+        var softOverlap = context.softBlockers.reduce(function (total, blocker) { return total + intersectionArea(rect, blocker); }, 0);
+        return distance + softOverlap * softWeight;
+      }
+      function chooseRadarPlacement(context, reference, options) {
+        options = options || {};
+        var softWeight = Number.isFinite(options.softWeight) ? options.softWeight : 100;
+        var candidates = nearbyCandidates(context, reference).concat(cornerCandidates(context));
+        var valid = candidates.filter(function (candidate) { return positionIsValid(candidate, context); });
+        valid.sort(function (first, second) {
+          return placementScore(first, context, reference, softWeight) - placementScore(second, context, reference, softWeight);
+        });
+        return valid.length ? valid[0] : null;
+      }
+      function applyPlacement(position, remember) {
+        var useLeft = position.left + panel.offsetWidth / 2 <= window.innerWidth / 2;
         panel.setAttribute('data-docked', 'true');
-        panel.setAttribute('data-dock-side', dockLeft ? 'left' : 'right');
-        panel.style.setProperty('--archify-radar-right', Math.round(right) + 'px');
-        panel.style.setProperty('--archify-radar-left', Math.round(left) + 'px');
-        panel.style.setProperty('--archify-radar-top', Math.round(Math.max(16, top)) + 'px');
+        panel.setAttribute('data-dock-side', useLeft ? 'left' : 'right');
+        if (useLeft) {
+          panel.style.setProperty('--archify-radar-left', Math.round(position.left) + 'px');
+          panel.style.removeProperty('--archify-radar-right');
+        } else {
+          panel.style.setProperty('--archify-radar-right', Math.round(window.innerWidth - position.left - panel.offsetWidth) + 'px');
+          panel.style.removeProperty('--archify-radar-left');
+        }
+        panel.style.setProperty('--archify-radar-top', Math.round(position.top) + 'px');
+        if (remember !== false) lastPlacement = { left: position.left, top: position.top };
+      }
+      function resetDockingStyles() {
+        panel.removeAttribute('data-docked');
+        panel.removeAttribute('data-dock-side');
+        panel.removeAttribute('data-panel-dragging');
+        panel.removeAttribute('data-placement-invalid');
+        panel.removeAttribute('data-placement-degraded');
+        panel.removeAttribute('data-placement-unavailable');
+        panel.removeAttribute('data-compact');
+        panel.removeAttribute('title');
+        panel.style.removeProperty('visibility');
+        panel.style.removeProperty('--archify-radar-right');
+        panel.style.removeProperty('--archify-radar-left');
+        panel.style.removeProperty('--archify-radar-top');
+      }
+      function updateDocking() {
+        var options = arguments[0] || {};
+        if (panel.hidden) return false;
+        if (panelDrag) return true;
+        panel.removeAttribute('data-compact');
+        panel.removeAttribute('data-placement-degraded');
+        panel.removeAttribute('data-placement-invalid');
+        panel.removeAttribute('data-placement-unavailable');
+        panel.removeAttribute('title');
+        panel.style.removeProperty('visibility');
+        var context = placementContext();
+        if (!context) {
+          resetDockingStyles();
+          return false;
+        }
+        var reference = manualPosition || lastPlacement;
+        var placementOptions = { softWeight: manualPosition ? 0 : 100 };
+        var placement = manualPosition && positionIsValid(manualPosition, context)
+          ? manualPosition
+          : chooseRadarPlacement(context, reference, placementOptions);
+        var compact = false;
+        if (!placement && options.allowCompact !== false) {
+          compact = true;
+          panel.setAttribute('data-compact', 'true');
+          panel.setAttribute('data-placement-degraded', 'true');
+          panel.setAttribute('title', viewerText('viewer.radar.compacted'));
+          context = placementContext();
+          placement = chooseRadarPlacement(context, reference, placementOptions);
+        }
+        if (!placement) {
+          resetDockingStyles();
+          panel.setAttribute('data-placement-unavailable', 'true');
+          return false;
+        }
+        if (manualPosition && !compact) manualPosition = { left: placement.left, top: placement.top };
+        applyPlacement(placement, true);
+        return true;
+      }
+      function clearSpaceRetry() {
+        if (spaceRetryTimer) window.clearTimeout(spaceRetryTimer);
+        spaceRetryTimer = 0;
+      }
+      function yieldPassport() {
+        if (!passport || passport.hidden || passportYielded) return passportYielded;
+        passportPreviousAriaHidden = passport.getAttribute('aria-hidden');
+        passportYielded = true;
+        passport.setAttribute('data-radar-yielded', 'true');
+        passport.setAttribute('aria-hidden', 'true');
+        return true;
+      }
+      function restorePassport() {
+        if (!passport || !passportYielded) return;
+        passportYielded = false;
+        passport.removeAttribute('data-radar-yielded');
+        if (passportPreviousAriaHidden === null) passport.removeAttribute('aria-hidden');
+        else passport.setAttribute('aria-hidden', passportPreviousAriaHidden);
+        passportPreviousAriaHidden = null;
+      }
+      function reflectVisible() {
+        panel.hidden = false;
+        panel.removeAttribute('data-placement-unavailable');
+        trigger.setAttribute('aria-expanded', 'true');
+        trigger.removeAttribute('data-radar-space-limited');
+        trigger.setAttribute('aria-label', viewerText('viewer.radar.close'));
+        trigger.title = viewerText('viewer.nav.radar.title');
+        feedback.hidden = true;
+      }
+      function scheduleSpaceRetry() {
+        if (!requestedOpen || spaceRetryTimer || spaceRetryCount >= 4) return;
+        spaceRetryCount += 1;
+        spaceRetryTimer = window.setTimeout(function () {
+          spaceRetryTimer = 0;
+          attemptRequestedOpen();
+        }, 60);
+      }
+      function reflectUnavailable() {
+        restorePassport();
+        panel.hidden = true;
+        panel.setAttribute('data-placement-unavailable', 'true');
+        trigger.setAttribute('aria-expanded', 'false');
+        trigger.setAttribute('aria-label', viewerText('viewer.radar.cancelWaiting'));
+        trigger.setAttribute('data-radar-space-limited', 'true');
+        trigger.title = viewerText('viewer.radar.needsSpace');
+        feedback.hidden = false;
+        scheduleSpaceRetry();
+      }
+      function attemptRequestedOpen(options) {
+        options = options || {};
+        if (!requestedOpen) return false;
+        panel.hidden = false;
+        if (!updateDocking(options)) {
+          reflectUnavailable();
+          return false;
+        }
+        clearSpaceRetry();
+        spaceRetryCount = 0;
+        reflectVisible();
+        sync();
+        if (options.focus === true && !panel.hasAttribute('data-compact')) surface.focus();
+        return true;
+      }
+      function expandCompactRadar() {
+        if (!requestedOpen || panel.hidden || !panel.hasAttribute('data-compact')) return false;
+        yieldPassport();
+        if (!updateDocking({ allowCompact: false })) {
+          restorePassport();
+          if (!updateDocking()) {
+            reflectUnavailable();
+            return false;
+          }
+        }
+        reflectVisible();
+        sync();
+        if (!panel.hasAttribute('data-compact')) surface.focus();
+        return !panel.hasAttribute('data-compact');
       }
       function syncNow() {
         syncFrame = 0;
         if (panel.hidden || !Archify.view || typeof Archify.view.logicalViewport !== 'function') return;
-        updateDocking();
+        if (!updateDocking()) {
+          reflectUnavailable();
+          return;
+        }
+        if (passportYielded && panel.hasAttribute('data-compact')) {
+          restorePassport();
+          if (!updateDocking()) {
+            reflectUnavailable();
+            return;
+          }
+        }
+        reflectVisible();
         var visible = Archify.view.logicalViewport();
         if (!visible) return;
         viewport.setAttribute('x', String(visible.x));
@@ -10816,9 +12178,11 @@
         var full = visible.width >= viewBox.width * 0.98 && visible.height >= viewBox.height * 0.98;
         var mobileWide = window.innerWidth <= 720 && container.hasAttribute('data-wide-diagram');
         var viewportCopy = full
-          ? 'full map'
-          : (mobileWide ? Math.round(visible.width / viewBox.width * 100) + '% width' : Math.round(visible.scale * 100) + '% viewport');
-        status.textContent = nodes.length + ' nodes · ' + viewportCopy;
+          ? viewerText('viewer.radar.viewport.full')
+          : (mobileWide
+            ? viewerText('viewer.radar.viewport.width', { percent: Math.round(visible.width / viewBox.width * 100) })
+            : viewerText('viewer.radar.viewport.scale', { percent: Math.round(visible.scale * 100) }));
+        status.textContent = viewerText('viewer.radar.status', { count: nodes.length, viewport: viewportCopy });
         nodes.forEach(function (item) {
           var active = item.node.hasAttribute('data-focus-selected') ||
             item.node.getAttribute('data-story-beat-state') === 'active';
@@ -10827,6 +12191,10 @@
         });
       }
       function sync() {
+        if (requestedOpen && panel.hidden) {
+          attemptRequestedOpen();
+          return;
+        }
         if (syncFrame) return;
         syncFrame = requestAnimationFrame(syncNow);
       }
@@ -10837,25 +12205,31 @@
         if (next && Archify.semanticLens && Archify.semanticLens.isOpen()) {
           Archify.semanticLens.close({ restoreFocus: false });
         }
-        panel.hidden = !next;
-        trigger.setAttribute('aria-expanded', next ? 'true' : 'false');
-        trigger.setAttribute('aria-label', next ? 'Close semantic radar' : 'Open semantic radar');
+        requestedOpen = next;
         if (next) {
+          clearSpaceRetry();
+          spaceRetryCount = 0;
           build();
-          updateDocking();
-          sync();
-          if (options.focus === true) surface.focus();
+          attemptRequestedOpen(options);
         } else {
-          panel.removeAttribute('data-docked');
-          panel.removeAttribute('data-dock-side');
-          panel.style.removeProperty('--archify-radar-right');
-          panel.style.removeProperty('--archify-radar-left');
-          panel.style.removeProperty('--archify-radar-top');
+          clearSpaceRetry();
+          spaceRetryCount = 0;
+          viewportDrag = null;
+          panelDrag = null;
+          container.classList.remove('is-panning');
+          panel.hidden = true;
+          resetDockingStyles();
+          restorePassport();
+          feedback.hidden = true;
+          trigger.setAttribute('aria-expanded', 'false');
+          trigger.removeAttribute('data-radar-space-limited');
+          trigger.setAttribute('aria-label', viewerText('viewer.nav.radar'));
+          trigger.title = viewerText('viewer.nav.radar.title');
           if (options.restoreFocus === true) trigger.focus();
         }
         return next;
       }
-      function toggle() { return setOpen(panel.hidden, { focus: false }); }
+      function toggle() { return setOpen(!requestedOpen, { focus: false }); }
       function close(options) { return setOpen(false, options); }
       function bringNodeIntoWindow(node) {
         var delay = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 540;
@@ -10900,31 +12274,91 @@
         Archify.view.centerAt(point.x, point.y, { minimumScale: 1.5, instant: true });
         sync();
       }
-      function endDrag(event) {
-        if (!drag) return;
-        drag = null;
+      function endViewportDrag(event) {
+        if (!viewportDrag) return;
+        viewportDrag = null;
         panel.removeAttribute('data-dragging');
         container.classList.remove('is-panning');
         try { surface.releasePointerCapture(event.pointerId); } catch (_) {}
       }
+      function beginPanelDrag(event) {
+        if (event.button !== 0 || event.target.closest('button, a, input, [role="button"]')) return;
+        var context = placementContext();
+        if (!context) return;
+        var rect = panel.getBoundingClientRect();
+        event.preventDefault();
+        event.stopPropagation();
+        panelDrag = {
+          pointerId: event.pointerId,
+          originX: event.clientX,
+          originY: event.clientY,
+          start: { left: rect.left, top: rect.top },
+          current: { left: rect.left, top: rect.top },
+          previousManual: manualPosition ? { left: manualPosition.left, top: manualPosition.top } : null
+        };
+        panel.setAttribute('data-panel-dragging', 'true');
+        try { panelHead.setPointerCapture(event.pointerId); } catch (_) {}
+      }
+      function movePanelDrag(event) {
+        if (!panelDrag || panelDrag.pointerId !== event.pointerId) return;
+        var context = placementContext();
+        if (!context) return;
+        event.preventDefault();
+        event.stopPropagation();
+        var bounds = context.bounds;
+        var position = {
+          left: clamp(panelDrag.start.left + event.clientX - panelDrag.originX, bounds.left, bounds.right - panel.offsetWidth),
+          top: clamp(panelDrag.start.top + event.clientY - panelDrag.originY, bounds.top, bounds.bottom - panel.offsetHeight)
+        };
+        panelDrag.current = position;
+        if (positionIsValid(position, context)) panel.removeAttribute('data-placement-invalid');
+        else panel.setAttribute('data-placement-invalid', 'true');
+        applyPlacement(position, false);
+      }
+      function finishPanelDrag(event, cancel) {
+        if (!panelDrag || panelDrag.pointerId !== event.pointerId) return;
+        event.preventDefault();
+        event.stopPropagation();
+        var activeDrag = panelDrag;
+        panelDrag = null;
+        panel.removeAttribute('data-panel-dragging');
+        panel.removeAttribute('data-placement-invalid');
+        try { panelHead.releasePointerCapture(event.pointerId); } catch (_) {}
+        var context = placementContext();
+        if (!context) return;
+        if (cancel) {
+          manualPosition = activeDrag.previousManual;
+          lastPlacement = { left: activeDrag.start.left, top: activeDrag.start.top };
+          updateDocking();
+          return;
+        }
+        var requested = activeDrag.current;
+        manualPosition = { left: requested.left, top: requested.top };
+        updateDocking();
+      }
 
       trigger.addEventListener('click', toggle);
       closeBtn.addEventListener('click', function () { close({ restoreFocus: true }); });
+      expandBtn.addEventListener('click', expandCompactRadar);
+      panelHead.addEventListener('pointerdown', beginPanelDrag);
+      panelHead.addEventListener('pointermove', movePanelDrag);
+      panelHead.addEventListener('pointerup', function (event) { finishPanelDrag(event, false); });
+      panelHead.addEventListener('pointercancel', function (event) { finishPanelDrag(event, true); });
       surface.addEventListener('pointerdown', function (event) {
         if (event.button !== 0 || event.target.closest('[data-radar-node-id]')) return;
         event.preventDefault();
-        drag = { pointerId: event.pointerId };
+        viewportDrag = { pointerId: event.pointerId };
         panel.setAttribute('data-dragging', 'true');
         container.classList.add('is-panning');
         try { surface.setPointerCapture(event.pointerId); } catch (_) {}
         navigate(event);
       });
       surface.addEventListener('pointermove', function (event) {
-        if (!drag || drag.pointerId !== event.pointerId) return;
+        if (!viewportDrag || viewportDrag.pointerId !== event.pointerId) return;
         navigate(event);
       });
-      surface.addEventListener('pointerup', endDrag);
-      surface.addEventListener('pointercancel', endDrag);
+      surface.addEventListener('pointerup', endViewportDrag);
+      surface.addEventListener('pointercancel', endViewportDrag);
       surface.addEventListener('click', function (event) {
         var node = event.target.closest('[data-radar-node-id]');
         if (node) focusNode(node.getAttribute('data-radar-node-id'));
@@ -10957,8 +12391,32 @@
         Archify.view.centerAt(x, y, { minimumScale: 1.5, instant: true });
         sync();
       });
-      window.addEventListener('resize', sync);
-      window.addEventListener('scroll', function () { updateDocking(); sync(); }, { passive: true });
+      document.addEventListener('keydown', function (event) {
+        if (!panelDrag || event.key !== 'Escape') return;
+        finishPanelDrag({
+          pointerId: panelDrag.pointerId,
+          preventDefault: function () { event.preventDefault(); },
+          stopPropagation: function () { event.stopPropagation(); }
+        }, true);
+      }, true);
+      function reflow() {
+        if (!requestedOpen) return;
+        clearSpaceRetry();
+        spaceRetryCount = 0;
+        sync();
+      }
+      window.addEventListener('resize', reflow);
+      window.addEventListener('scroll', reflow, { passive: true });
+      if (typeof ResizeObserver === 'function') {
+        var radarResizeObserver = new ResizeObserver(function (entries) {
+          if (!requestedOpen) return;
+          if (panel.hidden && entries.every(function (entry) { return entry.target === panel; })) return;
+          reflow();
+        });
+        [container, navigation, document.getElementById('focus-chip'), panel].filter(Boolean).forEach(function (element) {
+          radarResizeObserver.observe(element);
+        });
+      }
       requestAnimationFrame(build);
 
       return {
@@ -10967,7 +12425,7 @@
         toggle: toggle,
         sync: sync,
         focus: focusNode,
-        isOpen: function () { return !panel.hidden; },
+        isOpen: function () { return requestedOpen; },
         count: function () { return nodes.length; }
       };
     })();
@@ -10981,7 +12439,6 @@
     Archify.presentation = (function () {
       var html = document.documentElement;
       var btn = document.getElementById('btn-present');
-      var icon = document.getElementById('present-icon');
       var label = document.getElementById('present-label');
       var previousScrollY = 0;
 
@@ -10998,10 +12455,9 @@
 
       function render(next) {
         btn.setAttribute('aria-pressed', next ? 'true' : 'false');
-        btn.setAttribute('aria-label', next ? 'Exit presentation stage' : 'Enter presentation stage');
-        btn.title = next ? 'Exit presentation stage (F or Escape)' : 'Presentation stage (F)';
-        icon.textContent = next ? '\u00d7' : '\u25a1';
-        label.textContent = next ? 'Exit' : 'Present';
+        btn.setAttribute('aria-label', viewerText(next ? 'viewer.present.exit' : 'viewer.present.enter'));
+        btn.title = viewerText(next ? 'viewer.present.exit.title' : 'viewer.present.enter.title');
+        label.textContent = viewerText(next ? 'viewer.present.exit.label' : 'viewer.present.present');
       }
 
       function setActive(next, options) {
@@ -11070,11 +12526,11 @@
       function defaultContext() {
         return {
           kind: 'focus',
-          title: 'Find a node',
-          placeholder: 'Search labels or IDs',
-          empty: 'No matching nodes',
-          resultsLabel: 'Diagram nodes',
-          availableNoun: 'nodes',
+          title: viewerText('viewer.finder.title'),
+          placeholder: viewerText('viewer.finder.placeholder'),
+          empty: viewerText('viewer.finder.empty'),
+          resultsLabel: viewerText('viewer.finder.results'),
+          availableNoun: viewerText('viewer.finder.noun.nodes'),
           allowedIds: null,
           badges: null
         };
@@ -11111,6 +12567,7 @@
         var sublabel = node.getAttribute('data-node-sublabel') || '';
         var context = node.getAttribute('data-node-context') || '';
         var tag = node.getAttribute('data-node-tag') || '';
+        var brand = node.getAttribute('data-node-brand') || '';
         var type = semanticType(node);
         var sources = Archify.sourceEvidence.node(id);
         var sourceSearch = sources.map(function (source) {
@@ -11123,9 +12580,10 @@
           sublabel: sublabel,
           context: context,
           tag: tag,
+          brand: brand,
           sources: sources,
           links: connectionsFor(id),
-          search: (id + ' ' + label + ' ' + type + ' ' + sublabel + ' ' + context + ' ' + tag + ' ' + sourceSearch + ' ' + text).toLowerCase(),
+          search: (id + ' ' + label + ' ' + type + ' ' + sublabel + ' ' + context + ' ' + tag + ' ' + sourceSearch + ' ' + text).toLowerCase() + ' ' + brand.toLowerCase(),
           node: node
         };
       });
@@ -11197,13 +12655,13 @@
           var badge = context.badges && context.badges[item.id]
             ? context.badges[item.id]
             : context.kind === 'focus'
-              ? item.links + (item.links === 1 ? ' link' : ' links')
+              ? viewerCount('viewer.finder.link', item.links)
               : String(item.links);
           var action = context.kind === 'route-source'
-            ? 'Choose ' + item.label + ' as route start'
+            ? viewerText('viewer.finder.result.routeStart', { label: item.label })
             : context.kind === 'route-target'
-              ? 'Choose ' + item.label + ' as route destination, ' + badge
-              : 'Focus ' + item.label + ', ' + item.links + ' related connection' + (item.links === 1 ? '' : 's');
+              ? viewerText('viewer.finder.result.routeTarget', { label: item.label, links: badge })
+              : viewerCount('viewer.finder.result.focus', item.links, { label: item.label });
           button.setAttribute('aria-label', action);
 
           var name = document.createElement('strong');
@@ -11212,8 +12670,8 @@
           links.textContent = badge;
           links.title = context.kind === 'focus' ? badge : action;
           var meta = document.createElement('small');
-          meta.textContent = [item.type, item.id, item.sublabel, item.tag].filter(Boolean).join(' \u00b7 ');
-          meta.title = [item.type, item.id, item.context, item.sublabel, item.tag].filter(Boolean).join(' \u00b7 ');
+          meta.textContent = [viewerKindLabel(item.type), item.id, item.sublabel, item.tag].filter(Boolean).join(' \u00b7 ');
+          meta.title = [viewerKindLabel(item.type), item.id, item.context, item.sublabel, item.tag].filter(Boolean).join(' \u00b7 ');
           button.appendChild(name);
           button.appendChild(links);
           button.appendChild(meta);
@@ -11222,8 +12680,12 @@
         });
         empty.hidden = visibleItems.length !== 0;
         status.textContent = query
-          ? visibleItems.length + ' of ' + available.length + ' ' + context.availableNoun
-          : available.length + ' ' + context.availableNoun;
+          ? viewerText('viewer.finder.status.filtered', {
+              visible: visibleItems.length,
+              available: available.length,
+              noun: context.availableNoun
+            })
+          : viewerText('viewer.finder.status.all', { available: available.length, noun: context.availableNoun });
       }
 
       function open(options) {
@@ -11523,7 +12985,11 @@
             item.setAttribute('data-route-journey-index', String(index));
             item.setAttribute('data-route-node-id', id);
             item.setAttribute('tabindex', index === 0 ? '0' : '-1');
-            item.setAttribute('aria-label', 'Route position ' + (index + 1) + ' of ' + ids.length + ': ' + nodeLabel(byId[id], id));
+            item.setAttribute('aria-label', viewerText('viewer.route.position', {
+              index: index + 1,
+              total: ids.length,
+              label: nodeLabel(byId[id], id)
+            }));
           }
           item.className = 'route-probe-node';
           item.textContent = nodeLabel(byId[id], id);
@@ -11535,7 +13001,7 @@
       }
       function setTrigger(active) {
         trigger.setAttribute('aria-pressed', active ? 'true' : 'false');
-        trigger.setAttribute('aria-label', active ? 'Clear traced route' : 'Trace a directed route');
+        trigger.setAttribute('aria-label', viewerText(active ? 'viewer.route.trigger.clear' : 'viewer.guide.route.aria'));
       }
       function clear(options) {
         options = options || {};
@@ -11552,14 +13018,14 @@
         panel.hidden = true;
         panel.setAttribute('data-state', 'idle');
         panel.removeAttribute('data-finder-open');
-        title.textContent = 'Choose a start node';
-        renderPlaceholder('Pick two semantic nodes on the diagram');
-        status.textContent = 'Choose the source, then the destination. Direction matters.';
+        title.textContent = viewerText('viewer.route.start');
+        renderPlaceholder(viewerText('viewer.route.pickTwo'));
+        status.textContent = viewerText('viewer.route.instructions');
         findBtn.hidden = true;
-        findBtn.textContent = 'Find start';
-        findBtn.setAttribute('aria-label', 'Find a route start');
+        findBtn.textContent = viewerText('viewer.route.start.find');
+        findBtn.setAttribute('aria-label', viewerText('viewer.route.start.find.aria'));
         copyBtn.hidden = true;
-        copyBtn.textContent = 'Copy link';
+        copyBtn.textContent = viewerText('viewer.route.copy');
         if (Archify.exportMenu && typeof Archify.exportMenu.syncRouteShare === 'function') Archify.exportMenu.syncRouteShare();
         setTrigger(false);
         if (wasActive && options.preserveView !== true && Archify.view && typeof Archify.view.reset === 'function') {
@@ -11690,7 +13156,10 @@
           !Archify.motionGovernor.isPaused();
       }
       function routeOverviewStatus() {
-        return activeNodeIds.length + ' nodes · ' + activeEdges.length + ' directed hop' + (activeEdges.length === 1 ? '' : 's') + ' · shortest authored route';
+        return viewerText('viewer.route.overview.status', {
+          nodes: viewerCount('viewer.route.overview.node', activeNodeIds.length),
+          hops: viewerCount('viewer.route.overview.hop', activeEdges.length)
+        });
       }
       function centerJourneyButton(button) {
         if (!button) return;
@@ -11720,19 +13189,19 @@
         journeyPlayBtn.setAttribute('aria-pressed', journeyPlaying ? 'true' : 'false');
         if (journeyPlaying) {
           journeyPlayIcon.textContent = '\u275a\u275a';
-          journeyPlayLabel.textContent = 'Pause';
-          journeyPlayBtn.setAttribute('aria-label', 'Pause route journey');
-          journeyPlayBtn.title = 'Pause route journey';
+          journeyPlayLabel.textContent = viewerText('viewer.route.pause.label');
+          journeyPlayBtn.setAttribute('aria-label', viewerText('viewer.route.pause'));
+          journeyPlayBtn.title = viewerText('viewer.route.pause');
         } else if (journeyComplete || journeyIndex === activeNodeIds.length - 1) {
           journeyPlayIcon.textContent = '\u21bb';
-          journeyPlayLabel.textContent = 'Replay';
-          journeyPlayBtn.setAttribute('aria-label', 'Replay route journey');
-          journeyPlayBtn.title = canPlay ? 'Replay route journey' : 'Automatic journey requires Live motion';
+          journeyPlayLabel.textContent = viewerText('viewer.route.replay.label');
+          journeyPlayBtn.setAttribute('aria-label', viewerText('viewer.route.replay'));
+          journeyPlayBtn.title = viewerText(canPlay ? 'viewer.route.replay' : 'viewer.route.motionRequired');
         } else {
           journeyPlayIcon.textContent = '\u25b6';
-          journeyPlayLabel.textContent = 'Journey';
-          journeyPlayBtn.setAttribute('aria-label', 'Play route journey');
-          journeyPlayBtn.title = canPlay ? 'Play route journey' : 'Automatic journey requires Live motion';
+          journeyPlayLabel.textContent = viewerText('viewer.route.journey');
+          journeyPlayBtn.setAttribute('aria-label', viewerText('viewer.route.play'));
+          journeyPlayBtn.title = viewerText(canPlay ? 'viewer.route.play' : 'viewer.route.motionRequired');
         }
       }
       function journeyGeometry(shape) {
@@ -11823,8 +13292,17 @@
           else button.removeAttribute('aria-current');
         });
         if (options.center !== false) centerJourneyButton(buttons[journeyIndex]);
-        var phase = journeyPlaying ? 'Playing' : (journeyComplete ? 'Complete' : 'Inspecting');
-        status.textContent = 'Step ' + (journeyIndex + 1) + ' of ' + activeNodeIds.length + ' · ' + phase + ' · ' + nodeLabel(byId[activeNodeIds[journeyIndex]], activeNodeIds[journeyIndex]);
+        var phase = viewerText(journeyPlaying
+          ? 'viewer.route.phase.playing'
+          : journeyComplete
+            ? 'viewer.route.phase.complete'
+            : 'viewer.route.phase.inspecting');
+        status.textContent = viewerText('viewer.route.step', {
+          index: journeyIndex + 1,
+          total: activeNodeIds.length,
+          phase: phase,
+          label: nodeLabel(byId[activeNodeIds[journeyIndex]], activeNodeIds[journeyIndex])
+        });
         if (options.pulse === true && journeyIndex > 0) renderJourneyPulse(activeEdges[journeyIndex - 1]);
         if (options.reveal !== false && Archify.view && typeof Archify.view.reveal === 'function') {
           Archify.view.reveal(activeNodeIds.slice(Math.max(0, journeyIndex - 1), Math.min(activeNodeIds.length, journeyIndex + 2)), {
@@ -11996,15 +13474,15 @@
         });
         svg.setAttribute('data-route-picking', 'target');
         panel.setAttribute('data-state', 'target');
-        title.textContent = 'Choose a destination from ' + nodeLabel(byId[id], id);
+        title.textContent = viewerText('viewer.route.destination', { label: nodeLabel(byId[id], id) });
         renderPath([id]);
         var count = Math.max(0, Object.keys(reached).length - 1);
         status.textContent = count
-          ? count + ' directed destination' + (count === 1 ? '' : 's') + ' available. Pick a highlighted node.'
-          : 'No outgoing route starts here. Clear and choose another source.';
+          ? viewerCount('viewer.route.destination.count', count)
+          : viewerText('viewer.route.noOutgoing');
         findBtn.hidden = false;
-        findBtn.textContent = 'Find target';
-        findBtn.setAttribute('aria-label', 'Find a reachable route destination');
+        findBtn.textContent = viewerText('viewer.route.destination.find');
+        findBtn.setAttribute('aria-label', viewerText('viewer.route.destination.find.aria'));
         requestDocking();
         return true;
       }
@@ -12036,7 +13514,10 @@
         renderPath(result.nodes, { interactive: true });
         panel.setAttribute('data-state', 'result');
         panel.hidden = false;
-        title.textContent = nodeLabel(byId[startId], startId) + ' to ' + nodeLabel(byId[endId], endId);
+        title.textContent = viewerText('viewer.route.result.title', {
+          source: nodeLabel(byId[startId], startId),
+          target: nodeLabel(byId[endId], endId)
+        });
         findBtn.hidden = true;
         copyBtn.hidden = false;
         setTrigger(true);
@@ -12058,15 +13539,18 @@
         if (mode !== 'target') return false;
         if (id === startId) {
           panel.setAttribute('data-state', 'error');
-          title.textContent = 'Choose a different destination';
-          status.textContent = 'A route needs two distinct semantic nodes.';
+          title.textContent = viewerText('viewer.route.differentDestination');
+          status.textContent = viewerText('viewer.route.distinct');
           return false;
         }
         var result = shortestDirectedPath(startId, id);
         if (!result) {
           panel.setAttribute('data-state', 'error');
-          title.textContent = 'No directed route to ' + nodeLabel(byId[id], id);
-          status.textContent = nodeLabel(byId[id], id) + ' is not reachable from ' + nodeLabel(byId[startId], startId) + '. Pick a highlighted destination.';
+          title.textContent = viewerText('viewer.route.unreachable', { label: nodeLabel(byId[id], id) });
+          status.textContent = viewerText('viewer.route.unreachable.detail', {
+            target: nodeLabel(byId[id], id),
+            source: nodeLabel(byId[startId], startId)
+          });
           return false;
         }
         return showResult(result, options);
@@ -12094,12 +13578,12 @@
         panel.hidden = false;
         panel.setAttribute('data-state', 'source');
         svg.setAttribute('data-route-picking', 'source');
-        title.textContent = 'Choose a start node';
-        renderPlaceholder('Pick a semantic node on the diagram');
-        status.textContent = 'Select the source. The next step will reveal only directed destinations.';
+        title.textContent = viewerText('viewer.route.start');
+        renderPlaceholder(viewerText('viewer.route.pickOne'));
+        status.textContent = viewerText('viewer.route.start.instructions');
         findBtn.hidden = false;
-        findBtn.textContent = 'Find start';
-        findBtn.setAttribute('aria-label', 'Find a route start');
+        findBtn.textContent = viewerText('viewer.route.start.find');
+        findBtn.setAttribute('aria-label', viewerText('viewer.route.start.find.aria'));
         copyBtn.hidden = true;
         setTrigger(true);
         if (focused && nodesById()[focused]) chooseStart(focused);
@@ -12126,14 +13610,14 @@
             return outgoing[id] && outgoing[id].length;
           });
           var sourceBadges = {};
-          sourceIds.forEach(function (id) { sourceBadges[id] = 'start'; });
+          sourceIds.forEach(function (id) { sourceBadges[id] = viewerText('viewer.route.finder.source.badge'); });
           return {
             kind: 'route-source',
-            title: 'Choose route start',
-            placeholder: 'Search route sources',
-            empty: 'No matching route sources',
-            resultsLabel: 'Nodes that can start a route',
-            availableNoun: 'route sources',
+            title: viewerText('viewer.route.finder.source.title'),
+            placeholder: viewerText('viewer.route.finder.source.placeholder'),
+            empty: viewerText('viewer.route.finder.source.empty'),
+            resultsLabel: viewerText('viewer.route.finder.source.results'),
+            availableNoun: viewerText('viewer.route.finder.source.noun'),
             allowedIds: sourceIds,
             badges: sourceBadges
           };
@@ -12143,15 +13627,15 @@
           var targetIds = Object.keys(distances).filter(function (id) { return id !== startId && byId[id]; });
           var targetBadges = {};
           targetIds.forEach(function (id) {
-            targetBadges[id] = distances[id] + ' hop' + (distances[id] === 1 ? '' : 's');
+            targetBadges[id] = viewerCount('viewer.route.hop', distances[id]);
           });
           return {
             kind: 'route-target',
-            title: 'Destination from ' + nodeLabel(byId[startId], startId),
-            placeholder: 'Search reachable destinations',
-            empty: 'No matching reachable destinations',
-            resultsLabel: 'Reachable route destinations',
-            availableNoun: 'reachable destinations',
+            title: viewerText('viewer.route.finder.target.title', { label: nodeLabel(byId[startId], startId) }),
+            placeholder: viewerText('viewer.route.finder.target.placeholder'),
+            empty: viewerText('viewer.route.finder.target.empty'),
+            resultsLabel: viewerText('viewer.route.finder.target.results'),
+            availableNoun: viewerText('viewer.route.finder.target.noun'),
             allowedIds: targetIds,
             badges: targetBadges
           };
@@ -12192,11 +13676,11 @@
           ? navigator.clipboard.writeText(value).then(function () { return true; }).catch(function () { return fallbackCopy(value); })
           : Promise.resolve(fallbackCopy(value));
         return copy.then(function (copied) {
-          copyBtn.textContent = copied ? 'Copied' : 'Copy failed';
-          copyBtn.setAttribute('aria-label', copied ? 'Traced route link copied' : 'Could not copy traced route link');
+          copyBtn.textContent = viewerText(copied ? 'viewer.common.copied' : 'viewer.common.copyFailed');
+          copyBtn.setAttribute('aria-label', viewerText(copied ? 'viewer.route.copy.success' : 'viewer.route.copy.failed'));
           window.setTimeout(function () {
-            copyBtn.textContent = 'Copy link';
-            copyBtn.setAttribute('aria-label', 'Copy link to traced route');
+            copyBtn.textContent = viewerText('viewer.route.copy');
+            copyBtn.setAttribute('aria-label', viewerText('viewer.route.copy.aria'));
           }, 1600);
           return copied;
         });
@@ -12349,12 +13833,6 @@
       var finePointerQuery = window.matchMedia ? window.matchMedia('(hover: hover) and (pointer: fine)') : null;
       var MAX_LENS_FLOW_EDGES = 24;
 
-      function kindLabel(value) {
-        return String(value || 'neutral')
-          .replace(/messagebus/gi, 'message bus')
-          .replace(/[-_]+/g, ' ')
-          .replace(/\b\w/g, function (letter) { return letter.toUpperCase(); });
-      }
       function nodesById() {
         var byId = {};
         Array.prototype.forEach.call(svg.querySelectorAll('[data-node-id][data-node-kind]'), function (node) {
@@ -12369,7 +13847,7 @@
         Object.keys(byId).forEach(function (id) {
           var node = byId[id];
           var value = node.getAttribute('data-node-kind') || 'neutral';
-          var kind = kinds[value] || (kinds[value] = { id: value, label: kindLabel(value), nodes: [] });
+          var kind = kinds[value] || (kinds[value] = { id: value, label: viewerKindLabel(value), nodes: [] });
           kind.nodes.push(node);
         });
         return Object.keys(kinds).map(function (key) { return kinds[key]; }).sort(function (a, b) {
@@ -12472,7 +13950,8 @@
           }
           entry.setAttribute('role', 'button');
           entry.setAttribute('tabindex', legendEntries.length ? '-1' : '0');
-          entry.setAttribute('aria-label', 'Inspect ' + fact.label + ', ' + count + ' node' + (count === 1 ? '' : 's'));
+          var visibleLabel = entry.getAttribute('data-legend-label') || fact.label;
+          entry.setAttribute('aria-label', viewerCount('viewer.lens.legend.inspect', count, { label: visibleLabel }));
           entry.setAttribute('aria-pressed', 'false');
           entry.setAttribute('aria-haspopup', 'dialog');
           entry.setAttribute('aria-controls', 'semantic-lens');
@@ -12481,7 +13960,7 @@
         });
         if (!legendEntries.length) return false;
         legendBridge.setAttribute('role', legendEntries.length >= 3 ? 'toolbar' : 'group');
-        legendBridge.setAttribute('aria-label', 'Semantic legend');
+        legendBridge.setAttribute('aria-label', viewerText('viewer.lens.legend'));
         syncLegendBridge();
         layoutLegendBridge();
         try {
@@ -12629,7 +14108,7 @@
           button.className = 'semantic-lens-kind';
           button.setAttribute('data-kind', kind.id);
           button.setAttribute('aria-pressed', selectedKinds.indexOf(kind.id) >= 0 ? 'true' : 'false');
-          button.setAttribute('aria-label', kind.label + ', ' + kind.nodes.length + ' node' + (kind.nodes.length === 1 ? '' : 's'));
+          button.setAttribute('aria-label', viewerCount('viewer.lens.kind.count', kind.nodes.length, { label: kind.label }));
           button.disabled = selectedKinds.length >= 2 && selectedKinds.indexOf(kind.id) === -1;
           var swatch = document.createElement('span');
           swatch.className = 'semantic-lens-swatch';
@@ -12655,7 +14134,7 @@
       function updateTrigger() {
         var active = selectedKinds.length > 0;
         trigger.setAttribute('aria-pressed', active ? 'true' : 'false');
-        trigger.setAttribute('aria-label', active ? 'Open active semantic lens' : 'Open semantic lens');
+        trigger.setAttribute('aria-label', viewerText(active ? 'viewer.lens.openActive' : 'viewer.lens.open'));
         copyBtn.hidden = !active;
         syncLegendBridge();
       }
@@ -12666,7 +14145,7 @@
       }
       function dockPanel(byId) {
         panel.removeAttribute('data-dock-side');
-        if (panel.hidden || !selectedKinds.length || window.innerWidth <= 720) return 'right';
+        if (panel.hidden || window.innerWidth <= 720) return 'right';
         var panelRect = panel.getBoundingClientRect();
         var containerRect = container.getBoundingClientRect();
         if (!panelRect.width || !panelRect.height) return 'right';
@@ -12679,6 +14158,17 @@
         var rightCandidate = { left: containerRect.right - 16 - width, right: containerRect.right - 16, top: top, bottom: panelRect.bottom };
         var leftScore = selectedRects.reduce(function (score, rect) { return score + overlapArea(leftCandidate, rect); }, 0);
         var rightScore = selectedRects.reduce(function (score, rect) { return score + overlapArea(rightCandidate, rect); }, 0);
+        var legend = svg.querySelector('[data-legend]');
+        var nav = container.querySelector('.diagram-nav');
+        var protectedRects = [legend, nav].filter(function (element) {
+          return element && !element.hidden && window.getComputedStyle(element).display !== 'none';
+        }).map(function (element) { return element.getBoundingClientRect(); });
+        leftScore += protectedRects.reduce(function (score, rect) {
+          return score + overlapArea(leftCandidate, rect) * 1000;
+        }, 0);
+        rightScore += protectedRects.reduce(function (score, rect) {
+          return score + overlapArea(rightCandidate, rect) * 1000;
+        }, 0);
         var side = leftScore < rightScore ? 'left' : 'right';
         panel.setAttribute('data-dock-side', side);
         return side;
@@ -12690,7 +14180,7 @@
         var nodeKind = {};
         Object.keys(byId).forEach(function (id) { nodeKind[id] = byId[id].getAttribute('data-node-kind') || 'neutral'; });
         if (!selectedKinds.length) {
-          status.textContent = 'Choose a kind to inspect its nodes and touching relationships.';
+          status.textContent = viewerText('viewer.lens.choose');
           updateTrigger();
           renderKinds();
           dockPanel(byId);
@@ -12745,13 +14235,18 @@
         renderFlowOverlay(matchedFlow);
         if (crossKind) {
           var total = forward + reverse;
-          status.textContent = kindLabel(selectedKinds[0]) + ' → ' + kindLabel(selectedKinds[1]) + ': ' + forward + ' · ' +
-            kindLabel(selectedKinds[1]) + ' → ' + kindLabel(selectedKinds[0]) + ': ' + reverse + ' · ' +
-            total + ' direct relationship' + (total === 1 ? '' : 's');
+          status.textContent = viewerCount('viewer.lens.compare', total, {
+            first: viewerKindLabel(selectedKinds[0]),
+            second: viewerKindLabel(selectedKinds[1]),
+            forward: forward,
+            reverse: reverse
+          });
         } else {
           var nodeCount = collectKinds().filter(function (kind) { return kind.id === selectedKinds[0]; })[0].nodes.length;
-          status.textContent = nodeCount + ' ' + kindLabel(selectedKinds[0]) + ' node' + (nodeCount === 1 ? '' : 's') + ' · ' +
-            touching + ' touching relationship' + (touching === 1 ? '' : 's') + ' · connected peers remain visible';
+          status.textContent = viewerText('viewer.lens.single', {
+            nodes: viewerCount('viewer.lens.node', nodeCount, { label: viewerKindLabel(selectedKinds[0]) }),
+            relationships: viewerCount('viewer.lens.relationship', touching)
+          });
         }
         updateTrigger();
         renderKinds();
@@ -12824,7 +14319,7 @@
         panel.removeAttribute('data-dock-side');
         updateTrigger();
         renderKinds();
-        status.textContent = 'Choose a kind to inspect its nodes and touching relationships.';
+        status.textContent = viewerText('viewer.lens.choose');
         if (options.updateUrl !== false) updateHash();
         if (options.preserveView !== true && Archify.view && typeof Archify.view.reset === 'function') {
           Archify.view.reset({ automatic: true });
@@ -12852,8 +14347,8 @@
           ? navigator.clipboard.writeText(value).then(function () { return true; }).catch(function () { return fallbackCopy(value); })
           : Promise.resolve(fallbackCopy(value));
         return copy.then(function (copied) {
-          copyBtn.textContent = copied ? 'Copied' : 'Copy failed';
-          window.setTimeout(function () { copyBtn.textContent = 'Copy link'; }, 1600);
+          copyBtn.textContent = viewerText(copied ? 'viewer.common.copied' : 'viewer.common.copyFailed');
+          window.setTimeout(function () { copyBtn.textContent = viewerText('viewer.common.copyLink'); }, 1600);
           return copied;
         });
       }
@@ -13025,14 +14520,16 @@
         var nodes = svg.querySelectorAll('[data-node-id]').length;
         var relationships = relationshipCount();
         var views = viewCount();
-        stats.textContent = nodes + ' semantic node' + (nodes === 1 ? '' : 's') + ' · ' +
-          relationships + ' relationship' + (relationships === 1 ? '' : 's') + ' · ' +
-          views + ' guided view' + (views === 1 ? '' : 's');
+        stats.textContent = viewerText('viewer.guide.facts', {
+          nodes: viewerCount('viewer.guide.fact.node', nodes),
+          relationships: viewerCount('viewer.guide.fact.relationship', relationships),
+          views: viewerCount('viewer.guide.fact.view', views)
+        });
         storyBtn.disabled = views === 0;
         storyBtn.setAttribute('aria-disabled', views === 0 ? 'true' : 'false');
         storyCopy.textContent = views
-          ? 'Walk ' + views + ' authored chapter' + (views === 1 ? '' : 's') + ' and their real relationships.'
-          : 'No authored guided story in this diagram.';
+          ? viewerCount('viewer.guide.story.available', views)
+          : viewerText('viewer.guide.story.unavailable');
       }
       function actionButtons() {
         return Array.prototype.slice.call(actions.querySelectorAll('.diagram-guide-action:not(:disabled)'));
@@ -13043,7 +14540,7 @@
         html.removeAttribute('data-guide-open');
         routePanel.removeAttribute('data-guide-open');
         trigger.setAttribute('aria-expanded', 'false');
-        trigger.setAttribute('aria-label', 'Open diagram guide');
+        trigger.setAttribute('aria-label', viewerText('viewer.guide.open'));
         feedback.textContent = '';
         if (options.restoreFocus !== false) trigger.focus();
         return false;
@@ -13066,7 +14563,7 @@
         html.setAttribute('data-guide-open', 'true');
         routePanel.setAttribute('data-guide-open', 'true');
         trigger.setAttribute('aria-expanded', 'true');
-        trigger.setAttribute('aria-label', 'Close diagram guide');
+        trigger.setAttribute('aria-label', viewerText('viewer.guide.close'));
         feedback.textContent = '';
         requestAnimationFrame(function () {
           var first = actionButtons()[0];
@@ -13078,7 +14575,7 @@
       function execute(action) {
         feedback.textContent = '';
         if (action === 'story' && !viewCount()) {
-          feedback.textContent = 'This diagram has no authored guided story.';
+          feedback.textContent = viewerText('viewer.guide.noStory');
           return false;
         }
         close({ restoreFocus: false });


### PR DESCRIPTION
## 问题与价值

收紧 MCO 展示产物的公开仓库证据链和字节复现测试，避免用户显式配置错误时被静默当作环境缺失跳过，并消除测试层与正式 repository-evidence 验证逻辑的漂移。

Fixes #118

## 范围

- 自动发现相邻 MCO 仓库时复用正式 `verifyRepositoryEvidence` 验证入口。
- 只有未设置环境变量且自动候选缺失或不匹配时，字节比较才跳过。
- 显式 `ARCHIFY_MCO_REPO_ROOT` 无效时测试失败并保留正式诊断。
- HTML 证据与源 JSON 的 repository URL、完整 revision、短 revision 逐项绑定。
- 三份 README 与同一仓库链接和短 revision 绑定。
- 新增 HTTPS、SCP 风格 SSH 与 `ssh://` 远程地址的行为级测试。
- 删除测试层重复的仓库 URL 规范化实现。
- 未导出新的运行时 API，也未修改普通用户渲染路径。
- 保留 MCO 实验产物；其是否继续作为产品展示资产不在本 PR 的删除范围内。
- 无无关改动。

## 稳定性影响

- 兼容性与迁移风险：低；主要调整测试与展示证据约束。
- 生成物风险：公开证明字段漂移会更早失败。
- 失败行为与回滚：显式错误配置现在失败关闭；自动环境缺失仍可跳过。可回退本 PR 的两个提交恢复原测试行为。

## 已运行测试

```sh
cd archify
node --test test/real-repository-proof.test.mjs \
  test/repository-evidence.test.mjs
# 8 passed, 0 failed, 1 skipped
```

跳过项是需要本地存在匹配 `https://github.com/mco-org/mco` 固定 revision 的字节级比较。

同步最新 `main` 后还运行了联合回归：

```sh
node --test test/real-repository-proof.test.mjs \\
  test/repository-evidence.test.mjs \\
  test/generated-artifact-xml.test.mjs \\
  test/architecture-delta.test.mjs
# 28 passed, 0 failed, 1 skipped
```

另外验证了失败路径：

```sh
ARCHIFY_MCO_REPO_ROOT=/private/tmp/archify-missing-mco-root \
  node --test --test-name-pattern='checked-in MCO artifacts are byte-reproducible' \
  test/real-repository-proof.test.mjs
# 按预期失败，报告 repository-evidence/root-unreadable
```

## 可视化证据

未进行人工截图比较。连接标签几何由回归测试锁定，生成 HTML 同时通过 `archify check`。

## 生成物

- 更新 `experiments/mco-showcase/mco-runtime.architecture.json` 的固定证据信息。
- 从该输入重新生成 `experiments/mco-showcase/mco-runtime.html`。
- 普通 Gallery、README 页面与 `archify.zip` 未由本 PR 修改。

## Checklist

- [x] 使用聚焦改动，未修改已有 typed JSON 行为
- [ ] 在 `archify/` 运行完整 `npm test`（相关测试已通过，完整矩阵由 CI 执行）
- [x] 为行为变化添加或更新回归测试
- [x] 检查相关生成物新鲜度
- [x] 测试夹具不包含密钥、私有仓库或用户数据