### PR TITLE
fix(architecture): prefer straight routes over unnecessary Port Spread doglegs

### DIFF
--- a/archify/renderers/architecture/render-architecture.mjs
+++ b/archify/renderers/architecture/render-architecture.mjs
@@ -745,6 +745,7 @@ function sideAwareBridgeCandidates(start, end, fromSide, toSide) {
 
 const AUTOMATIC_PORT_CORNER_GUTTER = 16;
 const AUTOMATIC_PORT_ALIGNMENT_DELTA = 16;
+const AUTOMATIC_PORT_DISTINCT_EPSILON = 0.5;
 
 function portHasCornerClearance(rect, side, point) {
   if (side === 'left' || side === 'right') {
@@ -756,6 +757,68 @@ function portHasCornerClearance(rect, side, point) {
     return point[0] >= rect.x + inset && point[0] <= rect.x + rect.width - inset;
   }
   return false;
+}
+
+// A spread port is distinct when no other relationship occupies the same slot
+// on the same component side. Compared against the shared spread map so the
+// check stays deterministic regardless of connection input order.
+function spreadPortIsDistinct(rect, side, point, exceptConn) {
+  for (const [relation, endpoints] of automaticPorts) {
+    if (relation === exceptConn || !endpoints) continue;
+    const sides = connectionSides(relation);
+    const competitors = [];
+    if (relation.from === rect.id && sides.fromSide === side && endpoints.from) competitors.push(endpoints.from);
+    if (relation.to === rect.id && sides.toSide === side && endpoints.to) competitors.push(endpoints.to);
+    for (const competitor of competitors) {
+      if (Math.hypot(competitor[0] - point[0], competitor[1] - point[1]) < AUTOMATIC_PORT_DISTINCT_EPSILON) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// When both endpoints already occupy shared spread slots, prefer a zero-bend
+// shared axis for a near-aligned relationship, but only when the chosen slots
+// keep the competing ports distinct and the direct axis stays unobstructed.
+// Returns null to preserve the outside bridge when no compatible axis exists.
+function straightenSharedSpreadPorts(conn, from, to, start, end, fromSide, toSide, horizontallyFacing) {
+  const axisCoordinates = [];
+  const pushAxis = (value) => {
+    if (Number.isFinite(value)
+        && !axisCoordinates.some((existing) => Math.abs(existing - value) < AUTOMATIC_PORT_DISTINCT_EPSILON)) {
+      axisCoordinates.push(value);
+    }
+  };
+  if (horizontallyFacing) {
+    pushAxis(start[1]);
+    pushAxis(end[1]);
+    pushAxis(from.cy);
+    pushAxis(to.cy);
+    pushAxis((from.cy + to.cy) / 2);
+  } else {
+    pushAxis(start[0]);
+    pushAxis(end[0]);
+    pushAxis(from.cx);
+    pushAxis(to.cx);
+    pushAxis((from.cx + to.cx) / 2);
+  }
+  for (const coordinate of axisCoordinates) {
+    const candidate = horizontallyFacing
+      ? { start: [start[0], coordinate], end: [end[0], coordinate] }
+      : { start: [coordinate, start[1]], end: [coordinate, end[1]] };
+    const points = [candidate.start, candidate.end];
+    if (portHasCornerClearance(from, fromSide, candidate.start)
+        && portHasCornerClearance(to, toSide, candidate.end)
+        && spreadPortIsDistinct(from, fromSide, candidate.start, conn)
+        && spreadPortIsDistinct(to, toSide, candidate.end, conn)
+        && routeHonorsEndpointSides(points, fromSide, toSide)
+        && routeClearsEndpointComponents(points, from, to)
+        && routeClearsComponents(conn, points)) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 function alignFacingPorts(conn, from, to, start, end, fromSide, toSide, ports) {
@@ -778,23 +841,33 @@ function alignFacingPorts(conn, from, to, start, end, fromSide, toSide, ports) {
 
   const fromSpread = Boolean(ports?.from);
   const toSpread = Boolean(ports?.to);
-  if (fromSpread && toSpread) return { start, end };
+  const alignmentDelta = horizontallyFacing
+    ? Math.abs(start[1] - end[1])
+    : Math.abs(start[0] - end[0]);
+
+  if (fromSpread && toSpread) {
+    // Both endpoints already occupy shared spread slots. When the relationship
+    // is near-aligned, prefer a zero-bend shared axis if compatible slots keep
+    // the competing ports distinct; otherwise preserve the outside bridge.
+    if (alignmentDelta < AUTOMATIC_PORT_ALIGNMENT_DELTA) {
+      const straightened = straightenSharedSpreadPorts(
+        conn, from, to, start, end, fromSide, toSide, horizontallyFacing,
+      );
+      if (straightened) return straightened;
+    }
+    return { start, end };
+  }
   const hasExplicitSides = (
     (conn.fromSide && conn.fromSide !== 'auto')
     || (conn.toSide && conn.toSide !== 'auto')
   );
   if (!fromSpread && !toSpread && hasExplicitSides) return { start, end };
 
-  const alignmentDelta = horizontallyFacing
-    ? Math.abs(start[1] - end[1])
-    : Math.abs(start[0] - end[0]);
   if (alignmentDelta >= AUTOMATIC_PORT_ALIGNMENT_DELTA) return { start, end };
 
   // Keep the shared endpoint's distinct spread slot and move only the
   // relationship's unshared endpoint onto that axis. With no spread endpoint,
   // retain the existing least-movement choice between the two facing sides.
-  // If both endpoints are shared, preserve the outside bridge so no competing
-  // port is silently collapsed.
   const alignEndToStart = horizontallyFacing
     ? { start, end: [end[0], start[1]] }
     : { start, end: [start[0], end[1]] };

--- a/archify/test/automatic-port-spread.test.mjs
+++ b/archify/test/automatic-port-spread.test.mjs
@@ -176,8 +176,8 @@ test('architecture: incoming and outgoing relationships keep distinct bottom por
   );
 });
 
-test('architecture: a near-aligned relationship keeps the outside bridge when both endpoints are spread', () => {
-  const html = render('architecture', {
+test('architecture: an unobstructed doubly spread facing relationship keeps one straight axis', () => {
+  const doc = {
     schema_version: 1,
     diagram_type: 'architecture',
     meta: { title: 'Two-sided port competition' },
@@ -192,11 +192,59 @@ test('architecture: a near-aligned relationship keeps the outside bridge when bo
       { id: 'source-peer-target', from: 'source-peer', to: 'target', fromSide: 'top', toSide: 'bottom' },
       { id: 'source-target-peer', from: 'source', to: 'target-peer', fromSide: 'top', toSide: 'bottom' },
     ],
-  });
+  };
+  const forward = render('architecture', doc);
+  const reversed = render('architecture', { ...doc, connections: [...doc.connections].reverse() });
 
-  const points = connectionPoints(html, 'source-target');
-  assert.ok(points.length > 2);
-  assert.notEqual(points[0][0], points.at(-1)[0]);
+  const points = connectionPoints(forward, 'source-target');
+  assert.deepEqual(points, [[380, 320], [380, 160]]);
+
+  // Competing ports stay distinct from the straightened shared axis.
+  assert.notEqual(connectionPoints(forward, 'source-peer-target').at(-1)[0], points[0][0]);
+  assert.notEqual(connectionPoints(forward, 'source-target-peer')[0][0], points[0][0]);
+
+  for (const connection of doc.connections) {
+    assert.deepEqual(
+      connectionPoints(forward, connection.id),
+      connectionPoints(reversed, connection.id),
+      `${connection.id} moved after input reordering`,
+    );
+  }
+});
+
+test('architecture: an unobstructed doubly spread horizontal relationship keeps one straight axis', () => {
+  const doc = {
+    schema_version: 1,
+    diagram_type: 'architecture',
+    meta: { title: 'Two-sided horizontal port competition' },
+    components: [
+      { id: 'source', type: 'backend', label: 'Source', pos: [80, 300], size: [160, 60] },
+      { id: 'source-peer', type: 'backend', label: 'Source peer', pos: [80, 100], size: [160, 60] },
+      { id: 'target', type: 'database', label: 'Target', pos: [500, 300], size: [160, 60] },
+      { id: 'target-peer', type: 'database', label: 'Target peer', pos: [500, 500], size: [160, 60] },
+    ],
+    connections: [
+      { id: 'source-target', from: 'source', to: 'target', fromSide: 'right', toSide: 'left' },
+      { id: 'source-peer-target', from: 'source-peer', to: 'target', fromSide: 'right', toSide: 'left' },
+      { id: 'source-target-peer', from: 'source', to: 'target-peer', fromSide: 'right', toSide: 'left' },
+    ],
+  };
+  const forward = render('architecture', doc);
+  const reversed = render('architecture', { ...doc, connections: [...doc.connections].reverse() });
+
+  const points = connectionPoints(forward, 'source-target');
+  assert.deepEqual(points, [[240, 330], [500, 330]]);
+
+  assert.notEqual(connectionPoints(forward, 'source-peer-target').at(-1)[1], points[0][1]);
+  assert.notEqual(connectionPoints(forward, 'source-target-peer')[0][1], points[0][1]);
+
+  for (const connection of doc.connections) {
+    assert.deepEqual(
+      connectionPoints(forward, connection.id),
+      connectionPoints(reversed, connection.id),
+      `${connection.id} moved after input reordering`,
+    );
+  }
 });
 
 test('architecture: a singly spread near-aligned relationship keeps the bridge when its direct axis is blocked', () => {


### PR DESCRIPTION
## User problem

Fixes #137.

Architecture auto-routing preserved a conspicuous shallow dogleg for an unobstructed, near-aligned relationship whenever **both** endpoints participated in Automatic Port Spread. `alignFacingPorts()` returned the two independently selected spread slots unchanged, and the router then emitted an outside-channel bridge. With the shared 8px corner radius the result read as a small S-curve, i.e. routing noise, even though a straight segment was available.

## What changes

- `alignFacingPorts()` (architecture renderer) now treats the doubly-spread, near-aligned facing case as a joint port+route optimization instead of an unconditional early return.
- New `straightenSharedSpreadPorts()` tries an ordered, deterministic list of shared-axis coordinates (the relationship's own two spread slots first, then the component centers/midpoint) and accepts the first candidate that satisfies **all** existing gates: corner clearance, endpoint-side direction contract, endpoint-component clearance, and obstacle clearance — plus a new port-distinctness check.
- New `spreadPortIsDistinct()` ensures the chosen slot does not collapse onto a competing relationship's spread slot on the same component side (compared against the shared spread map, so the result is independent of connection input order).
- Regression test updated: the fixture from #137 now asserts a two-point straight route (`[[380,320],[380,160]]`), distinct competing ports, and stability under reversed connection input order. A horizontal (left/right) variant is added.

## What deliberately does not change

- Singly-spread and unspread alignment behavior is untouched.
- The blocked-axis case still routes around the obstacle via the outside bridge (the straightening candidate fails the obstacle-clearance check and falls back).
- Explicit authored geometry (`via`, named `route`, `channelX`/`channelY`, `labelAt`) still bypasses automatic alignment entirely.
- No schema, diagnostic-code, or CLI changes.

## Compatibility and migration impact

None. This only improves route selection for a specific automatic-routing configuration; authored geometry and validation rules are unchanged. Existing schema-v1 documents remain valid.

## Failure behavior and rollback path

If no compatible distinct axis exists (axis blocked, or every candidate would collide with a competing port or violate corner/side clearance), the function returns `null` and the previous outside-bridge route is preserved. Reverting the single commit restores the prior behavior.

## Evidence

- `node --test test/automatic-port-spread.test.mjs` — 16/16 pass (includes updated #137 fixture + new horizontal + reversed-order determinism checks).
- Full `npm test` in `archify/` (brand marks, validators, release identity, golden, and the full suite including showcase composition gates): **747 tests, 719 pass, 0 fail, 28 skipped** (skips are `ARCHIFY_CHROME` browser-only regressions).
- Rendered #137 fixture before/after:
  - before: `source-target -> 373,320;373,296;403,296;403,184;387,184;387,160` (6-point outside bridge)
  - after: `source-target -> 380,320;380,160` (straight), while `source-peer-target` and `source-target-peer` keep their distinct ports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Architecture connections now use straighter, zero-bend routes when ports are near-aligned and the shared path is unobstructed.
  * Port separation is preserved to prevent routing ambiguity.
  * Connections retain their outside route when the shared axis is blocked.
  * Routing results remain consistent regardless of input ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->