### PR TITLE
fix(repo): correct GitHub language classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Generated diagram artifacts and built documentation surfaces.
+# Keep renderer/viewer templates and the hand-authored landing page visible to Linguist.
+/archify/examples/*.html linguist-generated=true
+/examples/*.html linguist-generated=true
+/docs/cases/*.html linguist-generated=true
+/docs/gallery.html linguist-generated=true
+/docs/gallery/artifacts/*.html linguist-generated=true
+/docs/guide.html linguist-generated=true
+/docs/start.html linguist-generated=true
+/experiments/**/*.html linguist-generated=true
+
+# Deterministic build outputs committed for zero-install and release verification.
+/archify/renderers/shared/generated-brand-marks.mjs linguist-generated=true
+/archify/renderers/shared/generated-validators.mjs linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Turn a codebase or system description into a polished, interactive system map — directly in chat.**
 
-Archify is an agent skill for Raven, Cursor, Claude Code, Codex CLI, and OpenCode. Give it a system description or repository; get an interactive, shareable technical map.
+Archify is a Node.js rendering and validation system for Cursor, Claude Code, Codex CLI, and OpenCode. Agents produce typed JSON IR; Archify deterministically compiles it into HTML/SVG.
 
 - **Open it and present** — five diagram types, four presets, dark/light themes, built-in brand marks, and finite motion
 - **Review architecture changes before merge** — compare two validated snapshots as Before / Delta / After, with exact added, removed, changed, moved, and rerouted facts

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,7 +12,7 @@
 
 **Turn a codebase or system description into a polished, interactive system map — directly in chat.**
 
-Archify is an agent skill for Raven, Cursor, Claude Code, Codex CLI, and OpenCode. Give it a system description or repository; get an interactive, shareable technical map.
+Archify is a Node.js rendering and validation system for Cursor, Claude Code, Codex CLI, and OpenCode. Agents produce typed JSON IR; Archify deterministically compiles it into HTML/SVG.
 
 - **Open it and present** — five diagram types, four presets, dark/light themes, built-in brand marks, and finite motion
 - **Review architecture changes before merge** — compare two validated snapshots as Before / Delta / After, with exact added, removed, changed, moved, and rerouted facts

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,7 +8,7 @@
 
 **在对话里，把代码仓库或系统描述变成漂亮、可靠、可交互的系统地图。**
 
-Archify 是适用于 Raven、Cursor、Claude Code、Codex CLI 和 OpenCode 的 Agent Skill。给它系统描述或代码仓库，就能得到可交互、可分享的专业技术地图。
+Archify 是一套基于 Node.js 的渲染与校验系统，并以 Agent Skill 的形式支持 Raven、Cursor、Claude Code、Codex CLI 和 OpenCode。Agent 负责生成 Typed JSON IR，Archify 再校验并确定性编译为便携、独立的 HTML/SVG 成品。
 
 - **打开就是成品** —— 五种技术图、四套视觉预设、深浅主题、内置品牌徽标，以及显式启用的有限动态
 - **合并前先看清架构变化** —— 把两份已校验快照对比为 Before / Delta / After，准确区分新增、删除、语义变化、移动和重路由

--- a/archify/test/repository-language-metadata.test.mjs
+++ b/archify/test/repository-language-metadata.test.mjs
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function linguistGenerated(relativePath) {
+  const output = execFileSync(
+    'git',
+    ['check-attr', 'linguist-generated', '--', relativePath],
+    { cwd: repoRoot, encoding: 'utf8' },
+  ).trim();
+  return output.slice(output.lastIndexOf(':') + 1).trim();
+}
+
+test('repository language metadata separates generated artifacts from implementation source', () => {
+  for (const generatedPath of [
+    'archify/examples/web-app-rendered.html',
+    'examples/web-app.html',
+    'docs/cases/mco-runtime.architecture.html',
+    'docs/gallery.html',
+    'docs/gallery/artifacts/web-app.architecture.html',
+    'docs/guide.html',
+    'docs/start.html',
+    'experiments/mco-showcase/mco-runtime.html',
+    'archify/renderers/shared/generated-brand-marks.mjs',
+    'archify/renderers/shared/generated-validators.mjs',
+  ]) {
+    assert.equal(
+      linguistGenerated(generatedPath),
+      'true',
+      `${generatedPath} must be excluded from GitHub language statistics`,
+    );
+  }
+
+  for (const sourcePath of [
+    'archify/assets/template.html',
+    'scripts/gallery-template.html',
+    'scripts/guide-template.html',
+    'scripts/start-template.html',
+    'docs/index.html',
+    'archify/renderers/shared/geometry.mjs',
+  ]) {
+    assert.equal(
+      linguistGenerated(sourcePath),
+      'unspecified',
+      `${sourcePath} must remain visible as implementation source`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- mark generated diagram artifacts and built documentation outputs as `linguist-generated`
- keep renderer templates, the hand-authored landing page, and implementation source visible to GitHub Linguist
- clarify the Node.js → typed JSON IR → deterministic HTML/SVG compilation path in the English and Chinese README introductions
- add a regression test for representative generated and source paths

## Expected repository effect

The tracked-file simulation leaves about 1.56 MB of Linguist-visible JavaScript and 0.84 MB of Linguist-visible HTML, so GitHub should classify JavaScript as the primary language after merge and recalculation.

## Validation

- `node --test archify/test/repository-language-metadata.test.mjs archify/test/readme-showcase.test.mjs archify/test/cursor-onboarding.test.mjs`
- `node scripts/check-release-identity.mjs`
- `git diff --check`
- `npm test --prefix archify` — 714 passed, 0 failed, 21 skipped
