### PR TITLE
Improve workflow short-edge column diagnostics (Fixes #126)

### DIFF
--- a/archify/SKILL.md
+++ b/archify/SKILL.md
@@ -38,6 +38,8 @@ Do not read `renderers/shared/geometry.mjs`, renderer source, validator source, 
 
 Lifecycle note: phase columns `0..4` occupy the main rail; event/outcome columns `0..2` align beneath later phases. A recoverable state uses `type: "failure"` plus a real transition back to the active state.
 
+Workflow note: column centers are not uniform (`col` 0..5 at x 88 / 220 / 300 / 430 / 500 / 625). Same-lane adjacent pairs 1↔2 and 3↔4 are too tight for default 92px nodes: a straight edge there fails the 28px minimum even when an identical edge one column over passes. Prefer 0→1, 2→3, or 4→5; otherwise skip a column, reduce `width`, or route through a channel. Details: `renderers/workflow/README.md`.
+
 ## Type router
 
 | Type | Use for |

--- a/archify/renderers/workflow/README.md
+++ b/archify/renderers/workflow/README.md
@@ -81,8 +81,10 @@ backed by rendered nodes receive Semantic Legend controls.
 | Legend row | y = lane bottom + 44; viewBox height must be ≥ legend y + 18 |
 
 Column-center gaps are 132 / 80 / 130 / 70 / 125 px: columns 1↔2 (80px) and
-3↔4 (70px) cannot both hold default-width 92px nodes in the same lane — skip a
-column or reduce `width`.
+3↔4 (70px) cannot both hold default-width 92px nodes in the same lane with a
+straight labeled edge that clears the 28px minimum. Use 0→1, 2→3, or 4→5,
+skip a column, reduce `width`, or route through a channel. The short-edge
+diagnostic names those legal adjacent pairs for the node widths in play.
 
 ## Design Rules
 

--- a/archify/renderers/workflow/render-workflow.mjs
+++ b/archify/renderers/workflow/render-workflow.mjs
@@ -51,10 +51,69 @@ const layout = {
   laneH: 104,
   laneGap: 20,
   laneTitleH: 30,
+  // Non-uniform by design (phase/group rhythm). Adjacent gaps are
+  // 132 / 80 / 130 / 70 / 125 px. Pairs 1↔2 and 3↔4 are too tight for
+  // default-width (92px) same-lane edges that must clear MIN_EDGE_LENGTH.
   colXs: [88, 220, 300, 430, 500, 625],
   nodeW: 92,
   nodeH: 52
 };
+
+/** Straight same-lane edges must clear this length (matches layout budget). */
+const MIN_EDGE_LENGTH = 28;
+
+/** Horizontal clearance between two column centers given node widths. */
+function columnPairClearance(colXs, fromCol, toCol, fromWidth, toWidth) {
+  return Math.abs(colXs[toCol] - colXs[fromCol]) - fromWidth / 2 - toWidth / 2;
+}
+
+/**
+ * Adjacent column pairs whose default routing would clear `minLength` for the
+ * given node widths. Used only to name legal alternatives in diagnostics.
+ */
+function adjacentColumnPairsClearingMinimum(colXs, fromWidth, toWidth, minLength = MIN_EDGE_LENGTH) {
+  const pairs = [];
+  for (let fromCol = 0; fromCol < colXs.length - 1; fromCol += 1) {
+    const toCol = fromCol + 1;
+    if (columnPairClearance(colXs, fromCol, toCol, fromWidth, toWidth) >= minLength) {
+      pairs.push(`${fromCol}→${toCol}`);
+    }
+  }
+  return pairs;
+}
+
+function shortEdgeRepairHint(from, to) {
+  const channelHint = 'route it through a channel';
+  if (
+    !from
+    || !to
+    || from.lane !== to.lane
+    || !Number.isInteger(from.col)
+    || !Number.isInteger(to.col)
+  ) {
+    return channelHint;
+  }
+
+  const legalPairs = adjacentColumnPairsClearingMinimum(
+    layout.colXs,
+    from.width || layout.nodeW,
+    to.width || layout.nodeW,
+  ).filter((pair) => {
+    const [a, b] = pair.split('→').map(Number);
+    const lo = Math.min(from.col, to.col);
+    const hi = Math.max(from.col, to.col);
+    return !(lo === a && hi === b);
+  });
+
+  if (legalPairs.length === 0) {
+    return `reduce node width, skip a column, or ${channelHint}`;
+  }
+
+  const listed = legalPairs.length === 1
+    ? `col ${legalPairs[0]}`
+    : `col ${legalPairs.slice(0, -1).join(', ')}, or ${legalPairs[legalPairs.length - 1]}`;
+  return `move one node onto a wider adjacent pair (${listed} clear ${MIN_EDGE_LENGTH}px at these widths), or ${channelHint}`;
+}
 
 // Content is 680px wide (laneX + laneW); auto height fits the lanes plus legend.
 const autoHeight = layout.laneY
@@ -318,8 +377,12 @@ function validateWorkflow() {
       if (routed.points.length === 2) {
         const [start, end] = routed.points;
         const segmentLength = Math.hypot(end[0] - start[0], end[1] - start[1]);
-        if (segmentLength < 28) {
-          problems.push(`Edge "${edge.from}" -> "${edge.to}" is too short (${Math.round(segmentLength)}px; minimum 28px) — drop its label or route it through a channel.`);
+        if (segmentLength < MIN_EDGE_LENGTH) {
+          const from = nodes.get(edge.from);
+          const to = nodes.get(edge.to);
+          problems.push(
+            `Edge "${edge.from}" -> "${edge.to}" is too short (${Math.round(segmentLength)}px; minimum ${MIN_EDGE_LENGTH}px). ${shortEdgeRepairHint(from, to)}.`,
+          );
         }
       }
     }

--- a/archify/test/workflow-column-spacing.test.mjs
+++ b/archify/test/workflow-column-spacing.test.mjs
@@ -1,0 +1,78 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const skillRoot = path.resolve(here, '..');
+const cli = path.join(skillRoot, 'bin/archify.mjs');
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+function writeWorkflow(cwd, nodes) {
+  const input = path.join(cwd, 'diagram.workflow.json');
+  const spec = {
+    schema_version: 1,
+    diagram_type: 'workflow',
+    meta: { title: 'column spacing', quality_profile: 'showcase', viewBox: [900, 520] },
+    lanes: [{ id: 'lane', label: 'Lane' }],
+    nodes,
+    edges: [{ id: 'ab', from: 'a', to: 'b', label: 'step', variant: 'default' }],
+  };
+  fs.writeFileSync(input, `${JSON.stringify(spec, null, 2)}\n`);
+  return input;
+}
+
+test('short same-lane edge on a tight column pair names legal wider pairs', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-workflow-col-'));
+  const input = writeWorkflow(cwd, [
+    { id: 'a', lane: 'lane', col: 1, type: 'backend', label: 'A', sublabel: 'x' },
+    { id: 'b', lane: 'lane', col: 2, type: 'backend', label: 'B', sublabel: 'y' },
+  ]);
+
+  const result = run(['validate', 'workflow', input, '--quality', 'showcase'], cwd);
+  assert.notEqual(result.status, 0);
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /too short \(12px; minimum 28px\)/);
+  assert.match(output, /wider adjacent pair/);
+  assert.match(output, /0→1/);
+  assert.match(output, /2→3/);
+  assert.match(output, /4→5/);
+  assert.doesNotMatch(output, /drop its label/);
+});
+
+test('short same-lane edge on col 3→4 also names legal wider pairs', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-workflow-col-'));
+  const input = writeWorkflow(cwd, [
+    { id: 'a', lane: 'lane', col: 3, type: 'backend', label: 'A', sublabel: 'x' },
+    { id: 'b', lane: 'lane', col: 4, type: 'backend', label: 'B', sublabel: 'y' },
+  ]);
+
+  const result = run(['validate', 'workflow', input, '--quality', 'showcase'], cwd);
+  assert.notEqual(result.status, 0);
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /too short \(22px; minimum 28px\)/);
+  assert.match(output, /0→1/);
+  assert.match(output, /2→3/);
+  assert.match(output, /4→5/);
+});
+
+test('same-lane edge on a wide column pair still validates', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-workflow-col-'));
+  const input = writeWorkflow(cwd, [
+    { id: 'a', lane: 'lane', col: 0, type: 'backend', label: 'A', sublabel: 'x' },
+    { id: 'b', lane: 'lane', col: 1, type: 'backend', label: 'B', sublabel: 'y' },
+  ]);
+
+  const result = run(['validate', 'workflow', input, '--quality', 'showcase'], cwd);
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /too short/);
+});


### PR DESCRIPTION
## Summary
- Short same-lane edges no longer suggest dropping the label. The diagnostic names legal adjacent column pairs (`0→1`, `2→3`, `4→5`) for the node widths in play, or channel/width/skip-column repairs.
- Documents that workflow `colXs` are non-uniform (pairs `1↔2` / `3↔4` are too tight for default 92px nodes) in `SKILL.md` and `renderers/workflow/README.md`.
- Adds regression tests for the 12px / 22px tight pairs vs a wide pair that still validates.

This does not rebalance column spacing (that would break showcase layouts). It makes the existing constraint diagnosable and documented.

## Test plan
- [x] `node --test archify/test/workflow-column-spacing.test.mjs`
- [ ] Showcase workflow examples still validate as before
- [ ] Confirm short-edge message contains wider-pair hint and not "drop its label"

Fixes #126
