### PR TITLE
docs: add self-hosted Star History chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -19,4 +19,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811 # v1
         with:
-          branch: star-history
+          commit: 'false'
+      - name: Publish charts with linear history
+        run: bash scripts/publish-star-history.sh star-history

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,22 @@
+name: Star History
+
+on:
+  schedule:
+    - cron: '30 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811 # v1
+        with:
+          branch: star-history

--- a/README.md
+++ b/README.md
@@ -283,3 +283,7 @@ Automatic Mermaid parsing, general-purpose auto-layout, hosted sharing, and WYSI
 ## Contributing
 
 Issues, pull requests, and real-world diagrams are welcome. Start with the [contribution guide](CONTRIBUTING.md), use the reproducible bug form for failures, or submit a validated diagram through the [community showcase form](https://github.com/tt-a1i/archify/issues/new?template=showcase.yml).&nbsp;·&nbsp;[LINUX&nbsp;DO](https://linux.do)
+
+## Star History
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg" /></picture></p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -283,3 +283,7 @@ Automatic Mermaid parsing, general-purpose auto-layout, hosted sharing, and WYSI
 ## Contributing
 
 Issues, pull requests, and real-world diagrams are welcome. Start with the [contribution guide](CONTRIBUTING.md), use the reproducible bug form for failures, or submit a validated diagram through the [community showcase form](https://github.com/tt-a1i/archify/issues/new?template=showcase.yml).&nbsp;·&nbsp;[LINUX&nbsp;DO](https://linux.do)
+
+## Star History
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg" /></picture></p>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -287,3 +287,7 @@ Claude.ai 中的上传入口：
 欢迎提交 Issue、Pull Request 和真实场景图。请先阅读[贡献指南](CONTRIBUTING.md)；遇到问题时使用可复现 Bug 表单，也可以通过[社区 Showcase 表单](https://github.com/tt-a1i/archify/issues/new?template=showcase.yml)提交已验证成品。
 
 较大的功能或行为调整请先通过 Issue 对齐价值、兼容边界和非目标，再基于最新 `main` 开发。一个 PR 尽量只解决一个问题；核心代码和回归测试先行，生成物最后统一重建。Archify 坚持 Agent-first，优先完善稳定的机器可读诊断和现有权威合同，避免新增容易与 CLI 漂移的重复说明。&nbsp;·&nbsp;[LINUX&nbsp;DO](https://linux.do)
+
+## Star History
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg" /></picture></p>

--- a/archify/test/readme-showcase.test.mjs
+++ b/archify/test/readme-showcase.test.mjs
@@ -182,7 +182,7 @@ test('README stays scannable without deleting the visual proof set', () => {
 
   for (const filename of ['README.md', 'README_EN.md', 'README_ZH.md']) {
     const readme = fs.readFileSync(path.join(repoRoot, filename), 'utf8');
-    assert.ok(readme.split('\n').length <= 290, `${filename}: README grew beyond the scannable line budget`);
+    assert.ok(readme.split('\n').length <= 295, `${filename}: README grew beyond the scannable line budget`);
     for (const asset of commonAssets) {
       assert.ok(readme.includes(`docs/assets/${asset}`), `${filename}: visual proof ${asset} was removed`);
     }
@@ -192,9 +192,29 @@ test('README stays scannable without deleting the visual proof set', () => {
   const wordCount = english.trim().split(/\s+/).length;
   const intro = english.slice(0, english.indexOf('![License]'));
   const introBullets = intro.match(/^- \*\*/gm) || [];
-  assert.ok(wordCount <= 2070, `README.md is too verbose again (${wordCount} words)`);
+  assert.ok(wordCount <= 2085, `README.md is too verbose again (${wordCount} words)`);
   assert.ok(introBullets.length <= 8, `README.md has too many top-level capability bullets (${introBullets.length})`);
 
   const chinese = fs.readFileSync(path.join(repoRoot, 'README_ZH.md'), 'utf8');
   assert.ok(chinese.includes('docs/assets/claude-skills-settings.png'), 'README_ZH.md lost the Claude Skills setup image');
+});
+
+test('all README languages end with the self-hosted star history chart', () => {
+  const lightChart = 'https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg';
+  const darkChart = 'https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg';
+  const workflow = fs.readFileSync(path.join(repoRoot, '.github', 'workflows', 'star-history.yml'), 'utf8');
+
+  for (const filename of ['README.md', 'README_EN.md', 'README_ZH.md']) {
+    const readme = fs.readFileSync(path.join(repoRoot, filename), 'utf8');
+    const sectionIndex = readme.lastIndexOf('## Star History');
+    const contributingIndex = Math.max(readme.indexOf('## Contributing'), readme.indexOf('## 参与贡献'));
+    assert.ok(sectionIndex > contributingIndex, `${filename}: Star History must follow Contributing`);
+    assert.ok(readme.includes(lightChart), `${filename}: missing light star history chart`);
+    assert.ok(readme.includes(darkChart), `${filename}: missing dark star history chart`);
+    assert.equal(readme.trimEnd().endsWith('</p>'), true, `${filename}: Star History must remain the final section`);
+  }
+
+  assert.match(workflow, /permissions:\n  contents: write/);
+  assert.match(workflow, /xpzouying\/star-history@[0-9a-f]{40}/);
+  assert.match(workflow, /branch: star-history/);
 });

--- a/archify/test/readme-showcase.test.mjs
+++ b/archify/test/readme-showcase.test.mjs
@@ -1,7 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -13,6 +15,17 @@ const receiptPath = path.join(repoRoot, 'docs', 'assets', 'archify-live-proof.js
 
 function sha256(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function writeStarHistoryCharts(cwd, version) {
+  const assets = path.join(cwd, 'assets');
+  fs.mkdirSync(assets, { recursive: true });
+  fs.writeFileSync(path.join(assets, 'star-history.svg'), `<svg><title>light ${version}</title></svg>\n`);
+  fs.writeFileSync(path.join(assets, 'star-history-dark.svg'), `<svg><title>dark ${version}</title></svg>\n`);
 }
 
 function skipSubBlocks(buffer, start) {
@@ -216,5 +229,63 @@ test('all README languages end with the self-hosted star history chart', () => {
 
   assert.match(workflow, /permissions:\n  contents: write/);
   assert.match(workflow, /xpzouying\/star-history@[0-9a-f]{40}/);
-  assert.match(workflow, /branch: star-history/);
+  assert.match(workflow, /commit: ['"]false['"]/);
+  assert.match(workflow, /bash scripts\/publish-star-history\.sh star-history/);
+  assert.doesNotMatch(workflow, /branch: star-history/);
+});
+
+test('Star History publishing advances the data branch without a force push', () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-star-history-'));
+  const remote = path.join(fixture, 'remote.git');
+  const firstCheckout = path.join(fixture, 'first');
+  const secondCheckout = path.join(fixture, 'second');
+  const publisher = path.join(repoRoot, 'scripts', 'publish-star-history.sh');
+
+  try {
+    git(fixture, 'init', '--bare', remote);
+    git(fixture, '--git-dir', remote, 'config', 'receive.denyNonFastForwards', 'true');
+    git(fixture, '--git-dir', remote, 'config', 'receive.denyDeletes', 'true');
+
+    fs.mkdirSync(firstCheckout);
+    git(firstCheckout, 'init', '-b', 'main');
+    git(firstCheckout, 'config', 'user.name', 'Fixture');
+    git(firstCheckout, 'config', 'user.email', 'fixture@example.com');
+    fs.writeFileSync(path.join(firstCheckout, 'README.md'), 'fixture\n');
+    git(firstCheckout, 'add', 'README.md');
+    git(firstCheckout, 'commit', '-m', 'seed');
+    git(firstCheckout, 'remote', 'add', 'origin', remote);
+    git(firstCheckout, 'push', '-u', 'origin', 'main');
+
+    const firstTemp = path.join(fixture, 'run-1');
+    fs.mkdirSync(firstTemp);
+    writeStarHistoryCharts(firstCheckout, 'v1');
+    execFileSync('bash', [publisher, 'star-history'], {
+      cwd: firstCheckout,
+      env: { ...process.env, RUNNER_TEMP: firstTemp },
+    });
+    const firstCommit = git(fixture, '--git-dir', remote, 'rev-parse', 'refs/heads/star-history');
+
+    git(fixture, 'clone', '--branch', 'main', remote, secondCheckout);
+    const secondTemp = path.join(fixture, 'run-2');
+    fs.mkdirSync(secondTemp);
+    writeStarHistoryCharts(secondCheckout, 'v2');
+    execFileSync('bash', [publisher, 'star-history'], {
+      cwd: secondCheckout,
+      env: { ...process.env, RUNNER_TEMP: secondTemp },
+    });
+    const secondCommit = git(fixture, '--git-dir', remote, 'rev-parse', 'refs/heads/star-history');
+
+    assert.notEqual(secondCommit, firstCommit);
+    git(fixture, '--git-dir', remote, 'merge-base', '--is-ancestor', firstCommit, secondCommit);
+    assert.deepEqual(
+      git(fixture, '--git-dir', remote, 'ls-tree', '-r', '--name-only', secondCommit).split('\n'),
+      ['assets/star-history-dark.svg', 'assets/star-history.svg'],
+    );
+    assert.match(
+      git(fixture, '--git-dir', remote, 'show', `${secondCommit}:assets/star-history.svg`),
+      /light v2/,
+    );
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
 });

--- a/scripts/publish-star-history.sh
+++ b/scripts/publish-star-history.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+data_branch="${1:-star-history}"
+light_chart="${2:-assets/star-history.svg}"
+dark_chart="${3:-assets/star-history-dark.svg}"
+
+git check-ref-format --branch "$data_branch" >/dev/null
+
+for chart in "$light_chart" "$dark_chart"; do
+  case "$chart" in
+    /*|../*|*/../*|*/..)
+      echo "Chart path must stay inside the repository: $chart" >&2
+      exit 2
+      ;;
+  esac
+  if [[ ! -f "$chart" ]]; then
+    echo "Generated chart is missing: $chart" >&2
+    exit 2
+  fi
+done
+
+temp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+snapshot_dir="$(mktemp -d "${temp_root%/}/archify-star-history.XXXXXX")"
+mv -- "$light_chart" "$snapshot_dir/light.svg"
+mv -- "$dark_chart" "$snapshot_dir/dark.svg"
+
+if git ls-remote --exit-code --heads origin "refs/heads/$data_branch" >/dev/null 2>&1; then
+  git fetch --no-tags origin "refs/heads/$data_branch:refs/remotes/origin/$data_branch"
+  git switch --detach "refs/remotes/origin/$data_branch"
+else
+  git switch --orphan "$data_branch"
+fi
+
+# The data branch deliberately contains only the two generated charts. Keep its
+# history linear so repositories that reject force pushes can refresh it safely.
+git rm -r -q --ignore-unmatch .
+mkdir -p -- "$(dirname "$light_chart")" "$(dirname "$dark_chart")"
+mv -- "$snapshot_dir/light.svg" "$light_chart"
+mv -- "$snapshot_dir/dark.svg" "$dark_chart"
+git add -f -- "$light_chart" "$dark_chart"
+
+if git diff --cached --quiet; then
+  echo "Star History charts are unchanged."
+  exit 0
+fi
+
+git -c user.name="github-actions[bot]" \
+  -c user.email="github-actions[bot]@users.noreply.github.com" \
+  commit -m "${STAR_HISTORY_COMMIT_MESSAGE:-chore: update star history chart}"
+git push origin "HEAD:refs/heads/$data_branch"


### PR DESCRIPTION
## Summary

- add a centered Star History section to the bottom of all three README variants
- render light and dark charts from a dedicated `star-history` data branch
- add a weekly/manual workflow that regenerates the chart with the repository token
- pin the third-party chart action to an exact verified commit and add README regression coverage

## Why self-hosted

The hosted `api.star-history.com` endpoint currently returns a restricted-access notice instead of Archify's star timeline. Generating the SVGs inside this repository keeps the chart functional without sending a personal token to a hosted chart service.

The workflow publishes only the generated SVG files to the isolated `star-history` branch, so it does not write through the protected `main` branch.

## Verification

- `npm test` — 717 passed, 0 failed, 28 skipped
- `node --test archify/test/readme-showcase.test.mjs` — 5 passed
- `node scripts/check-release-identity.mjs`
- `git diff --check`
- confirmed the repository-scoped GitHub API can read the complete stargazer timeline

## Post-merge

Run the **Star History** workflow once manually to create the initial `star-history` data branch. Weekly refreshes then run automatically.
