### PR TITLE
fix(packaging): normalize line endings (fixes #144)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,7 @@
 # Deterministic build outputs committed for zero-install and release verification.
 /archify/renderers/shared/generated-brand-marks.mjs linguist-generated=true
 /archify/renderers/shared/generated-validators.mjs linguist-generated=true
+
+# Normalize line endings so working-tree bytes match the index on Windows (core.autocrlf=true).
+# See issue #144: tracked files materialized as CRLF on Windows, breaking byte-exact checks.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
Fixes #144. On machines with `core.autocrlf=true` (Git for Windows default),
a fresh clone materializes tracked text files as CRLF while the index stores
LF. `git status` stays clean, so the divergence is invisible -- but byte-exact
checks (and any tool comparing working-tree bytes to the index) break.

Add `* text=auto eol=lf` so Git normalizes line endings on checkout and the
working tree matches the index regardless of the host platform. Linguist
markers for generated HTML are preserved (declared before the catch-all).

Verification: `git check-attr text <file>` returns `auto`; golden checks pass.

Note: This PR supersedes the previous PR #191 which contained unrelated changes.
Only the line-ending fix is included here.
