### PR TITLE
fix(site): localize page identity and diagram filters

### DIFF
--- a/archify/test/site-language-continuity.test.mjs
+++ b/archify/test/site-language-continuity.test.mjs
@@ -9,6 +9,7 @@ import vm from 'node:vm';
 import { fileURLToPath } from 'node:url';
 
 import { ChromeVisualBrowser, findChrome } from '../bin/visual-check.mjs';
+import { DIAGRAM_TYPES, DIAGRAM_TYPE_LABELS } from '../../scripts/site-copy.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../..');
@@ -300,6 +301,78 @@ test('all site pages consume one language runtime and one navigation contract', 
   assert.match(navigation, /@media \(max-width: 640px\)/);
 });
 
+test('site page identity paths localize with the selected language', () => {
+  const pages = [
+    { paths: ['scripts/guide-template.html', 'docs/guide.html'], en: '/ guide', zh: '/ 场景指南' },
+    { paths: ['scripts/gallery-template.html', 'docs/gallery.html'], en: '/ proof lab', zh: '/ 验证作品集' },
+    { paths: ['scripts/start-template.html', 'docs/start.html'], en: '/ start', zh: '/ 快速上手' },
+  ];
+
+  for (const page of pages) {
+    for (const relative of page.paths) {
+      const html = fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+      assert.ok(
+        html.includes(`<span class="nav-logo-path" data-en="${page.en}" data-zh="${page.zh}">${page.en}</span>`),
+        `${relative}: page identity path must expose matching English and Chinese copy`,
+      );
+      assert.match(
+        html,
+        /querySelectorAll\('\[data-en\]\[data-zh\]'\)/,
+        `${relative}: language changes must update bilingual page identity copy`,
+      );
+    }
+  }
+});
+
+test('proof gallery type filters localize with the selected language', () => {
+  const filters = DIAGRAM_TYPES.map((type) => ({
+    type,
+    en: DIAGRAM_TYPE_LABELS.en[type],
+    zh: DIAGRAM_TYPE_LABELS.zh[type],
+  }));
+
+  const template = fs.readFileSync(path.join(repoRoot, 'scripts/gallery-template.html'), 'utf8');
+  for (const filter of filters) {
+    const placeholder = filter.type.toUpperCase();
+    assert.ok(
+      template.includes(`data-filter="${filter.type}" aria-pressed="false" data-en="[[DIAGRAM_TYPE_${placeholder}_EN]]" data-zh="[[DIAGRAM_TYPE_${placeholder}_ZH]]"`),
+      `gallery template: ${filter.type} filter must consume the shared copy source`,
+    );
+  }
+
+  for (const relative of ['docs/gallery.html']) {
+    const html = fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+    assert.match(
+      html,
+      /<button(?=[^>]*data-filter="all")(?=[^>]*data-en="All \/ [^"]+")(?=[^>]*data-zh="全部配方 \/ [^"]+")[^>]*>All \/ [^<]+<\/button>/,
+      `${relative}: all filter must expose English and Chinese copy`,
+    );
+    for (const filter of filters) {
+      const bilingualFilter = new RegExp(
+        `<button(?=[^>]*data-filter="${filter.type}")(?=[^>]*data-en="${filter.en}")(?=[^>]*data-zh="${filter.zh}")[^>]*>${filter.en}<\\/button>`,
+      );
+      assert.match(html, bilingualFilter, `${relative}: ${filter.type} filter must expose English and Chinese copy`);
+    }
+    assert.match(
+      html,
+      /querySelectorAll\('\[data-en\]\[data-zh\]'\)/,
+      `${relative}: language changes must update bilingual gallery filters`,
+    );
+  }
+});
+
+test('scenario guide type filters use consistent Chinese diagram names', () => {
+  const template = fs.readFileSync(path.join(repoRoot, 'scripts/guide-template.html'), 'utf8');
+  assert.match(template, /var types = \[\[DIAGRAM_TYPES_JSON\]\];/);
+  assert.match(template, /var labels = \[\[DIAGRAM_TYPE_LABELS_JSON\]\];/);
+
+  const html = fs.readFileSync(path.join(repoRoot, 'docs/guide.html'), 'utf8');
+  assert.ok(
+    html.includes(`var labels = ${JSON.stringify(DIAGRAM_TYPE_LABELS)};`),
+    'docs/guide.html: Guide filters must use the shared Chinese diagram names',
+  );
+});
+
 test('real Chrome preserves language through entry, navigation, selection, refresh, and consistent navigation chrome', {
   skip: chromePath ? false : 'Set ARCHIFY_CHROME to run the real site regression.',
   timeout: 60000,
@@ -346,10 +419,42 @@ test('real Chrome preserves language through entry, navigation, selection, refre
 
     await clickAndNavigate(browser, sessionId, '.site-nav a[href="gallery.html"]');
     assert.equal(await evaluate(browser, sessionId, 'document.documentElement.lang'), 'zh-CN');
-    await evaluate(browser, sessionId, 'document.getElementById("language").click()');
-    assert.equal(await evaluate(browser, sessionId, 'document.documentElement.lang'), 'en');
+    assert.equal(await evaluate(browser, sessionId, 'document.querySelector(".nav-logo-path").textContent'), '/ 验证作品集');
+    assert.deepEqual(await evaluate(browser, sessionId, `Array.from(document.querySelectorAll('[data-filter]')).map(function (button) {
+      return button.textContent;
+    })`), ['全部配方 / 11', '架构图', '工作流', '时序图', '数据流', '生命周期']);
+
+    await evaluate(browser, sessionId, 'document.querySelector(\'[data-filter="architecture"]\').click()');
+    state = await evaluate(browser, sessionId, `({
+      language: document.documentElement.lang,
+      selected: document.querySelector('[data-filter="architecture"]').getAttribute('aria-pressed'),
+      typeQuery: new URL(location.href).searchParams.get('type'),
+      visibleCount: document.querySelectorAll('.showcase-card:not([hidden])').length,
+      onlyArchitecture: Array.from(document.querySelectorAll('.showcase-card:not([hidden])')).every(function (card) {
+        return card.getAttribute('data-type') === 'architecture';
+      })
+    })`);
+    assert.deepEqual(state, {
+      language: 'zh-CN', selected: 'true', typeQuery: 'architecture', visibleCount: 2, onlyArchitecture: true,
+    });
 
     let loaded = browser.cdp.waitFor('Page.loadEventFired', sessionId);
+    await browser.cdp.send('Page.reload', {}, sessionId);
+    await loaded;
+    assert.deepEqual(await evaluate(browser, sessionId, `({
+      language: document.documentElement.lang,
+      selected: document.querySelector('[data-filter="architecture"]').getAttribute('aria-pressed'),
+      visibleCount: document.querySelectorAll('.showcase-card:not([hidden])').length
+    })`), { language: 'zh-CN', selected: 'true', visibleCount: 2 });
+
+    await evaluate(browser, sessionId, 'document.getElementById("language").click()');
+    assert.equal(await evaluate(browser, sessionId, 'document.documentElement.lang'), 'en');
+    assert.equal(await evaluate(browser, sessionId, 'document.querySelector(".nav-logo-path").textContent'), '/ proof lab');
+    assert.deepEqual(await evaluate(browser, sessionId, `Array.from(document.querySelectorAll('[data-filter]')).map(function (button) {
+      return button.textContent;
+    })`), ['All / 11', 'Architecture', 'Workflow', 'Sequence', 'Data flow', 'Lifecycle']);
+
+    loaded = browser.cdp.waitFor('Page.loadEventFired', sessionId);
     await browser.cdp.send('Page.reload', {}, sessionId);
     await loaded;
     assert.equal(await evaluate(browser, sessionId, 'document.documentElement.lang'), 'en');
@@ -364,10 +469,35 @@ test('real Chrome preserves language through entry, navigation, selection, refre
       hash: location.hash
     })`);
     assert.deepEqual(state, { language: 'zh-CN', stored: 'zh', langQuery: null, hash: '#recipes' });
+    assert.equal(await evaluate(browser, sessionId, 'document.querySelector(".nav-logo-path").textContent'), '/ 场景指南');
+    assert.deepEqual(await evaluate(browser, sessionId, `Array.from(document.querySelectorAll('#filters [data-filter]')).map(function (button) {
+      return button.textContent;
+    })`), ['全部配方', '架构图', '工作流', '时序图', '数据流', '生命周期']);
+
+    await evaluate(browser, sessionId, 'document.querySelector(\'#filters [data-filter="sequence"]\').click()');
+    state = await evaluate(browser, sessionId, `({
+      language: document.documentElement.lang,
+      selected: document.querySelector('#filters [data-filter="sequence"]').classList.contains('active'),
+      visibleCount: document.querySelectorAll('#cards .card').length,
+      onlySequence: Array.from(document.querySelectorAll('#cards .card .card-type')).every(function (label) {
+        return label.textContent === 'sequence';
+      }),
+      labels: Array.from(document.querySelectorAll('#filters [data-filter]')).map(function (button) {
+        return button.textContent;
+      })
+    })`);
+    assert.deepEqual(state, {
+      language: 'zh-CN',
+      selected: true,
+      visibleCount: 2,
+      onlySequence: true,
+      labels: ['全部配方', '架构图', '工作流', '时序图', '数据流', '生命周期'],
+    });
 
     await clickAndNavigate(browser, sessionId, '.site-nav a[href="start.html"]');
     assert.equal(await evaluate(browser, sessionId, 'document.documentElement.lang'), 'zh-CN');
     assert.equal(await evaluate(browser, sessionId, 'new URL(location.href).searchParams.has("lang")'), false);
+    assert.equal(await evaluate(browser, sessionId, 'document.querySelector(".nav-logo-path").textContent'), '/ 快速上手');
 
     const pages = ['index.html', 'gallery.html', 'guide.html', 'start.html'];
     const desktopReceipts = [];

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -227,7 +227,7 @@
   <nav class="site-nav" aria-label="Primary navigation">
     <a class="nav-logo" href="./" aria-label="Back to Archify home">
       <span class="nav-logo-text">Archify</span>
-      <span class="nav-logo-path">/ proof lab</span>
+      <span class="nav-logo-path" data-en="/ proof lab" data-zh="/ 验证作品集">/ proof lab</span>
     </a>
     <div class="nav-right">
       <a class="nav-link" href="guide.html" data-en="Guide" data-zh="场景指南">Guide</a>
@@ -258,12 +258,12 @@
     <section class="controls" aria-label="Gallery controls">
       <div class="shell controls-inner">
         <div class="filter-group" role="group" aria-label="Filter diagrams by type">
-          <button class="filter-button" type="button" data-filter="all" aria-pressed="true">All / 11</button>
-          <button class="filter-button" type="button" data-filter="architecture" aria-pressed="false">Architecture</button>
-          <button class="filter-button" type="button" data-filter="workflow" aria-pressed="false">Workflow</button>
-          <button class="filter-button" type="button" data-filter="sequence" aria-pressed="false">Sequence</button>
-          <button class="filter-button" type="button" data-filter="dataflow" aria-pressed="false">Data flow</button>
-          <button class="filter-button" type="button" data-filter="lifecycle" aria-pressed="false">Lifecycle</button>
+          <button class="filter-button" type="button" data-filter="all" aria-pressed="true" data-en="All / 11" data-zh="全部配方 / 11">All / 11</button>
+          <button class="filter-button" type="button" data-filter="architecture" aria-pressed="false" data-en="Architecture" data-zh="架构图">Architecture</button>
+          <button class="filter-button" type="button" data-filter="workflow" aria-pressed="false" data-en="Workflow" data-zh="工作流">Workflow</button>
+          <button class="filter-button" type="button" data-filter="sequence" aria-pressed="false" data-en="Sequence" data-zh="时序图">Sequence</button>
+          <button class="filter-button" type="button" data-filter="dataflow" aria-pressed="false" data-en="Data flow" data-zh="数据流">Data flow</button>
+          <button class="filter-button" type="button" data-filter="lifecycle" aria-pressed="false" data-en="Lifecycle" data-zh="生命周期">Lifecycle</button>
         </div>
         <div class="controls-actions">
           <button class="filter-button" id="preview-theme" type="button">Preview: dark</button>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -188,7 +188,7 @@
   <nav class="site-nav" aria-label="Primary navigation">
     <a class="nav-logo" href="./" aria-label="Archify home">
       <span class="nav-logo-text">Archify</span>
-      <span class="nav-logo-path">/ guide</span>
+      <span class="nav-logo-path" data-en="/ guide" data-zh="/ 场景指南">/ guide</span>
     </a>
     <div class="nav-right">
       <a class="nav-link" href="guide.html" aria-current="page" data-i18n="navGuide">Guide</a>
@@ -246,7 +246,7 @@
     (function () {
       'use strict';
       var recipes = JSON.parse(document.getElementById('guide-data').textContent);
-      var types = ['architecture','workflow','sequence','dataflow','lifecycle'];
+      var types = ["architecture","workflow","sequence","dataflow","lifecycle"];
       var colors = { architecture:'#0891b2', workflow:'#047857', sequence:'#6d28d9', dataflow:'#b45309', lifecycle:'#be123c' };
       var language = ArchifySiteLanguage.read();
       var activeType = 'all';
@@ -285,7 +285,7 @@
         document.getElementById('samples').innerHTML = t('samples').map(function (sample) { return '<button class="chip" type="button" data-query="'+escapeHtml(sample[1])+'">'+escapeHtml(sample[0])+'</button>'; }).join('');
       }
       function renderFilters() {
-        var labels = { en:{architecture:'Architecture',workflow:'Workflow',sequence:'Sequence',dataflow:'Data flow',lifecycle:'Lifecycle'}, zh:{architecture:'架构',workflow:'工作流',sequence:'时序',dataflow:'数据流',lifecycle:'生命周期'} };
+        var labels = {"en":{"architecture":"Architecture","workflow":"Workflow","sequence":"Sequence","dataflow":"Data flow","lifecycle":"Lifecycle"},"zh":{"architecture":"架构图","workflow":"工作流","sequence":"时序图","dataflow":"数据流","lifecycle":"生命周期"}};
         document.getElementById('filters').innerHTML = ['all'].concat(types).map(function (type) { return '<button class="filter '+(activeType === type ? 'active':'')+'" type="button" data-filter="'+type+'">'+escapeHtml(type === 'all' ? t('all') : labels[language][type])+'</button>'; }).join('');
       }
       function renderCards() {
@@ -318,6 +318,7 @@
         document.documentElement.lang = language === 'zh' ? 'zh-CN' : 'en';
         document.getElementById('language').textContent = language === 'zh' ? 'EN' : '中文';
         document.getElementById('language').setAttribute('aria-label', language === 'zh' ? 'Switch to English' : '切换到中文');
+        document.querySelectorAll('[data-en][data-zh]').forEach(function (node) { node.textContent=node.getAttribute(language === 'zh' ? 'data-zh' : 'data-en'); });
         document.querySelectorAll('[data-i18n]').forEach(function (node) { node.textContent=t(node.dataset.i18n); });
         document.querySelectorAll('[data-i18n-html]').forEach(function (node) { node.innerHTML=t(node.dataset.i18nHtml); });
         document.querySelectorAll('[data-i18n-placeholder]').forEach(function (node) { node.placeholder=t(node.dataset.i18nPlaceholder); });

--- a/docs/start.html
+++ b/docs/start.html
@@ -183,7 +183,7 @@
   <nav class="site-nav" aria-label="Primary navigation">
     <a class="nav-logo" href="./" aria-label="Archify project page">
       <span class="nav-logo-text">Archify</span>
-      <span class="nav-logo-path">/ start</span>
+      <span class="nav-logo-path" data-en="/ start" data-zh="/ 快速上手">/ start</span>
     </a>
     <div class="nav-right">
       <a class="nav-link" href="guide.html" data-en="Guide" data-zh="场景指南">Guide</a>

--- a/scripts/build-gallery.mjs
+++ b/scripts/build-gallery.mjs
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { copySiteAssets } from './copy-site-assets.mjs';
+import { DIAGRAM_TYPE_LABELS, diagramTypeCopyReplacements } from './site-copy.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -171,14 +172,6 @@ const SHAPES = {
   lifecycle: ['states', 'transitions'],
 };
 
-const TYPE_LABELS = {
-  architecture: 'Architecture',
-  workflow: 'Workflow',
-  sequence: 'Sequence',
-  dataflow: 'Data flow',
-  lifecycle: 'Lifecycle',
-};
-
 // Print-depth type hues shared with the site palette (guide page uses the same map).
 const TYPE_ACCENTS = {
   architecture: '#0891b2',
@@ -219,7 +212,7 @@ function renderCard(entry, index) {
             <header class="card-header">
               <div class="card-index">${String(index + 1).padStart(2, '0')}</div>
               <div class="card-title-wrap">
-                <div class="card-kicker">${esc(TYPE_LABELS[entry.type])} / ${entry.nodeCount} nodes${entry.viewCount ? ` / ${entry.viewCount} views · play` : ''}</div>
+                <div class="card-kicker">${esc(DIAGRAM_TYPE_LABELS.en[entry.type])} / ${entry.nodeCount} nodes${entry.viewCount ? ` / ${entry.viewCount} views · play` : ''}</div>
                 <h3 class="card-title" data-en="${esc(entry.titleEn)}" data-zh="${esc(entry.titleZh)}">${esc(entry.titleEn)}</h3>
               </div>
               <div class="card-mode">${esc(mode)}</div>
@@ -335,6 +328,7 @@ const manifestJson = JSON.stringify(manifest, null, 2);
 fs.writeFileSync(path.join(outputRoot, 'gallery', 'manifest.json'), `${manifestJson}\n`);
 
 const replacements = {
+  ...diagramTypeCopyReplacements(),
   '[[ARCHIFY_VERSION]]': packageJson.version,
   '[[ENTRY_COUNT]]': String(manifest.entryCount),
   '[[CHECK_COUNT]]': String(manifest.checkCount),

--- a/scripts/build-guide.mjs
+++ b/scripts/build-guide.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { publicGuideData } from '../archify/recipes/scenarios.mjs';
 import { copySiteAssets } from './copy-site-assets.mjs';
+import { diagramTypeCopyReplacements } from './site-copy.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -18,6 +19,7 @@ const guideJson = JSON.stringify(publicGuideData())
   .replaceAll('>', '\\u003e');
 
 const replacements = {
+  ...diagramTypeCopyReplacements(),
   '[[ARCHIFY_VERSION]]': packageJson.version,
   '[[RECIPE_COUNT]]': String(publicGuideData().length),
   '[[GUIDE_JSON]]': guideJson,

--- a/scripts/build-start.mjs
+++ b/scripts/build-start.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SCENARIO_RECIPES, startPromptsFor } from '../archify/recipes/scenarios.mjs';
 import { copySiteAssets } from './copy-site-assets.mjs';
+import { diagramTypeCopyReplacements } from './site-copy.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -49,6 +50,7 @@ const startJson = JSON.stringify(startData)
   .replaceAll('>', '\\u003e');
 
 const replacements = {
+  ...diagramTypeCopyReplacements(),
   '[[ARCHIFY_VERSION]]': packageJson.version,
   '[[START_JSON]]': startJson,
 };

--- a/scripts/gallery-template.html
+++ b/scripts/gallery-template.html
@@ -227,7 +227,7 @@
   <nav class="site-nav" aria-label="Primary navigation">
     <a class="nav-logo" href="./" aria-label="Back to Archify home">
       <span class="nav-logo-text">Archify</span>
-      <span class="nav-logo-path">/ proof lab</span>
+      <span class="nav-logo-path" data-en="/ proof lab" data-zh="/ 验证作品集">/ proof lab</span>
     </a>
     <div class="nav-right">
       <a class="nav-link" href="guide.html" data-en="Guide" data-zh="场景指南">Guide</a>
@@ -258,12 +258,12 @@
     <section class="controls" aria-label="Gallery controls">
       <div class="shell controls-inner">
         <div class="filter-group" role="group" aria-label="Filter diagrams by type">
-          <button class="filter-button" type="button" data-filter="all" aria-pressed="true">All / [[ENTRY_COUNT]]</button>
-          <button class="filter-button" type="button" data-filter="architecture" aria-pressed="false">Architecture</button>
-          <button class="filter-button" type="button" data-filter="workflow" aria-pressed="false">Workflow</button>
-          <button class="filter-button" type="button" data-filter="sequence" aria-pressed="false">Sequence</button>
-          <button class="filter-button" type="button" data-filter="dataflow" aria-pressed="false">Data flow</button>
-          <button class="filter-button" type="button" data-filter="lifecycle" aria-pressed="false">Lifecycle</button>
+          <button class="filter-button" type="button" data-filter="all" aria-pressed="true" data-en="All / [[ENTRY_COUNT]]" data-zh="全部配方 / [[ENTRY_COUNT]]">All / [[ENTRY_COUNT]]</button>
+          <button class="filter-button" type="button" data-filter="architecture" aria-pressed="false" data-en="[[DIAGRAM_TYPE_ARCHITECTURE_EN]]" data-zh="[[DIAGRAM_TYPE_ARCHITECTURE_ZH]]">[[DIAGRAM_TYPE_ARCHITECTURE_EN]]</button>
+          <button class="filter-button" type="button" data-filter="workflow" aria-pressed="false" data-en="[[DIAGRAM_TYPE_WORKFLOW_EN]]" data-zh="[[DIAGRAM_TYPE_WORKFLOW_ZH]]">[[DIAGRAM_TYPE_WORKFLOW_EN]]</button>
+          <button class="filter-button" type="button" data-filter="sequence" aria-pressed="false" data-en="[[DIAGRAM_TYPE_SEQUENCE_EN]]" data-zh="[[DIAGRAM_TYPE_SEQUENCE_ZH]]">[[DIAGRAM_TYPE_SEQUENCE_EN]]</button>
+          <button class="filter-button" type="button" data-filter="dataflow" aria-pressed="false" data-en="[[DIAGRAM_TYPE_DATAFLOW_EN]]" data-zh="[[DIAGRAM_TYPE_DATAFLOW_ZH]]">[[DIAGRAM_TYPE_DATAFLOW_EN]]</button>
+          <button class="filter-button" type="button" data-filter="lifecycle" aria-pressed="false" data-en="[[DIAGRAM_TYPE_LIFECYCLE_EN]]" data-zh="[[DIAGRAM_TYPE_LIFECYCLE_ZH]]">[[DIAGRAM_TYPE_LIFECYCLE_EN]]</button>
         </div>
         <div class="controls-actions">
           <button class="filter-button" id="preview-theme" type="button">Preview: dark</button>

--- a/scripts/guide-template.html
+++ b/scripts/guide-template.html
@@ -188,7 +188,7 @@
   <nav class="site-nav" aria-label="Primary navigation">
     <a class="nav-logo" href="./" aria-label="Archify home">
       <span class="nav-logo-text">Archify</span>
-      <span class="nav-logo-path">/ guide</span>
+      <span class="nav-logo-path" data-en="/ guide" data-zh="/ 场景指南">/ guide</span>
     </a>
     <div class="nav-right">
       <a class="nav-link" href="guide.html" aria-current="page" data-i18n="navGuide">Guide</a>
@@ -246,7 +246,7 @@
     (function () {
       'use strict';
       var recipes = JSON.parse(document.getElementById('guide-data').textContent);
-      var types = ['architecture','workflow','sequence','dataflow','lifecycle'];
+      var types = [[DIAGRAM_TYPES_JSON]];
       var colors = { architecture:'#0891b2', workflow:'#047857', sequence:'#6d28d9', dataflow:'#b45309', lifecycle:'#be123c' };
       var language = ArchifySiteLanguage.read();
       var activeType = 'all';
@@ -285,7 +285,7 @@
         document.getElementById('samples').innerHTML = t('samples').map(function (sample) { return '<button class="chip" type="button" data-query="'+escapeHtml(sample[1])+'">'+escapeHtml(sample[0])+'</button>'; }).join('');
       }
       function renderFilters() {
-        var labels = { en:{architecture:'Architecture',workflow:'Workflow',sequence:'Sequence',dataflow:'Data flow',lifecycle:'Lifecycle'}, zh:{architecture:'架构',workflow:'工作流',sequence:'时序',dataflow:'数据流',lifecycle:'生命周期'} };
+        var labels = [[DIAGRAM_TYPE_LABELS_JSON]];
         document.getElementById('filters').innerHTML = ['all'].concat(types).map(function (type) { return '<button class="filter '+(activeType === type ? 'active':'')+'" type="button" data-filter="'+type+'">'+escapeHtml(type === 'all' ? t('all') : labels[language][type])+'</button>'; }).join('');
       }
       function renderCards() {
@@ -318,6 +318,7 @@
         document.documentElement.lang = language === 'zh' ? 'zh-CN' : 'en';
         document.getElementById('language').textContent = language === 'zh' ? 'EN' : '中文';
         document.getElementById('language').setAttribute('aria-label', language === 'zh' ? 'Switch to English' : '切换到中文');
+        document.querySelectorAll('[data-en][data-zh]').forEach(function (node) { node.textContent=node.getAttribute(language === 'zh' ? 'data-zh' : 'data-en'); });
         document.querySelectorAll('[data-i18n]').forEach(function (node) { node.textContent=t(node.dataset.i18n); });
         document.querySelectorAll('[data-i18n-html]').forEach(function (node) { node.innerHTML=t(node.dataset.i18nHtml); });
         document.querySelectorAll('[data-i18n-placeholder]').forEach(function (node) { node.placeholder=t(node.dataset.i18nPlaceholder); });

--- a/scripts/site-copy.mjs
+++ b/scripts/site-copy.mjs
@@ -1,0 +1,39 @@
+export const DIAGRAM_TYPES = Object.freeze([
+  'architecture',
+  'workflow',
+  'sequence',
+  'dataflow',
+  'lifecycle',
+]);
+
+export const DIAGRAM_TYPE_LABELS = Object.freeze({
+  en: Object.freeze({
+    architecture: 'Architecture',
+    workflow: 'Workflow',
+    sequence: 'Sequence',
+    dataflow: 'Data flow',
+    lifecycle: 'Lifecycle',
+  }),
+  zh: Object.freeze({
+    architecture: '架构图',
+    workflow: '工作流',
+    sequence: '时序图',
+    dataflow: '数据流',
+    lifecycle: '生命周期',
+  }),
+});
+
+export function diagramTypeCopyReplacements() {
+  const replacements = {
+    '[[DIAGRAM_TYPES_JSON]]': JSON.stringify(DIAGRAM_TYPES),
+    '[[DIAGRAM_TYPE_LABELS_JSON]]': JSON.stringify(DIAGRAM_TYPE_LABELS),
+  };
+
+  for (const type of DIAGRAM_TYPES) {
+    const placeholder = type.toUpperCase();
+    replacements[`[[DIAGRAM_TYPE_${placeholder}_EN]]`] = DIAGRAM_TYPE_LABELS.en[type];
+    replacements[`[[DIAGRAM_TYPE_${placeholder}_ZH]]`] = DIAGRAM_TYPE_LABELS.zh[type];
+  }
+
+  return replacements;
+}

--- a/scripts/start-template.html
+++ b/scripts/start-template.html
@@ -183,7 +183,7 @@
   <nav class="site-nav" aria-label="Primary navigation">
     <a class="nav-logo" href="./" aria-label="Archify project page">
       <span class="nav-logo-text">Archify</span>
-      <span class="nav-logo-path">/ start</span>
+      <span class="nav-logo-path" data-en="/ start" data-zh="/ 快速上手">/ start</span>
     </a>
     <div class="nav-right">
       <a class="nav-link" href="guide.html" data-en="Guide" data-zh="场景指南">Guide</a>
@@ -215,11 +215,11 @@
       </div>
       <p class="type-label" id="type-label"><span data-en="Choose the question shape" data-zh="选择问题形态">Choose the question shape</span><strong data-en="5 typed renderers" data-zh="5 种类型化渲染器">5 typed renderers</strong></p>
       <div class="type-tabs" role="tablist" aria-label="Diagram type">
-        <button class="type-tab" type="button" role="tab" data-type="architecture" data-en="Architecture" data-zh="架构图">Architecture</button>
-        <button class="type-tab" type="button" role="tab" data-type="workflow" data-en="Workflow" data-zh="工作流">Workflow</button>
-        <button class="type-tab" type="button" role="tab" data-type="sequence" data-en="Sequence" data-zh="时序图">Sequence</button>
-        <button class="type-tab" type="button" role="tab" data-type="dataflow" data-en="Data flow" data-zh="数据流">Data flow</button>
-        <button class="type-tab" type="button" role="tab" data-type="lifecycle" data-en="Lifecycle" data-zh="生命周期">Lifecycle</button>
+        <button class="type-tab" type="button" role="tab" data-type="architecture" data-en="[[DIAGRAM_TYPE_ARCHITECTURE_EN]]" data-zh="[[DIAGRAM_TYPE_ARCHITECTURE_ZH]]">[[DIAGRAM_TYPE_ARCHITECTURE_EN]]</button>
+        <button class="type-tab" type="button" role="tab" data-type="workflow" data-en="[[DIAGRAM_TYPE_WORKFLOW_EN]]" data-zh="[[DIAGRAM_TYPE_WORKFLOW_ZH]]">[[DIAGRAM_TYPE_WORKFLOW_EN]]</button>
+        <button class="type-tab" type="button" role="tab" data-type="sequence" data-en="[[DIAGRAM_TYPE_SEQUENCE_EN]]" data-zh="[[DIAGRAM_TYPE_SEQUENCE_ZH]]">[[DIAGRAM_TYPE_SEQUENCE_EN]]</button>
+        <button class="type-tab" type="button" role="tab" data-type="dataflow" data-en="[[DIAGRAM_TYPE_DATAFLOW_EN]]" data-zh="[[DIAGRAM_TYPE_DATAFLOW_ZH]]">[[DIAGRAM_TYPE_DATAFLOW_EN]]</button>
+        <button class="type-tab" type="button" role="tab" data-type="lifecycle" data-en="[[DIAGRAM_TYPE_LIFECYCLE_EN]]" data-zh="[[DIAGRAM_TYPE_LIFECYCLE_ZH]]">[[DIAGRAM_TYPE_LIFECYCLE_EN]]</button>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

- localize the Guide, Proof Lab, and Start page identity paths with the selected language
- localize Gallery and Guide diagram-type filters, using 架构图 and 时序图 consistently in Chinese
- centralize bilingual diagram-type labels for Gallery, Guide, and Start build outputs
- add real-browser coverage for filter selection, visible cards, refresh, and cross-page language continuity

## Verification

- real Chrome regression: 7 passed, 0 failed
- full test suite: 986 passed, 0 failed, 27 conditionally skipped
- generated Gallery, Guide, and Start pages rebuilt successfully

Closes #218