### PR TITLE
docs: clarify visual evidence requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -86,25 +86,13 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: visual_impact
-    attributes:
-      label: Is this a visual problem?
-      description: Visual problems affect the final diagram, Viewer, or public page appearance or interaction.
-      options:
-        - Yes — I attached the current final-artifact screenshot below
-        - No — a screenshot is not applicable
-    validations:
-      required: true
-
   - type: upload
-    id: screenshot
+    id: visual_evidence
     attributes:
-      label: Current visual result
-      description: For visual problems, upload the current final-artifact screenshot and mark the defect if it is subtle.
+      label: Supporting visual evidence
+      description: When it helps reviewers evaluate a visual problem, upload screenshots or recordings and mark subtle defects. Reproducible steps above may be enough when media would not add useful context.
     validations:
       required: false
-      accept: ".png,.jpg,.jpeg,.webp,.gif"
 
   - type: textarea
     id: environment

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -86,11 +86,25 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: dropdown
+    id: visual_impact
+    attributes:
+      label: Is this a visual problem?
+      description: Visual problems affect the final diagram, Viewer, or public page appearance or interaction.
+      options:
+        - Yes — I attached the current final-artifact screenshot below
+        - No — a screenshot is not applicable
+    validations:
+      required: true
+
+  - type: upload
     id: screenshot
     attributes:
-      label: Optional final-artifact screenshot
-      description: Drag in a screenshot when the problem is visual. Mark the defect if it is subtle.
+      label: Current visual result
+      description: For visual problems, upload the current final-artifact screenshot and mark the defect if it is subtle.
+    validations:
+      required: false
+      accept: ".png,.jpg,.jpeg,.webp,.gif"
 
   - type: textarea
     id: environment

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,21 +20,14 @@ List exact commands and results. Do not write only “tests pass.”
 
 ## Visual evidence
 
-For visible changes, attach comparable final-artifact screenshots generated from the same input. For non-visual changes, write “Not applicable” and briefly explain why.
+Provide enough evidence to evaluate whether the intended user value was achieved. Use screenshots, recordings, or reproducible steps as appropriate to the affected behavior. For non-visual changes, write “Not applicable” and briefly explain why.
 
-### Before
+- Evidence provided:
+- Comparison conditions, when applicable (input, viewport, theme, preset, diagram mode, zoom, and page state):
+- Automated or browser checks:
+- Perceptual visual review: passed / failed / skipped / Not applicable
 
-<!-- Attach the result before this change. -->
-
-### After
-
-<!-- Attach the result after this change. -->
-
-- Reproduction input or fixture:
-- Viewport, theme, preset, or diagram mode:
-- Visual review: passed / failed / skipped / Not applicable
-
-Visible changes must reach `passed` before final review or merge. Draft pull requests may report `failed` or `skipped` while evidence or fixes are still in progress.
+When presenting a before/after comparison, keep its conditions genuinely comparable. Report automated or browser evidence separately from perceptual review; an automated check does not establish a perceptual pass.
 
 ## Generated artifacts
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,21 @@ List exact commands and results. Do not write only “tests pass.”
 
 ## Visual evidence
 
-For visible changes, attach before/after final-artifact screenshots and state whether visual review passed, failed, or was skipped. Write “Not applicable” for non-visual changes.
+For visible changes, attach comparable final-artifact screenshots generated from the same input. For non-visual changes, write “Not applicable” and briefly explain why.
+
+### Before
+
+<!-- Attach the result before this change. -->
+
+### After
+
+<!-- Attach the result after this change. -->
+
+- Reproduction input or fixture:
+- Viewport, theme, preset, or diagram mode:
+- Visual review: passed / failed / skipped / Not applicable
+
+Visible changes must reach `passed` before final review or merge. Draft pull requests may report `failed` or `skipped` while evidence or fixes are still in progress.
 
 ## Generated artifacts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,11 +124,11 @@ A useful bug report or fix contains:
 2. The smallest redacted typed JSON that still reproduces the failure.
 3. The complete machine-readable validation receipt or exact error.
 4. Expected versus actual behavior.
-5. The current final-artifact screenshot when the problem is visual. Mark subtle defects in the image and describe the expected visual result. Screenshots are not required for non-visual problems.
+5. Enough visual evidence to evaluate the problem when it is visual. Use screenshots, recordings, or reproducible steps as appropriate, mark subtle defects when useful, and describe the expected visual result. Media is not required when it would not add useful context.
 
-Do not replace deterministic evidence with a screenshot. For visual defects, keep both the validator result and final rendered evidence.
+Do not replace deterministic evidence with visual evidence. For visual defects, keep both the validator result and final rendered evidence.
 
-A pull request that changes the final diagram, Viewer, or public page appearance or interaction must include comparable before/after final-artifact screenshots. Generate both from the same input and keep the viewport, theme, preset, diagram mode, zoom, and page state consistent. Cover only the combinations affected by the change; use GIF or WebM when static screenshots cannot demonstrate an interaction. Draft pull requests may report visual review as `failed` or `skipped`, but visible changes must reach `passed` before final review or merge. A non-visual pull request must write `Not applicable` in its Visual evidence section and briefly explain why.
+A pull request that changes the final diagram, Viewer, or public page appearance or interaction must provide enough evidence to evaluate whether the intended user value was achieved. Use screenshots, recordings, or reproducible steps as appropriate to the affected behavior. When presenting a before/after comparison, generate both states from the same input and keep the viewport, theme, preset, diagram mode, zoom, and page state comparable. Report automated or browser evidence separately from perceptual review; an automated check does not establish a perceptual pass. A non-visual pull request must write `Not applicable` in its Visual evidence section and briefly explain why. Remove sensitive data from every submitted artifact.
 
 ## Community showcase submissions
 
@@ -142,8 +142,8 @@ Maintainers may ask for a smaller source file, rerun validation, or decline a ca
 - Complete `.github/PULL_REQUEST_TEMPLATE.md` with exact commands and numeric results; do not write only “tests pass.”
 - Add or update a regression test for behavioral changes.
 - Confirm existing public examples and compatibility fixtures still behave as intended.
-- Attach comparable before/after final-artifact screenshots for visible changes, or explain why visual evidence is not applicable.
-- State `visual review: passed`, `failed`, or `skipped` truthfully for visible changes; it must reach `passed` before final review or merge.
+- Provide enough evidence to evaluate the intended user value, using screenshots, recordings, or reproducible steps as appropriate, or explain why visual evidence is not applicable.
+- Report automated or browser evidence separately from perceptual review, and state each result truthfully.
 - Confirm remote CI actually ran on the current head. Local green checks do not mean GitHub CI passed, and zero checks is not green.
 - Remove unrelated files, debug output, local paths, generated noise, and sensitive data from the diff.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,11 @@ A useful bug report or fix contains:
 2. The smallest redacted typed JSON that still reproduces the failure.
 3. The complete machine-readable validation receipt or exact error.
 4. Expected versus actual behavior.
-5. A final-artifact screenshot only when the problem is visual.
+5. The current final-artifact screenshot when the problem is visual. Mark subtle defects in the image and describe the expected visual result. Screenshots are not required for non-visual problems.
 
 Do not replace deterministic evidence with a screenshot. For visual defects, keep both the validator result and final rendered evidence.
+
+A pull request that changes the final diagram, Viewer, or public page appearance or interaction must include comparable before/after final-artifact screenshots. Generate both from the same input and keep the viewport, theme, preset, diagram mode, zoom, and page state consistent. Cover only the combinations affected by the change; use GIF or WebM when static screenshots cannot demonstrate an interaction. Draft pull requests may report visual review as `failed` or `skipped`, but visible changes must reach `passed` before final review or merge. A non-visual pull request must write `Not applicable` in its Visual evidence section and briefly explain why.
 
 ## Community showcase submissions
 
@@ -140,7 +142,8 @@ Maintainers may ask for a smaller source file, rerun validation, or decline a ca
 - Complete `.github/PULL_REQUEST_TEMPLATE.md` with exact commands and numeric results; do not write only “tests pass.”
 - Add or update a regression test for behavioral changes.
 - Confirm existing public examples and compatibility fixtures still behave as intended.
-- State `visual review: passed`, `failed`, or `skipped` truthfully for visible changes.
+- Attach comparable before/after final-artifact screenshots for visible changes, or explain why visual evidence is not applicable.
+- State `visual review: passed`, `failed`, or `skipped` truthfully for visible changes; it must reach `passed` before final review or merge.
 - Confirm remote CI actually ran on the current head. Local green checks do not mean GitHub CI passed, and zero checks is not green.
 - Remove unrelated files, debug output, local paths, generated noise, and sensitive data from the diff.
 

--- a/archify/test/community-proof-intake.test.mjs
+++ b/archify/test/community-proof-intake.test.mjs
@@ -53,6 +53,8 @@ test('bug intake captures a minimal deterministic reproduction before visual dia
     'id: validation_receipt',
     'id: expected',
     'id: actual',
+    'id: visual_impact',
+    'id: screenshot',
     'id: environment',
     'id: sensitive_data',
   ]) {
@@ -60,8 +62,19 @@ test('bug intake captures a minimal deterministic reproduction before visual dia
   }
   assert.ok(
     template.indexOf('id: validation_receipt') < template.indexOf('id: screenshot'),
-    'deterministic evidence should be requested before optional visual evidence',
+    'deterministic evidence should be requested before visual evidence',
   );
+  const screenshotBlock = template.slice(
+    template.indexOf('id: screenshot'),
+    template.indexOf('id: environment'),
+  );
+  assert.match(template, /type: upload\s+id: screenshot/);
+  assert.match(screenshotBlock, /required:\s*false/);
+  assert.match(screenshotBlock, /For visual problems, upload/i);
+  assert.doesNotMatch(screenshotBlock, /Required for visual problems/i);
+  assert.match(template, /Yes — I attached the current final-artifact screenshot below/);
+  assert.match(template, /No — a screenshot is not applicable/);
+  assert.match(template, /accept: "\.png,\.jpg,\.jpeg,\.webp,\.gif"/);
 });
 
 test('contributor and pull-request guides keep proof changes reproducible and stability-first', () => {
@@ -97,8 +110,16 @@ test('contributor and pull-request guides keep proof changes reproducible and st
     'Tests run',
     'Generated artifacts',
     'Visual evidence',
+    '### Before',
+    '### After',
+    'Visual review: passed / failed / skipped / Not applicable',
     'No unrelated changes',
   ]) {
     assert.match(pullRequest, new RegExp(required), required);
   }
+  assert.match(contributing, /comparable before\/after final-artifact screenshots/i);
+  assert.match(contributing, /same input/i);
+  assert.match(contributing, /visible changes must reach `passed` before final review or merge/i);
+  assert.match(contributing, /non-visual pull request must write `Not applicable`/i);
+  assert.match(pullRequest, /Visible changes must reach `passed` before final review or merge/i);
 });

--- a/archify/test/community-proof-intake.test.mjs
+++ b/archify/test/community-proof-intake.test.mjs
@@ -53,28 +53,26 @@ test('bug intake captures a minimal deterministic reproduction before visual dia
     'id: validation_receipt',
     'id: expected',
     'id: actual',
-    'id: visual_impact',
-    'id: screenshot',
+    'id: visual_evidence',
     'id: environment',
     'id: sensitive_data',
   ]) {
     assert.match(template, new RegExp(field), field);
   }
   assert.ok(
-    template.indexOf('id: validation_receipt') < template.indexOf('id: screenshot'),
+    template.indexOf('id: validation_receipt') < template.indexOf('id: visual_evidence'),
     'deterministic evidence should be requested before visual evidence',
   );
-  const screenshotBlock = template.slice(
-    template.indexOf('id: screenshot'),
+  const evidenceBlock = template.slice(
+    template.indexOf('id: visual_evidence'),
     template.indexOf('id: environment'),
   );
-  assert.match(template, /type: upload\s+id: screenshot/);
-  assert.match(screenshotBlock, /required:\s*false/);
-  assert.match(screenshotBlock, /For visual problems, upload/i);
-  assert.doesNotMatch(screenshotBlock, /Required for visual problems/i);
-  assert.match(template, /Yes — I attached the current final-artifact screenshot below/);
-  assert.match(template, /No — a screenshot is not applicable/);
-  assert.match(template, /accept: "\.png,\.jpg,\.jpeg,\.webp,\.gif"/);
+  assert.match(template, /type: upload\s+id: visual_evidence/);
+  assert.match(evidenceBlock, /required:\s*false/);
+  assert.match(evidenceBlock, /screenshots or recordings/i);
+  assert.match(evidenceBlock, /Reproducible steps above may be enough/i);
+  assert.doesNotMatch(evidenceBlock, /Required for visual problems/i);
+  assert.doesNotMatch(evidenceBlock, /accept:/);
 });
 
 test('contributor and pull-request guides keep proof changes reproducible and stability-first', () => {
@@ -110,16 +108,20 @@ test('contributor and pull-request guides keep proof changes reproducible and st
     'Tests run',
     'Generated artifacts',
     'Visual evidence',
-    '### Before',
-    '### After',
-    'Visual review: passed / failed / skipped / Not applicable',
+    'Evidence provided:',
+    'Automated or browser checks:',
+    'Perceptual visual review: passed / failed / skipped / Not applicable',
     'No unrelated changes',
   ]) {
     assert.match(pullRequest, new RegExp(required), required);
   }
-  assert.match(contributing, /comparable before\/after final-artifact screenshots/i);
+  assert.match(contributing, /enough evidence to evaluate whether the intended user value was achieved/i);
+  assert.match(contributing, /screenshots, recordings, or reproducible steps/i);
   assert.match(contributing, /same input/i);
-  assert.match(contributing, /visible changes must reach `passed` before final review or merge/i);
+  assert.match(contributing, /automated or browser evidence separately from perceptual review/i);
   assert.match(contributing, /non-visual pull request must write `Not applicable`/i);
-  assert.match(pullRequest, /Visible changes must reach `passed` before final review or merge/i);
+  assert.match(pullRequest, /screenshots, recordings, or reproducible steps/i);
+  assert.match(pullRequest, /automated or browser evidence separately from perceptual review/i);
+  assert.doesNotMatch(contributing, /must reach `passed` before final review or merge/i);
+  assert.doesNotMatch(pullRequest, /must reach `passed` before final review or merge/i);
 });


### PR DESCRIPTION
## Problem and value

Closes #298.

Archify's visible output is often easiest to review with concrete evidence, but the evidence should stay proportional to the affected behavior. This change asks contributors for enough truthful, reproducible evidence to evaluate the intended user value without turning contribution into a rigid media checklist.

## Scope

- What changed: clarified optional visual evidence in the bug form, made the PR template outcome-oriented, documented screenshots, recordings, or reproducible steps as appropriate evidence, separated automated or browser evidence from perceptual review, and updated the intake contract test.
- What deliberately did not change: no CI enforcement, blank-issue policy, renderer behavior, schema, visual-check runtime, or generated artifacts.
- No unrelated changes: confirmed.

## Stability impact

- Compatibility and migration risk: none; this changes contribution intake and guidance only.
- Renderer, validator, package, or generated-artifact risk: none.
- Failure behavior and rollback path: revert the two documentation/template commits to restore the previous intake wording.

## Tests run

- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/bug-report.yml")'` — passed; the issue form is valid YAML.
- `node --test archify/test/community-proof-intake.test.mjs` — 3 passed, 0 failed.
- `cd archify && npm test` — 1000 passed, 0 failed, 27 skipped on the current head after syncing #275.
- `git diff --check` — passed.

## Visual evidence

Not applicable — this changes repository contribution forms and guidance, not an Archify diagram, Viewer, or public product page.

- Evidence provided: Not applicable.
- Comparison conditions: Not applicable.
- Automated or browser checks: Not applicable for product visuals; the deterministic template checks are listed above.
- Perceptual visual review: Not applicable.

## Generated artifacts

None. No generated-artifact source changed, so Gallery pages, guides, README proofs, and `archify.zip` remain fresh.

## Checklist

- [x] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [x] I ran the relevant targeted tests and `npm test` in `archify/`.
- [x] I added or updated a regression test for behavioral changes.
- [x] I checked generated artifacts and package freshness when their sources changed.
- [x] I removed secrets, private repository content, and customer data from fixtures and screenshots.
