### PR TITLE
fix(ci): create Star History output directory

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Prepare chart output directory
+        run: mkdir -p assets
       - uses: xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811 # v1
         with:
           commit: 'false'

--- a/archify/test/readme-showcase.test.mjs
+++ b/archify/test/readme-showcase.test.mjs
@@ -232,6 +232,10 @@ test('all README languages end with the self-hosted star history chart', () => {
   assert.match(workflow, /commit: ['"]false['"]/);
   assert.match(workflow, /bash scripts\/publish-star-history\.sh star-history/);
   assert.doesNotMatch(workflow, /branch: star-history/);
+  const prepareOutputIndex = workflow.indexOf('run: mkdir -p assets');
+  const generateChartIndex = workflow.indexOf('uses: xpzouying/star-history@');
+  assert.ok(prepareOutputIndex >= 0, 'Star History workflow must create the chart output directory');
+  assert.ok(prepareOutputIndex < generateChartIndex, 'Star History output directory must exist before generation');
 });
 
 test('Star History publishing advances the data branch without a force push', () => {


### PR DESCRIPTION
## Summary

- create the `assets` output directory before invoking the pinned Star History generator
- add a regression assertion that preparation exists and precedes generation

## Root cause

The first post-merge workflow successfully fetched all 24,179 stargazer records, then failed because the action writes directly to `assets/star-history.svg` without creating the parent directory.

## Verification

- reproduced the missing-directory failure in run `33142759462`
- `node --test archify/test/readme-showcase.test.mjs` — 6 passed
- `bash -n scripts/publish-star-history.sh`
- `node scripts/check-release-identity.mjs`
- `git diff --check`
