### PR TITLE
docs: remove LINUX DO links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then ask your agent: `Use archify to map this repository's runtime architecture.
   <tr><td align="center" width="240"><a href="https://github.com/EverMind-AI/Raven"><img src="docs/assets/sponsors/evermind-archify-raven.png" alt="Archify × Raven" width="200" /></a><br/><strong><a href="https://github.com/EverMind-AI">EverMind</a> · <a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td><td>EverMind sponsors Archify and builds memory infrastructure for agents. Its <a href="https://github.com/EverMind-AI/Raven"><strong>Raven</strong></a> harness supports Archify as a Skill for verified, interactive system maps.</td></tr>
 </table>
 
-> Sponsor Archify: [email](mailto:2801884530@qq.com) · [LINUX DO](https://linux.do)
+> Want to sponsor Archify? [Contact us by email.](mailto:2801884530@qq.com)
 
 ## See Archify in action
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -42,7 +42,7 @@ Then ask your agent: `Use archify to map this repository's runtime architecture.
   <tr><td align="center" width="240"><a href="https://github.com/EverMind-AI/Raven"><img src="docs/assets/sponsors/evermind-archify-raven.png" alt="Archify × Raven" width="200" /></a><br/><strong><a href="https://github.com/EverMind-AI">EverMind</a> · <a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td><td>EverMind sponsors Archify and builds memory infrastructure for agents. Its <a href="https://github.com/EverMind-AI/Raven"><strong>Raven</strong></a> harness supports Archify as a Skill for verified, interactive system maps.</td></tr>
 </table>
 
-> Sponsor Archify: [email](mailto:2801884530@qq.com) · [LINUX DO](https://linux.do)
+> Want to sponsor Archify? [Contact us by email.](mailto:2801884530@qq.com)
 
 ## See Archify in action
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -38,7 +38,7 @@ npx skills add tt-a1i/archify -g
   <tr><td align="center" width="240"><a href="https://github.com/EverMind-AI/Raven"><img src="docs/assets/sponsors/evermind-archify-raven.png" alt="Archify × Raven" width="200" /></a><br/><strong><a href="https://github.com/EverMind-AI">EverMind</a> · <a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td><td>感谢 EverMind 赞助 Archify。EverMind 专注 Agent 记忆基础设施，旗下 <a href="https://github.com/EverMind-AI/Raven"><strong>Raven</strong></a> 已支持 Archify Skill，让 Raven 工作流可以直接生成经过验证的交互式系统地图。</td></tr>
 </table>
 
-> 赞助 Archify：[邮件联系](mailto:2801884530@qq.com) · 社区友链：[LINUX DO](https://linux.do)
+> 想赞助 Archify？[欢迎通过邮件联系我们。](mailto:2801884530@qq.com)
 
 ## 看看 Archify 能做什么
 


### PR DESCRIPTION
Removes the LINUX DO references from all English and Chinese README variants while keeping the existing email sponsorship contact.\n\nValidation:\n- git diff --check\n- README.md and README_EN.md remain byte-identical\n- node archify/test/readme-showcase.test.mjs (4/4)