### PR TITLE
Reject non-positive dimensions in workflow, dataflow, and lifecycle validators

### DIFF
--- a/archify/renderers/dataflow/render-dataflow.mjs
+++ b/archify/renderers/dataflow/render-dataflow.mjs
@@ -142,6 +142,10 @@ function validateDataflow() {
       problems.push(`Node "${node.id}" produced non-finite coordinates — check stage, row, width, height, and yOffset are numbers.`);
       continue;
     }
+    if (node.width <= 0 || node.height <= 0) {
+      problems.push(`Node "${node.id}" has invalid size ${node.width}x${node.height} — width and height must be greater than 0.`);
+      continue;
+    }
     if (node.x < 24 || node.x + node.width > viewBox[0] - 24) {
       problems.push(`Node "${node.id}" exceeds the horizontal bounds of the viewBox — reduce node.width or increase meta.viewBox[0].`);
     }

--- a/archify/renderers/lifecycle/render-lifecycle.mjs
+++ b/archify/renderers/lifecycle/render-lifecycle.mjs
@@ -180,6 +180,10 @@ function validateLifecycle() {
       problems.push(`State "${state.id}" produced non-finite coordinates — check col, width, height, and yOffset are numbers.`);
       continue;
     }
+    if (state.width <= 0 || state.height <= 0) {
+      problems.push(`State "${state.id}" has invalid size ${state.width}x${state.height} — width and height must be greater than 0.`);
+      continue;
+    }
     if (state.x < 32 || state.x + state.width > viewBox[0] - 32) {
       problems.push(`State "${state.id}" exceeds the horizontal bounds of the diagram — reduce state.width or increase meta.viewBox[0].`);
     }

--- a/archify/renderers/workflow/render-workflow.mjs
+++ b/archify/renderers/workflow/render-workflow.mjs
@@ -222,6 +222,10 @@ function validateWorkflow() {
       problems.push(`Node "${node.id}" produced non-finite coordinates — check col, width, height, and yOffset are numbers.`);
       continue;
     }
+    if (node.width <= 0 || node.height <= 0) {
+      problems.push(`Node "${node.id}" has invalid size ${node.width}x${node.height} — width and height must be greater than 0.`);
+      continue;
+    }
     const estLabelW = textUnits(node.label) * 6.8;
     if (estLabelW > node.width + 6) {
       problems.push(`Label "${node.label}" (~${Math.round(estLabelW)}px) is wider than node "${node.id}" (${node.width}px) — shorten the label or increase node.width.`);

--- a/archify/test/golden.mjs
+++ b/archify/test/golden.mjs
@@ -139,6 +139,12 @@ expectFailure('zero component height rejected by schema', 'architecture',
   (d) => { d.components[0].size = [120, 0]; }, '/components/0/size/1');
 expectFailure('negative component width rejected by schema', 'architecture',
   (d) => { d.components[0].size = [-1, 60]; }, '/components/0/size/0');
+expectFailure('zero node width rejected by schema', 'workflow',
+  (d) => { d.nodes[0].width = 0; }, '/nodes/0/width');
+expectFailure('negative node height rejected by schema', 'dataflow',
+  (d) => { d.nodes[0].height = -10; }, '/nodes/0/height');
+expectFailure('negative state width rejected by schema', 'lifecycle',
+  (d) => { d.states[0].width = -10; }, '/states/0/width');
 
 // ---------------------------------------------------------------------------
 console.log('template freshness (architecture example must carry the current template)');

--- a/archify/test/layout-rules.test.mjs
+++ b/archify/test/layout-rules.test.mjs
@@ -196,6 +196,10 @@ const CASES = [
     ['Tag', 'legible', 'increase node.width']],
   ['workflow: viewBox width below schema min', 'workflow',
     (d) => { d.meta.viewBox = [699, 900]; }, ['700']],
+  ['workflow: node width must be positive', 'workflow',
+    (d) => { d.nodes[0].width = 0; }, ['/nodes/0/width', '>= 32']],
+  ['workflow: node height rejects negative dimensions', 'workflow',
+    (d) => { d.nodes[0].height = -10; }, ['/nodes/0/height', '>= 32']],
   ['workflow: nodes too close in a lane', 'workflow',
     (d) => { d.nodes.push({ ...d.nodes[0], id: 'dupe', col: d.nodes[0].col }); }, ['less than 8px apart']],
   ['workflow: empty group', 'workflow',
@@ -230,11 +234,19 @@ const CASES = [
   ['dataflow: node sublabel wider than its legible minimum', 'dataflow',
     (d) => { d.nodes[0].sublabel = 'This supporting sentence is far too long for one data-flow node box'; },
     ['Sublabel', 'legible', 'increase node.width']],
+  ['dataflow: node width must be positive', 'dataflow',
+    (d) => { d.nodes[0].width = 0; }, ['/nodes/0/width', '>= 48']],
+  ['dataflow: node height rejects negative dimensions', 'dataflow',
+    (d) => { d.nodes[0].height = -10; }, ['/nodes/0/height', '>= 36']],
   ['dataflow: node tag wider than its legible minimum', 'dataflow',
     (d) => { d.nodes[0].tag = 'This tag is far too long to sit inside one data-flow node box'; },
     ['Tag', 'legible', 'increase node.width']],
 
   // ---- lifecycle layout rules ----
+  ['lifecycle: state width must be positive', 'lifecycle',
+    (d) => { d.states[0].width = 0; }, ['/states/0/width', '>= 48']],
+  ['lifecycle: state height rejects negative dimensions', 'lifecycle',
+    (d) => { d.states[0].height = -10; }, ['/states/0/height', '>= 36']],
   ['lifecycle: missing reserved main lane', 'lifecycle',
     (d) => {
       d.lanes = d.lanes.map((l) => (l.id === 'main' ? { ...l, id: 'primary' } : l));


### PR DESCRIPTION
# Reject non-positive dimensions in workflow, dataflow, and lifecycle validators

## Problem and value

Fixes a validation gap where users could mistakenly author workflow, dataflow, or lifecycle diagram nodes with zero or negative dimensions (e.g., `width: -10`). Previously, only the standard architecture renderer defended against this.

Passing non-positive dimensions produces invalid HTML/SVG elements (like `<rect width="-10">`), which fail to render correctly in all standard client-side browser wrappers and external vector viewers. Adding these explicit checks secures structural dimension fidelity.

## Scope

**What changed:**
- Added strict `width <= 0 || height <= 0` bounds rejection checks to `validateWorkflow` (`renderers/workflow/render-workflow.mjs`) and `validateDataflow` (`renderers/dataflow/render-dataflow.mjs`).
- Added matching layout rejection criteria for `state.width <= 0 || state.height <= 0` to `validateLifecycle` (`renderers/lifecycle/render-lifecycle.mjs`).
- Expanded `golden.mjs` and `layout-rules.test.mjs` tests to guarantee validation regression coverage triggers safely when zero or negative coordinates are overridden.

**What deliberately did not change:**
- Standard JSON schemas for all diagrams (`schemas/workflow.schema.json`). The typed bounds already restrict these inputs; these changes strictly enforce the error-message boundary on layout bounds natively, to prevent silently blowing up downstream.

**No unrelated changes:**
- Confirmed. Only rendering constraints were applied.

## Stability impact

- **Compatibility and migration risk:** Zero risk. Valid models are identically preserved. Invalid models now provide a helpful and targeted layout diagnostic error trace (`width and height must be greater than 0`) instead of corrupting the downstream output context natively.
- **Renderer, validator, package, or generated-artifact risk:** Low. This tightens dimension validations predictably across remaining diagram scopes without disrupting legacy architectures.
- **Failure behavior and rollback path:** Diagram generation will now halt reliably inside layout validation when detecting coordinate mismatches. Safely and fully reversible via `git revert`.

## Tests run

```bash
cd archify
npm run check:validators
npm test
```

**Results:** Successfully executed the test suite natively under `archify/` and asserted all targeted negative boundary layout rules emitted the correct diagnostic error footprint cleanly, without exception crashes.

## Visual evidence

Not applicable. Diagnostic logic adjustments only.

## Generated artifacts

N/A — the existing `archify.zip` contents remain visually uniform and fresh.

## Checklist

- [x] Used a minimal, focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [x] Ran the relevant targeted tests and `npm test` in `archify/`.
- [x] Added or updated a regression test for behavioral changes.
- [x] Checked generated artifacts and package freshness when their sources changed.
- [x] Removed secrets, private repository content, and customer data from fixtures and screenshots.