### PR TITLE
fix(repo): check out tracked text files as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,14 @@
+# Checked-in artifacts are compared byte-for-byte against renderer output and
+# staged into the canonical archify.zip. A CRLF checkout rewrites those bytes,
+# so pin every text file to LF in the working tree regardless of core.autocrlf.
+* text=auto eol=lf
+
+# Binary payloads must never be line-ending converted.
+*.gif binary
+*.jpg binary
+*.png binary
+*.zip binary
+
 # Generated diagram artifacts and built documentation surfaces.
 # Keep renderer/viewer templates and the hand-authored landing page visible to Linguist.
 /archify/examples/*.html linguist-generated=true

--- a/archify/test/repository-line-endings.test.mjs
+++ b/archify/test/repository-line-endings.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function trackedFilesConvertedToCrlf() {
+  const output = execFileSync('git', ['ls-files', '--eol'], { cwd: repoRoot, encoding: 'utf8' });
+  return output
+    .split('\n')
+    .filter((line) => /\bw\/crlf\b/.test(line))
+    .map((line) => line.slice(line.indexOf('\t') + 1).trim());
+}
+
+test('tracked text files check out as LF so working-tree bytes match the index', () => {
+  const converted = trackedFilesConvertedToCrlf();
+  assert.deepEqual(
+    converted,
+    [],
+    `checked out with CRLF, so these no longer match their committed bytes and cannot be compared against renderer output or staged into archify.zip:\n${converted.join('\n')}`,
+  );
+});


### PR DESCRIPTION
## Problem and value

Fixes #144.

`.gitattributes` marks generated artifacts `linguist-generated=true` but sets no `text`/`eol` attribute. With `core.autocrlf=true` — the Git for Windows installer default — a fresh clone materializes 373 tracked files with CRLF while the index stores LF. `git status` stays clean, so the divergence is invisible:

```console
$ git show HEAD:examples/checkout-platform-delta.html | head -c 16 | od -c
0000000   <   !   d   o   c   t   y   p   e       h   t   m   l   >  \n

$ head -c 16 examples/checkout-platform-delta.html | od -c
0000000   <   !   d   o   c   t   y   p   e       h   t   m   l   >  \r
```

Two consequences. Tests that compare renderer output against a checked-in artifact fail on bytes that were never actually different in the repository. And `scripts/build-zip.sh` stages tracked content, so a CRLF checkout feeds different bytes into `archify.zip` — a second byte representation of identical logical contents, which is the outcome the Node 22 pin in the zip builder exists to prevent (#119, #129). `build-zip.sh` is itself checked out with CRLF.

`windows-latest` is in the `package-smoke` matrix in `.github/workflows/ci.yml` and in `.github/workflows/dsh.yml`, so this is a supported target.

## Scope

- **What changed:** `.gitattributes` pins text files to `eol=lf` and marks `.gif` / `.jpg` / `.png` / `.zip` as `binary`. Adds `archify/test/repository-line-endings.test.mjs`, which asserts no tracked file materializes with CRLF.
- **What deliberately did not change:** no renderer, schema, validator, CLI, viewer, or typed JSON behavior. No file contents were renormalized. The existing `linguist-generated` rules are untouched. The four pre-existing Windows packaging failures are left alone — they are a separate concern overlapping #132.
- **No unrelated changes:** confirmed. Two commits, two files.

## Stability impact

- **Compatibility and migration risk:** none for the index. Every tracked file is already stored as LF — `git ls-files --eol | grep -c "i/crlf"` returns `0` — so this renormalizes nothing and produces no diff churn. It only stops the checkout filter from rewriting bytes on the way out. Linux and macOS checkouts are already LF and are unaffected. No tracked `.bat`, `.cmd`, or `.ps1` files exist that would want CRLF.
- **Renderer, validator, package, or generated-artifact risk:** none. `archify.zip` is unchanged and remains fresh: `scripts/build-zip.sh` excludes `archify/test` and `archify/test/*` explicitly, and the archive contains no test files, so the added test cannot enter the package. No skill runtime, schema, renderer, or `SKILL.md` content changed.
- **Failure behavior and rollback path:** the new test fails closed, listing every offending path. Rollback is reverting the two commits; because the index is untouched, a revert restores the previous behavior exactly.

Contributors who already have a CRLF working tree need one refresh to pick up the corrected attributes:

```bash
git ls-files -z | xargs -0 rm -f
git checkout -- .
```

## Tests run

All on Windows 11, Node v22.15.1, npm 11.3.0, Git 2.49.0, `core.autocrlf=true`, base `9a50605`.

Baseline on `main`, before the change:

```
cd archify && npm test
# tests 735
# pass 699
# fail 15
# skipped 21
```

After the change:

```
cd archify && npm test
# tests 736
# pass 711
# fail 4
# skipped 21
```

Eleven failures cleared. The 4 that remain are present on `main` before this change and are untouched by it: `archive build excludes untracked files and external symlinks from the live working tree`, `archive build is byte-for-byte reproducible across caller time zones without system zip`, `cli: preview runs from an installed skill without node_modules and exits cleanly`, `package smoke rejects every dependency metadata field in a built package`.

Targeted regression test, verified red then green:

```
# with .gitattributes from main, one file re-materialized
cd archify && node --test test/repository-line-endings.test.mjs
# tests 1
# pass 0
# fail 1

# with this change
cd archify && node --test test/repository-line-endings.test.mjs
# tests 1
# pass 1
# fail 0
```

Working tree verified after the change:

```console
$ git ls-files --eol | grep -c "w/crlf"
0
$ git status --porcelain
                                   # clean
```

One unrelated flake to report honestly: `benchmark never accepts a visual pass without an identified reviewer` (`test/ordinary-model-floor.test.mjs`) failed once with `INTERNAL_ERROR: Unexpected end of JSON input` — the spawned `verify` process's stdout read back truncated under `--test-concurrency=2`. It passed 18/18 in isolation and did not recur in the final run. It is not related to this change, and I did not attempt to fix it here.

## Visual evidence

Not applicable. No rendered output changes; this affects only the bytes a checkout writes to disk. Visual review: **skipped** — no visible surface is touched.

## Generated artifacts

None regenerated. `archify.zip` remains fresh because no skill runtime, schema, renderer, or `SKILL.md` content changed, and `scripts/build-zip.sh` excludes `archify/test` so the added test is not packaged. No Gallery, guide, start-page, or README proof inputs changed.

## Checklist

- [x] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [x] I ran the relevant targeted tests and `npm test` in `archify/`.
- [x] I added or updated a regression test for behavioral changes.
- [x] I checked generated artifacts and package freshness when their sources changed.
- [x] I removed secrets, private repository content, and customer data from fixtures and screenshots.
