### PR TITLE
chore(release): publish v2.16.0 update manifest

### DIFF
--- a/docs/skill-updates/archify/stable.json
+++ b/docs/skill-updates/archify/stable.json
@@ -2,17 +2,17 @@
   "schemaVersion": 1,
   "skillId": "archify",
   "channel": "stable",
-  "version": "2.15.0",
-  "publishedAt": "2026-08-17T15:47:24Z",
+  "version": "2.16.0",
+  "publishedAt": "2026-08-30T11:13:26Z",
   "source": {
     "repository": "https://github.com/tt-a1i/archify",
-    "ref": "v2.15.0",
-    "treeSha": "f748f9d0c4833061d657a55cbcd9707aecc73234"
+    "ref": "v2.16.0",
+    "treeSha": "a198a3e0d03cd08eb582062a52dc4b0bd5b0aa4f"
   },
   "artifact": {
-    "sha256": "156f0d3cd6ba11706344683e3d94e6b6b44b5732bd3c8c81b75c267c3f5d04c4"
+    "sha256": "4c59fa6557a2385beaaef8c7219cc414573acc9f0c30a932d5053b0b20689a46"
   },
-  "summary": "Adds authored brand identity, sequence column fitting, and the DeepSeek Harness distribution.",
-  "releaseNotes": "https://github.com/tt-a1i/archify/releases/tag/v2.15.0",
+  "summary": "Adds constraint-driven compilation and update awareness, improves multilingual authoring and viewer behavior, and hardens reproducible releases.",
+  "releaseNotes": "https://github.com/tt-a1i/archify/releases/tag/v2.16.0",
   "severity": "normal"
 }


### PR DESCRIPTION
Publishes the stable update manifest only after the v2.16.0 GitHub Release exists.

Binds the public notifier to:
- annotated tag `v2.16.0` / Skill tree `a198a3e0d03cd08eb582062a52dc4b0bd5b0aa4f`
- released `archify.zip` SHA-256 `4c59fa6557a2385beaaef8c7219cc414573acc9f0c30a932d5053b0b20689a46`
- canonical tagger timestamp and official release notes

Validation:
- `check-stable-update-manifest`: passed against the exact tag and archive
- full test suite: 979 passed, 0 failed, 31 environment-gated skips