### PR TITLE
docs: use official-style Star History chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare chart output directory
-        run: mkdir -p assets
-      - uses: xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811 # v1
+      - uses: narayann7/star-history-action@a68d8f9d67ca20d55b682a264e69152dcf326e9c # v1.0.5
         with:
+          output-dir: assets
+          update-readme: 'false'
           commit: 'false'
       - name: Publish charts with linear history
         run: bash scripts/publish-star-history.sh star-history

--- a/README.md
+++ b/README.md
@@ -286,4 +286,4 @@ Issues, pull requests, and real-world diagrams are welcome. Start with the [cont
 
 ## Star History
 
-<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg" /></picture></p>
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-light.svg" /></picture></p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -286,4 +286,4 @@ Issues, pull requests, and real-world diagrams are welcome. Start with the [cont
 
 ## Star History
 
-<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg" /></picture></p>
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-light.svg" /></picture></p>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -290,4 +290,4 @@ Claude.ai 中的上传入口：
 
 ## Star History
 
-<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg" /></picture></p>
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg" /><img alt="Star History" src="https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-light.svg" /></picture></p>

--- a/archify/test/readme-showcase.test.mjs
+++ b/archify/test/readme-showcase.test.mjs
@@ -24,7 +24,7 @@ function git(cwd, ...args) {
 function writeStarHistoryCharts(cwd, version) {
   const assets = path.join(cwd, 'assets');
   fs.mkdirSync(assets, { recursive: true });
-  fs.writeFileSync(path.join(assets, 'star-history.svg'), `<svg><title>light ${version}</title></svg>\n`);
+  fs.writeFileSync(path.join(assets, 'star-history-light.svg'), `<svg><title>light ${version}</title></svg>\n`);
   fs.writeFileSync(path.join(assets, 'star-history-dark.svg'), `<svg><title>dark ${version}</title></svg>\n`);
 }
 
@@ -213,7 +213,7 @@ test('README stays scannable without deleting the visual proof set', () => {
 });
 
 test('all README languages end with the self-hosted star history chart', () => {
-  const lightChart = 'https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history.svg';
+  const lightChart = 'https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-light.svg';
   const darkChart = 'https://raw.githubusercontent.com/tt-a1i/archify/star-history/assets/star-history-dark.svg';
   const workflow = fs.readFileSync(path.join(repoRoot, '.github', 'workflows', 'star-history.yml'), 'utf8');
 
@@ -228,14 +228,13 @@ test('all README languages end with the self-hosted star history chart', () => {
   }
 
   assert.match(workflow, /permissions:\n  contents: write/);
-  assert.match(workflow, /xpzouying\/star-history@[0-9a-f]{40}/);
+  assert.match(workflow, /narayann7\/star-history-action@[0-9a-f]{40}/);
+  assert.match(workflow, /output-dir: assets/);
+  assert.match(workflow, /update-readme: ['"]false['"]/);
   assert.match(workflow, /commit: ['"]false['"]/);
   assert.match(workflow, /bash scripts\/publish-star-history\.sh star-history/);
   assert.doesNotMatch(workflow, /branch: star-history/);
-  const prepareOutputIndex = workflow.indexOf('run: mkdir -p assets');
-  const generateChartIndex = workflow.indexOf('uses: xpzouying/star-history@');
-  assert.ok(prepareOutputIndex >= 0, 'Star History workflow must create the chart output directory');
-  assert.ok(prepareOutputIndex < generateChartIndex, 'Star History output directory must exist before generation');
+  assert.doesNotMatch(workflow, /xpzouying\/star-history/);
 });
 
 test('Star History publishing advances the data branch without a force push', () => {
@@ -283,10 +282,10 @@ test('Star History publishing advances the data branch without a force push', ()
     git(fixture, '--git-dir', remote, 'merge-base', '--is-ancestor', firstCommit, secondCommit);
     assert.deepEqual(
       git(fixture, '--git-dir', remote, 'ls-tree', '-r', '--name-only', secondCommit).split('\n'),
-      ['assets/star-history-dark.svg', 'assets/star-history.svg'],
+      ['assets/star-history-dark.svg', 'assets/star-history-light.svg'],
     );
     assert.match(
-      git(fixture, '--git-dir', remote, 'show', `${secondCommit}:assets/star-history.svg`),
+      git(fixture, '--git-dir', remote, 'show', `${secondCommit}:assets/star-history-light.svg`),
       /light v2/,
     );
   } finally {

--- a/scripts/publish-star-history.sh
+++ b/scripts/publish-star-history.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 data_branch="${1:-star-history}"
-light_chart="${2:-assets/star-history.svg}"
+light_chart="${2:-assets/star-history-light.svg}"
 dark_chart="${3:-assets/star-history-dark.svg}"
 
 git check-ref-format --branch "$data_branch" >/dev/null


### PR DESCRIPTION
## Summary

- replace the plain area chart with the recognizable official Star History xkcd-style renderer
- keep light/dark SVGs on the existing linear `star-history` data branch
- pin the external action to the verified v1.0.5 commit and disable its README/commit mutations
- update the publishing regression for the renderer's stable filenames

## Verification

- `node --test archify/test/readme-showcase.test.mjs` (6/6 passed)
- `npm test --prefix archify` (718 passed, 28 browser-dependent skipped, 0 failed)
- Impeccable detector: no findings
- locally rendered both themes against `tt-a1i/archify` using the pinned action
