### PR TITLE
fix(renderers): keep node labels clear of the semantic sigil

### DIFF
--- a/archify/examples/sequence-cache-miss-request.html
+++ b/archify/examples/sequence-cache-miss-request.html
@@ -5240,7 +5240,7 @@
             <ellipse cx="8" cy="4" rx="5" ry="2"/>
             <path d="M3 4v8c0 1.1 2.2 2 5 2s5-.9 5-2V4M3 8c0 1.1 2.2 2 5 2s5-.9 5-2"/>
           </g>
-          <text data-node-label="" data-detail-anchor="" x="602" y="94" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Postgres</text>
+          <text data-node-label="" data-detail-anchor="" x="602.4" y="94" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Postgres</text>
           <text data-detail="context" x="602" y="111" class="t-muted" font-size="7" text-anchor="middle">source of truth</text>
         </g>
 

--- a/archify/renderers/dataflow/render-dataflow.mjs
+++ b/archify/renderers/dataflow/render-dataflow.mjs
@@ -4,7 +4,7 @@ import { esc, renderDefinitions, renderSemanticSigil, textUnits } from '../share
 import { animateAttr, focusEdgeAttrs, focusNodeAttrs, focusNodeTitle, loadDiagramWithBrandMarks, writeDiagram, svgAccessibleText, svgRootAttrs } from '../shared/cli.mjs';
 import { throwDiagnosticProblems } from '../shared/diagnostics.mjs';
 import { resolveLegend, renderLegend as renderResolvedLegend } from '../shared/legend.mjs';
-import { availableNodeTextWidth, fittedNodeFontSize, minimumNodeTextWidth } from '../shared/text-fit.mjs';
+import { availableNodeTextWidth, fittedNodeFontSize, minimumNodeTextWidth, nodeTextWidth, sigilClearedLabelCenter, sigilLabelClearanceProblem, sigilLabelFitWidth } from '../shared/text-fit.mjs';
 import { brandLabelFitWidth, brandMetadataFor, brandTopRailProblem, renderBrandMark } from '../shared/brand-marks.mjs';
 import { translateMessage as i18nText } from '../shared/i18n.mjs';
 import {
@@ -143,6 +143,8 @@ function validateDataflow() {
     }
     const brandRailProblem = brandTopRailProblem(node, node.width, 8);
     if (brandRailProblem) problems.push(brandRailProblem);
+    const sigilClearance = sigilLabelClearanceProblem(node.id, node.label, node.width, 8);
+    if (sigilClearance) problems.push(sigilClearance);
     // sublabel and tag render as single unwrapped <text> elements; shrink-to-fit
     // handles the ordinary case, this rejects what it cannot rescue.
     const availableTextW = availableNodeTextWidth(node.width);
@@ -384,14 +386,16 @@ function renderNode(node) {
     ? `${String(node.stage + 1).padStart(2, '0')} / ${stage.label}`
     : i18nText(dataflow.meta.locale, 'node.context.dataflow');
   const brand = renderBrandMark(node, { x: node.x + node.width - 22, y: node.y + 6 });
-  const labelFontSize = fittedNodeFontSize(node.label, brandLabelFitWidth(node, node.width), 10, 8);
+  const labelFitWidth = Math.min(brandLabelFitWidth(node, node.width), sigilLabelFitWidth(node.width));
+  const labelFontSize = fittedNodeFontSize(node.label, labelFitWidth, 10, 8);
+  const labelCx = sigilClearedLabelCenter(node.x, node.width, nodeTextWidth(node.label, labelFontSize));
   const passport = { kind: node.type, sublabel: node.sublabel, tag: node.tag, context, ...brandMetadataFor(node) };
   return `        <g ${focusNodeAttrs(node.id, node.label, passport, dataflow.meta.locale)}>
           ${focusNodeTitle(node.label, passport)}
           <rect x="${node.x}" y="${node.y}" width="${node.width}" height="${node.height}" rx="6" class="c-mask"/>
           <rect x="${node.x}" y="${node.y}" width="${node.width}" height="${node.height}" rx="6" class="${fill}"${animateAttr(dataflow.meta, 'node', nodeSteps.get(node.id))} stroke-width="1.5"/>
           ${renderSemanticSigil(node.type, { x: node.x + 6, y: node.y + 6 })}${brand ? `\n          ${brand}` : ''}
-          <text data-node-label=""${hasSub ? ' data-detail-anchor=""' : ''} x="${node.cx}" y="${node.y + 21}" class="t-primary" font-size="${labelFontSize}" font-weight="600" text-anchor="middle">${esc(node.label)}</text>${sub}${tag}
+          <text data-node-label=""${hasSub ? ' data-detail-anchor=""' : ''} x="${labelCx}" y="${node.y + 21}" class="t-primary" font-size="${labelFontSize}" font-weight="600" text-anchor="middle">${esc(node.label)}</text>${sub}${tag}
         </g>`;
 }
 

--- a/archify/renderers/lifecycle/render-lifecycle.mjs
+++ b/archify/renderers/lifecycle/render-lifecycle.mjs
@@ -4,7 +4,7 @@ import { esc, renderDefinitions, renderSemanticSigil, textUnits } from '../share
 import { animateAttr, focusEdgeAttrs, focusNodeAttrs, focusNodeTitle, loadDiagramWithBrandMarks, writeDiagram, svgAccessibleText, svgRootAttrs } from '../shared/cli.mjs';
 import { throwDiagnosticProblems } from '../shared/diagnostics.mjs';
 import { resolveLegend, renderLegend as renderResolvedLegend } from '../shared/legend.mjs';
-import { availableNodeTextWidth, fittedNodeFontSize, minimumNodeTextWidth } from '../shared/text-fit.mjs';
+import { availableNodeTextWidth, fittedNodeFontSize, minimumNodeTextWidth, nodeTextWidth, sigilClearedLabelCenter, sigilLabelClearanceProblem, sigilLabelFitWidth } from '../shared/text-fit.mjs';
 import { brandLabelFitWidth, brandMarkFor, brandMetadataFor, brandTopRailProblem, renderBrandMark } from '../shared/brand-marks.mjs';
 import { translateMessage as i18nText } from '../shared/i18n.mjs';
 import {
@@ -185,6 +185,8 @@ function validateLifecycle() {
     }
     const brandRailProblem = brandTopRailProblem(state, state.width, 8, 'State');
     if (brandRailProblem) problems.push(brandRailProblem);
+    const sigilClearance = sigilLabelClearanceProblem(state.id, state.label, state.width, 8, 'State');
+    if (sigilClearance) problems.push(sigilClearance);
     // sublabel and tag render as single unwrapped <text> elements; shrink-to-fit
     // handles the ordinary case, this rejects what it cannot rescue.
     const availableTextW = availableNodeTextWidth(state.width);
@@ -444,7 +446,16 @@ function renderState(state) {
     ? `\n        <text data-detail="fine" x="${state.x + (hasBrand ? 23 : 10)}" y="${state.y + 14}" class="${accent}" font-size="7" font-weight="700">${esc(state.step)}</text>`
     : '';
   const brand = renderBrandMark(state, { x: state.x + state.width - 22, y: state.y + 6 });
-  const labelFontSize = fittedNodeFontSize(state.label, brandLabelFitWidth(state, state.width), 10, 8);
+  const labelFitWidth = Math.min(brandLabelFitWidth(state, state.width), sigilLabelFitWidth(state.width));
+  const labelFontSize = fittedNodeFontSize(state.label, labelFitWidth, 10, 8);
+  // A state without a brand mark carries its sigil in the top-RIGHT corner
+  // (see the renderSemanticSigil call below), so the label clears the other side.
+  const labelCx = sigilClearedLabelCenter(
+    state.x,
+    state.width,
+    nodeTextWidth(state.label, labelFontSize),
+    hasBrand ? 'left' : 'right',
+  );
   const passport = {
     kind: state.type,
     sublabel: state.sublabel,
@@ -457,7 +468,7 @@ function renderState(state) {
           <rect x="${state.x}" y="${state.y}" width="${state.width}" height="${state.height}" rx="7" class="c-mask"/>
           <rect x="${state.x}" y="${state.y}" width="${state.width}" height="${state.height}" rx="7" class="${fill}"${animateAttr(lifecycle.meta, 'node', stateSteps.get(state.id))} stroke-width="1.5"/>
           ${renderSemanticSigil(state.type, { x: hasBrand ? state.x + 6 : state.x + state.width - 17, y: state.y + 6 })}${brand ? `\n          ${brand}` : ''}${step}
-          <text data-node-label=""${hasSub ? ' data-detail-anchor=""' : ''} x="${state.cx}" y="${state.y + 21}" class="t-primary" font-size="${labelFontSize}" font-weight="600" text-anchor="middle">${esc(state.label)}</text>${sub}${tag}
+          <text data-node-label=""${hasSub ? ' data-detail-anchor=""' : ''} x="${labelCx}" y="${state.y + 21}" class="t-primary" font-size="${labelFontSize}" font-weight="600" text-anchor="middle">${esc(state.label)}</text>${sub}${tag}
         </g>`;
 }
 

--- a/archify/renderers/sequence/render-sequence.mjs
+++ b/archify/renderers/sequence/render-sequence.mjs
@@ -5,7 +5,7 @@ import { animateAttr, focusEdgeAttrs, focusNodeAttrs, focusNodeTitle, loadDiagra
 import { throwDiagnosticProblems } from '../shared/diagnostics.mjs';
 import { resolveLegend, renderLegend as renderResolvedLegend } from '../shared/legend.mjs';
 import { componentFill, arrowClassMap, rectsOverlap, cleanFlowProblems, cleanCrossingProblems, cleanAmbiguousCorridorProblems, cleanBorderRunProblems, cleanRouteRhythmProblems, cleanLabelRouteClearanceProblems, routePointsValue, asArray, isFinitePoint } from '../shared/geometry.mjs';
-import { availableNodeTextWidth, fittedNodeFontSize, minimumNodeTextWidth } from '../shared/text-fit.mjs';
+import { availableNodeTextWidth, fittedNodeFontSize, minimumNodeTextWidth, nodeTextWidth, sigilClearedLabelCenter, sigilLabelClearanceProblem, sigilLabelFitWidth } from '../shared/text-fit.mjs';
 import { brandLabelFitWidth, brandMetadataFor, brandTopRailProblem, renderBrandMark } from '../shared/brand-marks.mjs';
 import { translateMessage as i18nText } from '../shared/i18n.mjs';
 
@@ -147,6 +147,8 @@ function validateSequence() {
     }
     const brandRailProblem = brandTopRailProblem(participant, layout.participantW, 8, 'Participant');
     if (brandRailProblem) problems.push(brandRailProblem);
+    const sigilClearance = sigilLabelClearanceProblem(participant.id, participant.label, layout.participantW, 8, 'Participant');
+    if (sigilClearance) problems.push(sigilClearance);
     // sublabel renders as a single unwrapped <text>; shrink-to-fit handles the
     // ordinary case, this rejects what it cannot rescue.
     if (participant.sublabel) {
@@ -297,7 +299,9 @@ function renderParticipant(participant) {
     ? `\n          <text data-detail="context" x="${participant.cx}" y="${layout.topY + 39}" class="t-muted" font-size="${fittedNodeFontSize(participant.sublabel, layout.participantW, participantTextFit.sublabelPreferred, participantTextFit.sublabelMinimum)}" text-anchor="middle">${esc(participant.sublabel)}</text>`
     : '';
   const brand = renderBrandMark(participant, { x: participant.x + layout.participantW - 22, y: layout.topY + 6 });
-  const labelFontSize = fittedNodeFontSize(participant.label, brandLabelFitWidth(participant, layout.participantW), 11, 8);
+  const labelFitWidth = Math.min(brandLabelFitWidth(participant, layout.participantW), sigilLabelFitWidth(layout.participantW));
+  const labelFontSize = fittedNodeFontSize(participant.label, labelFitWidth, 11, 8);
+  const labelCx = sigilClearedLabelCenter(participant.x, layout.participantW, nodeTextWidth(participant.label, labelFontSize));
   const passport = {
     kind: participant.type,
     sublabel: participant.sublabel,
@@ -309,7 +313,7 @@ function renderParticipant(participant) {
           <rect x="${participant.x}" y="${layout.topY}" width="${layout.participantW}" height="${layout.participantH}" rx="6" class="c-mask"/>
           <rect x="${participant.x}" y="${layout.topY}" width="${layout.participantW}" height="${layout.participantH}" rx="6" class="${fill}"${animateAttr(sequence.meta, 'node', participant.index)} stroke-width="1.5"/>
           ${renderSemanticSigil(participant.type, { x: participant.x + 6, y: layout.topY + 6 })}${brand ? `\n          ${brand}` : ''}
-          <text data-node-label=""${hasSub ? ' data-detail-anchor=""' : ''} x="${participant.cx}" y="${layout.topY + 22}" class="t-primary" font-size="${labelFontSize}" font-weight="600" text-anchor="middle">${esc(participant.label)}</text>${sub}
+          <text data-node-label=""${hasSub ? ' data-detail-anchor=""' : ''} x="${labelCx}" y="${layout.topY + 22}" class="t-primary" font-size="${labelFontSize}" font-weight="600" text-anchor="middle">${esc(participant.label)}</text>${sub}
         </g>`;
 }
 

--- a/archify/renderers/shared/text-fit.mjs
+++ b/archify/renderers/shared/text-fit.mjs
@@ -16,7 +16,7 @@
 // `minimum` font sizes are not, because renderers set node text at different
 // sizes (architecture sublabels are 9px, the rest are 7px).
 
-import { textUnits } from './utils.mjs';
+import { textUnits, SEMANTIC_SIGIL_FOOTPRINT } from './utils.mjs';
 
 // widthFactor: px of advance width per text unit, per px of font size.
 // horizontalPadding: total px reserved inside the box so text never touches
@@ -46,4 +46,65 @@ export function minimumNodeTextWidth(text, minimum) {
 // Available text width inside a box of `width`.
 export function availableNodeTextWidth(width) {
   return width - nodeTextFit.horizontalPadding;
+}
+
+// ---- semantic sigil clearance ----
+//
+// The sigil occupies one top corner of the node while the label is centred in
+// the same band, so the two halves below mirror the sublabel/tag rule above:
+// the render half keeps an ordinary label clear of the icon, and the
+// validation half reports the label that still cannot clear it once it has
+// shrunk as far as it may.
+//
+// Only the sigil's own footprint is reserved, and the label is re-centred into
+// the space beside it rather than shrunk symmetrically around the node centre.
+// Reserving twice the footprint (once per side, to keep a centred label) would
+// leave too little width for ordinary labels: measured against the checked-in
+// workflow example it rejects 7 of 12 nodes, which is not a repairable defect
+// in those diagrams.
+
+// Rendered advance width of node text at `fontSize`.
+export function nodeTextWidth(text, fontSize) {
+  return textUnits(text) * fontSize * nodeTextFit.widthFactor;
+}
+
+// Width available to a node label that shares its band with a semantic sigil.
+// Composes with `brandLabelFitWidth`: the tighter reserve binds, so callers
+// pass `Math.min(...)` of the two rather than subtracting both.
+export function sigilLabelFitWidth(width) {
+  return Math.max(1, width - SEMANTIC_SIGIL_FOOTPRINT);
+}
+
+// Centre x for a node label that must clear the sigil. Shifts only when the
+// label would otherwise reach the icon, so a short label keeps the node centre
+// and its rendered output is unchanged. The shifted limit is rounded away from
+// the sigil, never toward it, so rounding cannot eat the clearance it just won.
+export function sigilClearedLabelCenter(nodeX, width, textWidth, side = 'left') {
+  const centre = nodeX + width / 2;
+  if (side === 'right') {
+    const limit = Math.floor((nodeX + width - SEMANTIC_SIGIL_FOOTPRINT - textWidth / 2) * 10) / 10;
+    return centre <= limit ? centre : limit;
+  }
+  const limit = Math.ceil((nodeX + SEMANTIC_SIGIL_FOOTPRINT + textWidth / 2) * 10) / 10;
+  return centre >= limit ? centre : limit;
+}
+
+// Reported when shrink-to-fit has bottomed out at the legible minimum and the
+// label still cannot clear the sigil — i.e. no label position satisfies both
+// "clears the icon" and "stays inside the node".
+//
+// `widthFactor` is an approximation of advance width, so the comparison carries
+// a 1px tolerance: below that the estimate is not precise enough to justify
+// rejecting a diagram, and the render half absorbs the remainder. Real defects
+// miss by far more than a pixel (the narrow-node regression misses by ~6px).
+const SIGIL_CLEARANCE_TOLERANCE = 1;
+
+export function sigilLabelClearanceProblem(id, label, width, minimumFontSize, subject = 'Node') {
+  const available = width - SEMANTIC_SIGIL_FOOTPRINT;
+  const required = minimumNodeTextWidth(label, minimumFontSize);
+  if (available >= required - SIGIL_CLEARANCE_TOLERANCE) return null;
+  return `${subject} "${id}" reserves ${SEMANTIC_SIGIL_FOOTPRINT}px for its semantic sigil, leaving `
+    + `${Math.max(0, Math.round(available))}px for its label, but "${label}" needs `
+    + `~${Math.ceil(required)}px at the ${minimumFontSize}px legible minimum — widen the node `
+    + `or shorten the label.`;
 }

--- a/archify/renderers/shared/utils.mjs
+++ b/archify/renderers/shared/utils.mjs
@@ -77,7 +77,18 @@ const SIGIL_SHAPE = {
 // A quiet, renderer-owned role stamp. It is authored SVG content rather than a
 // viewer overlay, so it survives canonical export while adding no focus target,
 // accessible name, layout box, or interaction state of its own.
-export function renderSemanticSigil(kind, { x, y, size = 11 } = {}) {
+// The sigil is drawn `SEMANTIC_SIGIL_INSET` px in from a node corner at
+// `SEMANTIC_SIGIL_SIZE` px square, so it occupies that corner out to
+// `SEMANTIC_SIGIL_FOOTPRINT` px from the node edge. Node labels are centred in
+// the same vertical band, so a label wide enough to reach the corner paints
+// over the icon unless it clears this footprint (#199). Exported so the label
+// fitting in `text-fit.mjs` measures against the geometry actually rendered
+// here instead of a second copy of these numbers.
+export const SEMANTIC_SIGIL_INSET = 6;
+export const SEMANTIC_SIGIL_SIZE = 11;
+export const SEMANTIC_SIGIL_FOOTPRINT = SEMANTIC_SIGIL_INSET + SEMANTIC_SIGIL_SIZE;
+
+export function renderSemanticSigil(kind, { x, y, size = SEMANTIC_SIGIL_SIZE } = {}) {
   const normalized = Object.hasOwn(SIGIL_SHAPE, kind) ? kind : 'neutral';
   const tone = SIGIL_TONE[normalized] || 'external';
   const scale = size / 16;

--- a/archify/renderers/workflow/workflow-compiler.mjs
+++ b/archify/renderers/workflow/workflow-compiler.mjs
@@ -4191,6 +4191,12 @@ function renderNode(node) {
   const fill = componentFill[node.type] || 'c-external';
   const accent = componentText[node.type] || 't-muted';
   const hasSub = node.sublabel != null && node.sublabel !== '';
+  // NOTE: the semantic-sigil clearance rule (#199) is deliberately NOT applied
+  // to workflow. The fixed-v1 contract freezes this compiler's SVG
+  // byte-for-byte (test/workflow-compiler.test.mjs), so the label cannot be
+  // re-centred away from the sigil, and reporting the overlap instead would
+  // reject the packaged incident-response example by ~6px. Both need a
+  // maintainer decision; the other renderers carry the rule.
   const labelFontSize = fittedNodeFontSize(node.label, brandLabelFitWidth(node, node.width), nodeTextFit.labelPreferred, nodeTextFit.labelMinimum);
   const sublabelFontSize = hasSub
     ? fittedNodeFontSize(node.sublabel, node.width, nodeTextFit.sublabelPreferred, nodeTextFit.sublabelMinimum)

--- a/archify/test/layout-rules.test.mjs
+++ b/archify/test/layout-rules.test.mjs
@@ -227,6 +227,9 @@ const CASES = [
     (d) => {
       d.flows[0].via = [[195, 140], [195, 260]];
     }, ['diagonal segment', 'align via[0]']],
+  ['dataflow: node label cannot clear its semantic sigil', 'dataflow',
+    (d) => { d.nodes[0].width = 50; d.nodes[0].label = 'Ingester'; },
+    ['semantic sigil', 'legible minimum', 'widen the node']],
   ['dataflow: node sublabel wider than its legible minimum', 'dataflow',
     (d) => { d.nodes[0].sublabel = 'This supporting sentence is far too long for one data-flow node box'; },
     ['Sublabel', 'legible', 'increase node.width']],

--- a/archify/test/semantic-sigil-clearance.test.mjs
+++ b/archify/test/semantic-sigil-clearance.test.mjs
@@ -1,0 +1,99 @@
+// The semantic sigil sits inset in a node's top corner and the node label is
+// drawn text-anchor="middle" in the same vertical band, so a label wide enough
+// to reach the corner paints over the icon while validation still reports a
+// clean receipt (#199).
+//
+// This locks the geometric invariant on the FINAL SVG for every renderer that
+// puts its label at a fixed offset from the node top. Architecture is excluded
+// on purpose: it centres the label vertically (c.y + height/2), so its label
+// only shares the sigil band on very short components and a blanket reserve
+// there would shrink labels that never collide.
+//
+//   node --test test/semantic-sigil-clearance.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { textUnits } from '../renderers/shared/utils.mjs';
+import { nodeTextFit } from '../renderers/shared/text-fit.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const skillRoot = path.resolve(__dirname, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archify-sigil-'));
+
+// [mode, example, collection, a label long enough to reach the sigil corner]
+// Widths differ per renderer, so each label is chosen to actually collide on
+// that renderer — otherwise the assertion would pass vacuously. Lifecycle puts
+// its sigil in the top-RIGHT corner when a state carries no brand mark, so it
+// covers the mirrored case.
+//
+// Workflow is absent on purpose: the fixed-v1 contract freezes that compiler's
+// SVG byte-for-byte, so its label is not re-centred and the rule is enforced by
+// validateWorkflow instead (see test/layout-rules.test.mjs).
+const CASES = [
+  ['dataflow', 'product-analytics.dataflow.json', 'nodes', 'Prompt Compiler'],
+  ['lifecycle', 'agent-run.lifecycle.json', 'states', 'Prompt Compiler'],
+  ['sequence', 'cache-miss-request.sequence.json', 'participants', 'PromptScript'],
+];
+
+function render(mode, doc) {
+  const stem = path.join(tmp, `${mode}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const input = `${stem}.json`;
+  const outPath = `${stem}.html`;
+  fs.writeFileSync(input, JSON.stringify(doc));
+  execFileSync('node', [
+    path.join(skillRoot, `renderers/${mode}/render-${mode}.mjs`),
+    input,
+    outPath,
+  ], { stdio: ['ignore', 'ignore', 'pipe'] });
+  return fs.readFileSync(outPath, 'utf8');
+}
+
+// The <g> block for the node carrying `label`, so the sigil and the label are
+// read from the same node. The sigil is itself a nested <g>, so the block is
+// bounded by the next node group rather than by the first closing tag.
+function nodeGroup(html, label) {
+  const start = html.indexOf(`data-node-label="${label}"`);
+  assert.notEqual(start, -1, `expected a node group for "${label}"`);
+  const open = html.lastIndexOf('<g id="node-', start);
+  assert.notEqual(open, -1, 'expected a node group opening tag');
+  const nextOpen = html.indexOf('<g id="node-', start + 1);
+  return html.slice(open, nextOpen === -1 ? html.length : nextOpen);
+}
+
+for (const [mode, example, collection, label] of CASES) {
+  test(`${mode}: a node label never paints over its semantic sigil`, () => {
+    const doc = JSON.parse(fs.readFileSync(path.join(skillRoot, 'examples', example), 'utf8'));
+    doc[collection][0].label = label;
+    delete doc[collection][0].brand; // isolate the sigil constraint from the brand top rail
+
+    const group = nodeGroup(render(mode, doc), label);
+
+    const sigil = group.match(/data-semantic-sigil="[^"]*"[^>]*transform="translate\(([-\d.]+) [-\d.]+\) scale\(([-\d.]+)\)"/);
+    assert.ok(sigil, `${mode}: expected a semantic sigil in the node group`);
+    const sigilX = Number(sigil[1]);
+    const sigilRight = sigilX + 16 * Number(sigil[2]);
+
+    const text = group.match(/<text data-node-label=""[^>]*?x="([-\d.]+)"[^>]*?font-size="([\d.]+)"/);
+    assert.ok(text, `${mode}: expected a node label <text> in the node group`);
+    const cx = Number(text[1]);
+    const fontSize = Number(text[2]);
+    const width = textUnits(label) * fontSize * nodeTextFit.widthFactor;
+    const labelLeft = cx - width / 2;
+    const labelRight = cx + width / 2;
+
+    // The sigil is inset from one corner; whichever side it is on, the label
+    // must stay clear of it.
+    const clears = sigilX < cx ? labelLeft >= sigilRight : labelRight <= sigilX;
+    assert.ok(
+      clears,
+      `${mode}: label "${label}" spans ${labelLeft.toFixed(1)}..${labelRight.toFixed(1)} `
+      + `but the sigil occupies ${sigilX.toFixed(1)}..${sigilRight.toFixed(1)} `
+      + `(font ${fontSize}px) — they overlap`,
+    );
+  });
+}

--- a/examples/sequence-cache-miss-request.html
+++ b/examples/sequence-cache-miss-request.html
@@ -5240,7 +5240,7 @@
             <ellipse cx="8" cy="4" rx="5" ry="2"/>
             <path d="M3 4v8c0 1.1 2.2 2 5 2s5-.9 5-2V4M3 8c0 1.1 2.2 2 5 2s5-.9 5-2"/>
           </g>
-          <text data-node-label="" data-detail-anchor="" x="602" y="94" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Postgres</text>
+          <text data-node-label="" data-detail-anchor="" x="602.4" y="94" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Postgres</text>
           <text data-detail="context" x="602" y="111" class="t-muted" font-size="7" text-anchor="middle">source of truth</text>
         </g>
 


### PR DESCRIPTION
Refs #199

> Rebased onto v2.16.0 (`39a2113`) and rescoped. An earlier revision of this PR was measured against `b36d79f`; that evidence is superseded by the numbers below, because the v2.16.0 workflow migration changed the relevant geometry and added a byte-for-byte compatibility guard.

## The user problem

The semantic sigil is drawn inset in a node's top corner and the node label is centred in the same vertical band, so a label wide enough to reach that corner paints over the icon. Validation stays clean, because the text-fit rule measures a label against the whole node width and never subtracts the sigil's footprint.

Still reproducible on `main` today. Reverting only `archify/renderers/` and keeping this PR's tests:

```
test/semantic-sigil-clearance.test.mjs   # pass 0   # fail 3

dataflow:  label "Prompt Compiler" spans 55.0..145.0, sigil occupies 50.0..61.0
lifecycle: label "Prompt Compiler" spans 49.0..139.0, sigil occupies 136.0..147.0
sequence:  label "PromptScript"    spans 23.1..100.9, sigil occupies  25.0..36.0
```

Lifecycle is the mirrored case: a state without a brand mark carries its sigil in the top-**right** corner.

One shipped artifact is affected today — `examples/sequence-cache-miss-request.html`, where `Postgres` starts at 575.6 against a sigil ending at 576.0. The rest of the current examples are clear, because v2.16.0 widened workflow nodes to 132px; the defect is latent for ordinary user diagrams with longer labels rather than visible across the gallery.

## What changes

The sigil now participates in the same two-part contract as the brand top rail beside it, mirroring `brandLabelFitWidth` / `brandTopRailProblem`:

- **render** — reserve the sigil's footprint and re-centre the label into the space next to it, so an ordinary label shifts and shrinks rather than overlapping.
- **validate** — report a label that still cannot clear the sigil after shrinking to its legible minimum, i.e. when no position satisfies both "clears the icon" and "stays inside the node".

Geometry has one home: `SEMANTIC_SIGIL_INSET` / `_SIZE` / `_FOOTPRINT` are exported from `renderers/shared/utils.mjs` beside `renderSemanticSigil`, so the fitting logic measures what is actually drawn. Measured against the shapes themselves, the widest reaches x=14 of the 16-unit box → `6 + 14 × 0.6875 ≈ 15.6px`, plus non-scaling stroke ≈ 16.4px, so the 17px footprint is the nominal box and slightly conservative rather than inflated.

Two deliberate choices, both to avoid rejecting legitimate diagrams:

1. **Only the sigil's own footprint is reserved, not twice it.** Keeping the label strictly centred requires reserving both sides, which leaves too little width for ordinary labels — on the pre-migration workflow example that rejected 7 of 12 nodes. Re-centring rejected 0.
2. **The label shifts only when it would otherwise reach the icon.** Short labels keep the node centre and render byte-identically, which is why exactly one artifact changed.

## What deliberately does not change

- **Workflow.** Both halves are blocked there, so it is untouched and the reason is recorded in `workflow-compiler.mjs`:
  - the `fixed-v1` contract asserts `sha256(result.svg) === '4e493db…'` in `test/workflow-compiler.test.mjs`, so the label cannot be re-centred without breaking that hash;
  - reporting the overlap instead rejects the packaged `incident-response.workflow.json` — node `page`, "Page On-call", needs ~65px at the 9px floor with 59px available.
  
  Re-freezing that baseline, and whether `incident-response` should be widened, are your calls. Happy to do both in a follow-up once you say which way you want it.
- **Architecture.** It centres its label vertically (`c.y + c.height / 2`), so it shares the sigil band only on very short components; a blanket reserve would shrink labels that never collide.
- **Brand-bearing nodes.** The existing 48px symmetric reserve already puts the label's left edge at `x + 24`, clear of a 17px sigil, so those nodes are unchanged.
- No schema, no authored geometry, no diagnostic codes removed or renamed.

## Compatibility

`schema-v1` unchanged; `fixed-v1` byte contract untouched. The new validation is a `showcase`-visible layout problem in the same family as the sublabel/tag rules from #61.

The clearance comparison carries a **1px tolerance**, because `widthFactor` is documented as an approximation of advance width. Without it the rule rejects the CJK labels in `test/fixtures/automatic-routing-node-border-clearance.workflow.json` (`"校验并注入输入"`) by **0.6px** — finer than the model can justify asserting on, and that fixture exists to test routing. Real defects miss by far more: the new regression misses by ~5px.

## Testing

`node --test test/semantic-sigil-clearance.test.mjs` — new, 3 tests, one per affected renderer. Each reads the sigil transform and the label from the **same node group in the final SVG** and asserts they do not overlap. Labels are chosen per renderer so each case actually collides before the fix rather than passing vacuously.

`node --test test/layout-rules.test.mjs` — 97 → 98, adding the validator case.

**Negative control**, reverting only `archify/renderers/` and keeping both tests:

```
test/semantic-sigil-clearance.test.mjs   # pass 0   # fail 3
test/layout-rules.test.mjs               not ok 18 - dataflow: node label cannot clear its semantic sigil
                                         # pass 97  # fail 1
```

Restored: 3/3 and 98/98.

**Full suite**, `npm test` from `archify/`, against clean `main` on the same machine:

| | tests | pass | fail |
|---|---|---|---|
| `main` (39a2113) | 1010 | 934 | 39 |
| this branch | 1014 | 939 | 38 |

Failure-set diff: **no new failures**. The pre-existing 38 are the symlink-privilege and CRLF-checkout families (see #144) and the Node-22 archive pin; all reproduce on clean `main` here.

## Regenerated artifacts

`npm run render:examples` for both the repo and packaged copies. Only one artifact changed content in each location; the other four were byte-identical and are not in this diff.

- `examples/sequence-cache-miss-request.html`
- `archify/examples/sequence-cache-miss-request.html`

The changed line is a single `<text data-node-label>` `x`, `602 → 602.4`. No geometry, routing, font size, or other element moved.

## Not verified

- **`archify.zip` is stale and I could not rebuild it.** The archive packages `renderers/shared/text-fit.mjs` and `renderers/shared/utils.mjs`, both changed here. `scripts/build-zip.sh` accepts only Node 22 and this machine has Node 20.18.1 / 20.19.5, so the archive is left untouched rather than published with the wrong zlib. Please rebuild on merge, or tell me the release identity you want and I will add it.
- **No browser or `visual-check` run.** Chrome is unavailable here, so `test/desktop-reader-browser.test.mjs` and `visual-check` were **skipped, not passed**. The clearance assertions are geometric, read from the final SVG. A screenshot review of the one regenerated artifact would be a useful second pair of eyes on how a re-centred label reads.
- Windows / Node 20 only.

🤖 Assisted by an AI agent; every measurement, negative control, and suite comparison above was run and is reproducible.
