### PR TITLE
Sandbox CLI output paths (Fixes #124)

### DIFF
--- a/archify/bin/archify.mjs
+++ b/archify/bin/archify.mjs
@@ -472,6 +472,7 @@ async function commandCompare(args) {
       defaultOutput: compareReceiptPath(outputPath),
       inputPaths: [basePath, headPath],
       otherOutputPaths: [outputPath],
+      requiredExtension: '.json',
     }));
   } catch (error) {
     const outputDiagnostic = error.archifyDiagnostics?.[0];
@@ -645,6 +646,7 @@ async function commandCompare(args) {
         defaultOutput: compareReceiptPath(currentOutput),
         inputPaths: [basePath, headPath],
         otherOutputPaths: [currentOutput],
+        requiredExtension: '.json',
       });
     } catch (error) {
       const outputDiagnostic = error.archifyDiagnostics?.[0];

--- a/archify/renderers/shared/output-path.mjs
+++ b/archify/renderers/shared/output-path.mjs
@@ -247,6 +247,11 @@ export class OutputPathError extends Error {
   }
 }
 
+function normalizeRequiredExtension(extension) {
+  const value = String(extension || '.html').trim().toLowerCase();
+  return value.startsWith('.') ? value : `.${value}`;
+}
+
 export function resolveOutputPath({
   requestedOutput,
   authoredOutput,
@@ -255,9 +260,20 @@ export function resolveOutputPath({
   inputDescription = 'an input',
   otherOutputPaths = [],
   cwd = process.cwd(),
+  // Artifact outputs default to .html. Compare receipts pass '.json'.
+  requiredExtension = '.html',
 }) {
   const rawOutput = requestedOutput || authoredOutput || defaultOutput;
   const source = requestedOutput ? 'cli' : (authoredOutput ? 'meta' : 'default');
+  const extension = source === 'meta' ? '.html' : normalizeRequiredExtension(requiredExtension);
+  const label = source === 'meta' ? 'meta.output' : 'CLI output';
+  const relativeFix = source === 'meta'
+    ? `set meta.output to a relative ${extension} path inside the current working directory`
+    : `pass a relative ${extension} path inside the current working directory`;
+  const sandboxSource = source === 'meta' || source === 'cli';
+
+  // meta.output must stay authored-relative. CLI absolute paths are still
+  // resolved, then rejected by the shared cwd containment check below.
   if (
     source === 'meta'
     && (path.isAbsolute(rawOutput) || path.posix.isAbsolute(rawOutput) || path.win32.isAbsolute(rawOutput))
@@ -269,29 +285,35 @@ export function resolveOutputPath({
       supportedFixes: ['set meta.output to a relative .html path inside the current working directory'],
     });
   }
-  if (source === 'meta' && path.extname(rawOutput).toLowerCase() !== '.html') {
-    throw new OutputPathError('meta.output must target an .html file.', {
-      code: 'output/meta-extension',
-      message: 'meta.output must target an .html file.',
-      subject: { output: rawOutput },
-      supportedFixes: ['change meta.output to a path ending in .html'],
+  if (sandboxSource && path.extname(rawOutput).toLowerCase() !== extension) {
+    throw new OutputPathError(`${label} must target a ${extension} file.`, {
+      code: source === 'meta' ? 'output/meta-extension' : 'output/cli-extension',
+      message: `${label} must target a ${extension} file.`,
+      subject: { output: rawOutput, requiredExtension: extension },
+      supportedFixes: [
+        source === 'meta'
+          ? 'change meta.output to a path ending in .html'
+          : `change the CLI output path to end in ${extension}`,
+      ],
     });
   }
   const outputPath = path.resolve(cwd, rawOutput);
-  if (source === 'meta' && path.extname(canonicalFuturePath(outputPath)).toLowerCase() !== '.html') {
-    throw new OutputPathError('meta.output must resolve to an .html file.', {
-      code: 'output/meta-resolved-extension',
-      message: 'meta.output must resolve to an .html file after symbolic links are followed.',
-      subject: { output: rawOutput },
-      supportedFixes: ['remove the symbolic-link alias or point it to an .html target inside the current working directory'],
+  if (sandboxSource && path.extname(canonicalFuturePath(outputPath)).toLowerCase() !== extension) {
+    throw new OutputPathError(`${label} must resolve to a ${extension} file.`, {
+      code: source === 'meta' ? 'output/meta-resolved-extension' : 'output/cli-resolved-extension',
+      message: `${label} must resolve to a ${extension} file after symbolic links are followed.`,
+      subject: { output: rawOutput, requiredExtension: extension },
+      supportedFixes: [
+        `remove the symbolic-link alias or point it to a ${extension} target inside the current working directory`,
+      ],
     });
   }
-  if (source === 'meta' && !pathIsInside(cwd, outputPath)) {
-    throw new OutputPathError('meta.output must stay inside the current working directory.', {
-      code: 'output/meta-outside-cwd',
-      message: 'meta.output must stay inside the current working directory after symbolic links are resolved.',
+  if (sandboxSource && !pathIsInside(cwd, outputPath)) {
+    throw new OutputPathError(`${label} must stay inside the current working directory.`, {
+      code: source === 'meta' ? 'output/meta-outside-cwd' : 'output/cli-outside-cwd',
+      message: `${label} must stay inside the current working directory after symbolic links are resolved.`,
       subject: { output: rawOutput, cwd: path.resolve(cwd) },
-      supportedFixes: ['set meta.output to a relative .html path inside the current working directory'],
+      supportedFixes: [relativeFix],
     });
   }
 

--- a/archify/test/output-path.test.mjs
+++ b/archify/test/output-path.test.mjs
@@ -75,15 +75,18 @@ test('future-path aliases follow the containing directory case and Unicode seman
   );
 });
 
-test('compare rejects case-only future targets before input work when the directory aliases case', () => {
+test('compare rejects case-only receipt aliases of an input when the directory aliases case', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-output-compare-case-'));
   const caseInsensitive = directoryAliasesNames(cwd, 'ArchifyCaseProbe', 'archifycaseprobe');
+  const base = path.join(cwd, 'Base.JSON');
   const output = path.join(cwd, 'Future.HTML');
-  const receiptPath = path.join(cwd, 'future.html');
+  const receiptPath = path.join(cwd, 'base.json');
+  const baseSource = fs.readFileSync(baseFixture);
+  fs.writeFileSync(base, baseSource);
 
   const result = run([
     'compare', 'architecture',
-    path.join(cwd, 'missing-base.json'),
+    base,
     path.join(cwd, 'missing-head.json'),
     output,
     '--receipt', receiptPath,
@@ -94,9 +97,10 @@ test('compare rejects case-only future targets before input work when the direct
   const receipt = JSON.parse(result.stdout);
   assert.equal(
     receipt.diagnostics[0].code,
-    caseInsensitive ? 'output/target-alias' : 'delta/base-input',
+    caseInsensitive ? 'output/input-alias' : 'delta/head-input',
   );
   assert.equal(receipt.stage, caseInsensitive ? 'prepare' : 'input');
+  assert.deepEqual(fs.readFileSync(base), baseSource);
 });
 
 test('render reports an output symlink cycle as a structured output diagnostic', () => {
@@ -397,7 +401,8 @@ test('compare rejects a dangling receipt symlink to the future artifact path', (
   assert.equal(result.status, 1);
   const receipt = JSON.parse(result.stdout);
   assert.equal(receipt.stage, 'prepare');
-  assert.equal(receipt.diagnostics[0].code, 'output/target-alias');
+  // Symlink resolves to the .html artifact, so the receipt fails the .json extension guard.
+  assert.equal(receipt.diagnostics[0].code, 'output/cli-resolved-extension');
   assert.equal(fs.lstatSync(receiptPath).isSymbolicLink(), true);
   assert.equal(fs.existsSync(output), false);
 });
@@ -584,4 +589,56 @@ test('doctor reports a missing output-path safety runtime in an installed skill'
 
   assert.equal(result.status, 1);
   assert.match(result.stdout, /\[missing\] Output path safety runtime/);
+});
+
+test('deliver rejects a CLI output that escapes the working directory', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-output-cli-parent-'));
+  const cwd = path.join(parent, 'work');
+  fs.mkdirSync(cwd);
+  const input = path.join(cwd, 'diagram.workflow.json');
+  const escaped = path.join(parent, 'marker.env');
+  fs.copyFileSync(workflowFixture, input);
+  fs.writeFileSync(escaped, 'preserve-me\n');
+
+  const result = run(['deliver', 'workflow', input, '../marker.env', '--json'], cwd);
+
+  assert.equal(result.status, 1);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.diagnostics[0].code, 'output/cli-extension');
+  assert.equal(fs.readFileSync(escaped, 'utf8'), 'preserve-me\n');
+});
+
+test('deliver rejects a CLI .html path that escapes the working directory', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-output-cli-html-parent-'));
+  const cwd = path.join(parent, 'work');
+  fs.mkdirSync(cwd);
+  const input = path.join(cwd, 'diagram.workflow.json');
+  const escaped = path.join(parent, 'escaped.html');
+  fs.copyFileSync(workflowFixture, input);
+
+  const result = run(['deliver', 'workflow', input, '../escaped.html', '--json'], cwd);
+
+  assert.equal(result.status, 1);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.diagnostics[0].code, 'output/cli-outside-cwd');
+  assert.equal(fs.existsSync(escaped), false);
+});
+
+test('compare rejects a non-json CLI receipt path', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-output-cli-receipt-ext-'));
+  const output = path.join(cwd, 'delta.html');
+  const receiptPath = path.join(cwd, 'delta.receipt.html');
+
+  const result = run([
+    'compare', 'architecture', baseFixture, headFixture, output,
+    '--receipt', receiptPath, '--json',
+  ], cwd);
+
+  assert.equal(result.status, 1);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.stage, 'prepare');
+  assert.equal(receipt.diagnostics[0].code, 'output/cli-extension');
+  assert.equal(fs.existsSync(output), false);
 });


### PR DESCRIPTION
## Summary
- Apply the same cwd + extension sandbox used for `meta.output` to CLI output paths, so `deliver`/`render`/`compare` cannot overwrite arbitrary files (e.g. `../marker.env`).
- Keep compare receipts as `.json` via `requiredExtension: '.json'` while HTML artifacts still require `.html`.
- Add regression tests for CLI escape, non-`.html` deliver targets, and non-`.json` receipts.

Fixes #124

## Test plan
- [x] `node --test test/output-path.test.mjs` (non-symlink cases; symlink tests need Windows Developer Mode / elevated privileges)
- [ ] `archify deliver workflow <input> ../outside.env` fails and leaves the outside file untouched
- [ ] `archify deliver workflow <input> ../escaped.html` fails with `output/cli-outside-cwd`
- [ ] `archify compare ... --receipt foo.html` fails with `output/cli-extension`
- [ ] Relative in-cwd `.html` / `.receipt.json` outputs still succeed

Made with [Cursor](https://cursor.com)