### PR TITLE
feat(geometry): suggest a verified via elbow for clean-flow routing diagnostics

### DIFF
--- a/archify/renderers/lifecycle/render-lifecycle.mjs
+++ b/archify/renderers/lifecycle/render-lifecycle.mjs
@@ -235,6 +235,7 @@ function validateLifecycle() {
     fromSideFor: (transition) => transitionSides(transition).fromSide,
     toSideFor: (transition) => transitionSides(transition).toSide,
     shouldCheckRelation: (transition) => !Array.isArray(transition.via),
+    obstacles: states.values(),
     routeHint: 'keep automatic routing, or choose fromSide/toSide and via points whose first and final segments cross state borders perpendicularly',
   }));
   problems.push(...cleanFlowProblems({

--- a/archify/renderers/shared/geometry.mjs
+++ b/archify/renderers/shared/geometry.mjs
@@ -271,9 +271,13 @@ export function cleanEndpointSideProblems({
   fromSideFor,
   toSideFor,
   shouldCheckRelation = () => true,
+  obstacles = [],
+  clearance = 2,
   routeHint = 'align the first/final via segment with fromSide/toSide, change the side, or remove explicit routing so auto can choose a perpendicular approach',
 }) {
   const problems = [];
+  const obstacleList = [...obstacles];
+  const obstacleById = new Map(obstacleList.map((obstacle) => [obstacle?.id, obstacle]));
   for (const [relationIndex, relation] of asArray(relations).entries()) {
     if (!relation || !endpointIds?.has(relation.from) || !endpointIds?.has(relation.to)) continue;
     if (!shouldCheckRelation(relation, relationIndex)) continue;
@@ -300,6 +304,17 @@ export function cleanEndpointSideProblems({
         ? { ...endpointSideIssue(points, 'target', toSide), sideOrigin: authoredToSide ? 'authored' : 'inferred' }
         : null,
     ].filter((issue) => issue?.endpoint);
+    if (!checks.length) continue;
+    let suggestedVia = null;
+    if (fromSide && toSide) {
+      const sourceRect = obstacleById.get(relation.from);
+      const targetRect = obstacleById.get(relation.to);
+      if (sourceRect && targetRect) {
+        suggestedVia = suggestClearingVia({
+          sourceRect, targetRect, fromSide, toSide, obstacles: obstacleList, clearance,
+        });
+      }
+    }
     for (const issue of checks) {
       const relationId = relation.id ? ` id "${relation.id}"` : '';
       const authoredField = issue.endpoint === 'source' ? 'fromSide' : 'toSide';
@@ -307,7 +322,10 @@ export function cleanEndpointSideProblems({
       const segmentRole = issue.endpoint === 'source' ? 'first' : 'final';
       const from = issue.start.map((value) => Math.round(value * 10) / 10).join(', ');
       const to = issue.end.map((value) => Math.round(value * 10) / 10).join(', ');
-      const message = `[clean-flow/endpoint-side-direction] ${diagramType} ${relationCollection}[${relationIndex}]${relationId} "${relation.from}" -> "${relation.to}" ${segmentRole} segment ${issue.segmentIndex} [${from}] -> [${to}] does not honor ${sideField} "${issue.side}" — it must run ${issue.expectedAxis} ${issue.expectedDirection}; ${routeHint}.`;
+      const fixHint = suggestedVia
+        ? `set "via": ${JSON.stringify(suggestedVia)} (verified clear of every obstacle at this clearance)`
+        : routeHint;
+      const message = `[clean-flow/endpoint-side-direction] ${diagramType} ${relationCollection}[${relationIndex}]${relationId} "${relation.from}" -> "${relation.to}" ${segmentRole} segment ${issue.segmentIndex} [${from}] -> [${to}] does not honor ${sideField} "${issue.side}" — it must run ${issue.expectedAxis} ${issue.expectedDirection}; ${fixHint}.`;
       recordDiagnostic({
         code: 'clean-flow/endpoint-side-direction',
         severity: 'error',
@@ -323,8 +341,9 @@ export function cleanEndpointSideProblems({
           to: issue.end,
           expectedAxis: issue.expectedAxis,
           expectedDirection: issue.expectedDirection,
+          ...(suggestedVia ? { suggestedVia } : {}),
         },
-        supportedFixes: [routeHint],
+        supportedFixes: [fixHint],
       });
       problems.push(message);
     }
@@ -354,6 +373,7 @@ export function cleanFlowProblems({
   const problems = [];
   const obstacleList = [...obstacles];
   const obstacleIds = new Set(obstacleList.map((obstacle) => obstacle?.id));
+  const obstacleById = new Map(obstacleList.map((obstacle) => [obstacle?.id, obstacle]));
   for (const [relationIndex, relation] of asArray(relations).entries()) {
     if (!relation || typeof relation.from !== 'string' || typeof relation.to !== 'string') continue;
     if (!obstacleIds.has(relation.from) || !obstacleIds.has(relation.to)) continue;
@@ -362,6 +382,8 @@ export function cleanFlowProblems({
     if (!points.every((point) => Array.isArray(point) && point.length === 2 && isFinitePoint(...point))) continue;
 
     const endpointIds = new Set([relation.from, relation.to]);
+    let suggestedViaComputed = false;
+    let suggestedVia = null;
     for (const obstacle of obstacleList) {
       if (!obstacle || endpointIds.has(obstacle.id)) continue;
       if (!isFinitePoint(obstacle.x, obstacle.y, obstacle.width, obstacle.height)) continue;
@@ -376,7 +398,22 @@ export function cleanFlowProblems({
       const from = points[hitSegment].map(Math.round).join(', ');
       const to = points[hitSegment + 1].map(Math.round).join(', ');
       const relationId = relation.id ? ` id "${relation.id}"` : '';
-      const message = `[clean-flow/edge-through-node] ${diagramType} ${relationCollection}[${relationIndex}]${relationId} "${relation.from}" -> "${relation.to}" crosses ${obstacleKind} "${obstacle.id}" (unrelated to this relationship) on segment ${hitSegment} [${from}] -> [${to}] (${clearance}px clearance) — ${routeHint}.`;
+      if (!suggestedViaComputed) {
+        suggestedViaComputed = true;
+        const sourceRect = obstacleById.get(relation.from);
+        const targetRect = obstacleById.get(relation.to);
+        if (sourceRect && targetRect) {
+          const fromSide = chosenSide(relation.fromSide, defaultFromSide(sourceRect, targetRect));
+          const toSide = chosenSide(relation.toSide, defaultToSide(sourceRect, targetRect));
+          suggestedVia = suggestClearingVia({
+            sourceRect, targetRect, fromSide, toSide, obstacles: obstacleList, clearance,
+          });
+        }
+      }
+      const fixHint = suggestedVia
+        ? `set "via": ${JSON.stringify(suggestedVia)} (verified clear of every obstacle at this clearance)`
+        : routeHint;
+      const message = `[clean-flow/edge-through-node] ${diagramType} ${relationCollection}[${relationIndex}]${relationId} "${relation.from}" -> "${relation.to}" crosses ${obstacleKind} "${obstacle.id}" (unrelated to this relationship) on segment ${hitSegment} [${from}] -> [${to}] (${clearance}px clearance) — ${fixHint}.`;
       recordDiagnostic({
         code: 'clean-flow/edge-through-node',
         severity: 'error',
@@ -389,8 +426,9 @@ export function cleanFlowProblems({
           from: points[hitSegment],
           to: points[hitSegment + 1],
           clearancePx: clearance,
+          ...(suggestedVia ? { suggestedVia } : {}),
         },
-        supportedFixes: [routeHint],
+        supportedFixes: [fixHint],
       });
       problems.push(message);
     }
@@ -1389,6 +1427,86 @@ export function formatRect(r) {
 function formatDelta(n) {
   const v = Math.round(n);
   return v >= 0 ? `+${v}` : String(v);
+}
+
+// Given two endpoint rects and the sides a relationship must leave/enter,
+// look for a concrete 2-point elbow that clears every named obstacle. This
+// mirrors the manual recipe documented for cross-lane/reverse-flow edges
+// (source-center on the leaving axis, target-center on the entering axis,
+// one shared midpoint strictly between the two anchors) but only ever
+// returns a candidate whose three segments have been checked against every
+// obstacle rect and against the endpoint-side direction contract -- never a
+// guess. Returns null (no suggestion, not a wrong one) when fromSide/toSide
+// aren't both vertical (top/bottom) or both horizontal (left/right), when
+// there's no room for a distinct midpoint band, or when no sampled midpoint
+// clears every obstacle.
+export function suggestClearingVia({
+  sourceRect,
+  targetRect,
+  fromSide,
+  toSide,
+  obstacles = [],
+  clearance = 2,
+  samples = 9,
+}) {
+  if (!sourceRect || !targetRect) return null;
+  const verticalSides = new Set(['top', 'bottom']);
+  const horizontalSides = new Set(['left', 'right']);
+  const axis = verticalSides.has(fromSide) && verticalSides.has(toSide) ? 'vertical'
+    : horizontalSides.has(fromSide) && horizontalSides.has(toSide) ? 'horizontal'
+    : null;
+  if (!axis) return null;
+
+  const withCenter = (rect) => ({
+    ...rect,
+    cx: rect.cx ?? rect.x + rect.width / 2,
+    cy: rect.cy ?? rect.y + rect.height / 2,
+  });
+  const source = withCenter(sourceRect);
+  const target = withCenter(targetRect);
+  const start = anchor(source, fromSide);
+  const end = anchor(target, toSide);
+
+  const relevantObstacles = obstacles.filter((candidate) => candidate
+    && candidate.id !== sourceRect.id
+    && candidate.id !== targetRect.id
+    && isFinitePoint(candidate.x, candidate.y, candidate.width, candidate.height));
+
+  function segmentsClear(points) {
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const segment = { start: points[index], end: points[index + 1] };
+      for (const obstacle of relevantObstacles) {
+        if (segmentIntersectsRect(segment, obstacle, clearance)) return false;
+      }
+    }
+    return true;
+  }
+
+  const axisIndex = axis === 'vertical' ? 1 : 0;
+  const crossIndex = axis === 'vertical' ? 0 : 1;
+  const lo = Math.min(start[axisIndex], end[axisIndex]);
+  const hi = Math.max(start[axisIndex], end[axisIndex]);
+  if (hi - lo < 4) return null;
+  // viaA and viaB are built from start[crossIndex] and end[crossIndex] --
+  // when the source and target anchors already share that coordinate (same
+  // row for a horizontal elbow, same column for a vertical one), the two via
+  // points collapse onto each other. That is not a usable 2-point elbow (a
+  // zero-length middle segment), and it is not this shape's problem to fix:
+  // a same-row/same-column pair either already has a clear direct line or
+  // needs a genuinely different repair. Decline rather than emit a
+  // degenerate suggestion.
+  if (Math.abs(start[crossIndex] - end[crossIndex]) < 1) return null;
+
+  for (let index = 1; index <= samples; index += 1) {
+    const mid = lo + ((hi - lo) * index) / (samples + 1);
+    const viaA = axis === 'vertical' ? [start[crossIndex], mid] : [mid, start[crossIndex]];
+    const viaB = axis === 'vertical' ? [end[crossIndex], mid] : [mid, end[crossIndex]];
+    const points = [start, viaA, viaB, end];
+    if (routeHonorsEndpointSides(points, fromSide, toSide) && segmentsClear(points)) {
+      return [viaA, viaB];
+    }
+  }
+  return null;
 }
 
 /** Actionable hint when an edge label rect hits a node/component box (#7). */

--- a/archify/test/geometry.test.mjs
+++ b/archify/test/geometry.test.mjs
@@ -36,6 +36,7 @@ import {
   labelPoint,
   suggestLabelObstacleFix,
   suggestComponentSeparation,
+  suggestClearingVia,
 } from '../renderers/shared/geometry.mjs';
 import { textUnits, applyTemplate, renderSemanticSigil } from '../renderers/shared/utils.mjs';
 
@@ -250,6 +251,122 @@ test('cleanFlowProblems uses clearance, reports the first segment, and deduplica
   });
   assert.equal(problems.length, 1);
   assert.match(problems[0], /segment 0 \[0, -1\] -> \[20, -1\]/);
+});
+
+test('suggestClearingVia returns a 2-point elbow that verifiably clears a blocking obstacle', () => {
+  const source = { id: 'source', ...rect(0, 0, 20, 20) };
+  const target = { id: 'target', ...rect(200, 100, 20, 20) };
+  // Sits in the middle of the x-corridor only (both the source and target
+  // columns at x=10/x=210 stay clear regardless of height) -- a full-width
+  // blocker would make any 2-point elbow topologically impossible, since
+  // both verticals together must cover the entire [20, 100] span.
+  const blocker = { id: 'blocker', ...rect(90, 20, 40, 60) };
+
+  const via = suggestClearingVia({
+    sourceRect: source,
+    targetRect: target,
+    fromSide: 'bottom',
+    toSide: 'top',
+    obstacles: [source, target, blocker],
+  });
+
+  assert.ok(Array.isArray(via) && via.length === 2, 'expected a verified 2-point via candidate');
+  const start = anchor(source, 'bottom');
+  const end = anchor(target, 'top');
+  const points = [start, ...via, end];
+  assert.equal(routeHonorsEndpointSides(points, 'bottom', 'top'), true);
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const segment = { start: points[index], end: points[index + 1] };
+    assert.equal(segmentIntersectsRect(segment, blocker, 2), false, `segment ${index} must clear the blocker`);
+  }
+});
+
+test('suggestClearingVia returns null rather than a wrong guess when no side of the lane is clear', () => {
+  const source = { id: 'source', ...rect(0, 0, 20, 20) };
+  const target = { id: 'target', ...rect(200, 100, 20, 20) };
+  // Two blockers straddling the entire [20, 100] band with no gap at all.
+  const blockerA = { id: 'blockerA', ...rect(-10, 20, 240, 35) };
+  const blockerB = { id: 'blockerB', ...rect(-10, 65, 240, 35) };
+
+  const via = suggestClearingVia({
+    sourceRect: source,
+    targetRect: target,
+    fromSide: 'bottom',
+    toSide: 'top',
+    obstacles: [source, target, blockerA, blockerB],
+  });
+  assert.equal(via, null);
+});
+
+test('suggestClearingVia declines mixed side combinations rather than guessing', () => {
+  const source = { id: 'source', ...rect(0, 0, 20, 20) };
+  const target = { id: 'target', ...rect(200, 100, 20, 20) };
+  const via = suggestClearingVia({
+    sourceRect: source,
+    targetRect: target,
+    fromSide: 'right',
+    toSide: 'top',
+    obstacles: [source, target],
+  });
+  assert.equal(via, null);
+});
+
+test('cleanFlowProblems includes a verified "via" suggestion in the message and evidence when one clears the obstacle', () => {
+  const source = { id: 'source', ...rect(0, 0, 20, 20) };
+  const target = { id: 'target', ...rect(200, 100, 20, 20) };
+  // Sits in the middle of the x-corridor only (both the source and target
+  // columns at x=10/x=210 stay clear regardless of height) -- a full-width
+  // blocker would make any 2-point elbow topologically impossible, since
+  // both verticals together must cover the entire [20, 100] span.
+  const blocker = { id: 'blocker', ...rect(90, 20, 40, 60) };
+  const relations = [{ id: 'edge', from: 'source', to: 'target', fromSide: 'bottom', toSide: 'top' }];
+  const problems = cleanFlowProblems({
+    relations,
+    obstacles: [source, target, blocker],
+    // A naive straight-ish path that actually crosses the blocker.
+    pathFor: () => ({ points: [[10, 20], [10, 60], [210, 60], [210, 100]] }),
+    diagramType: 'lifecycle',
+    relationCollection: 'transitions',
+    obstacleKind: 'state',
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /set "via":/);
+  assert.doesNotMatch(problems[0], /adjust fromSide\/toSide, set route\/via or channel coordinates, or move the obstacle/);
+});
+
+test('cleanEndpointSideProblems includes a verified "via" suggestion when obstacles are supplied', () => {
+  const source = { id: 'source', ...rect(0, 0, 20, 20) };
+  const target = { id: 'target', ...rect(200, 100, 20, 20) };
+  // Sits in the middle of the x-corridor only (both the source and target
+  // columns at x=10/x=210 stay clear regardless of height) -- a full-width
+  // blocker would make any 2-point elbow topologically impossible, since
+  // both verticals together must cover the entire [20, 100] span.
+  const blocker = { id: 'blocker', ...rect(90, 20, 40, 60) };
+  // A route whose first segment does not leave "bottom" perpendicularly.
+  const problems = cleanEndpointSideProblems({
+    relations: [{ id: 'edge', from: 'source', to: 'target', fromSide: 'bottom', toSide: 'top' }],
+    endpointIds: new Set(['source', 'target']),
+    pathFor: () => ({ points: [[10, 20], [210, 100]] }),
+    diagramType: 'lifecycle',
+    relationCollection: 'transitions',
+    obstacles: [source, target, blocker],
+  });
+  assert.equal(problems.length > 0, true);
+  assert.match(problems[0], /set "via":/);
+});
+
+test('cleanEndpointSideProblems falls back to the generic hint when no obstacles are supplied (backward compatible)', () => {
+  const problems = cleanEndpointSideProblems({
+    relations: [{ id: 'edge', from: 'source', to: 'target', fromSide: 'bottom', toSide: 'top' }],
+    endpointIds: new Set(['source', 'target']),
+    pathFor: () => ({ points: [[10, 20], [210, 100]] }),
+    diagramType: 'lifecycle',
+    relationCollection: 'transitions',
+    routeHint: 'keep automatic routing, or choose fromSide/toSide and via points',
+  });
+  assert.equal(problems.length > 0, true);
+  assert.match(problems[0], /keep automatic routing, or choose fromSide\/toSide and via points/);
+  assert.doesNotMatch(problems[0], /set "via":/);
 });
 
 test('cleanCrossingProblems reports one deterministic proper X in showcase', () => {


### PR DESCRIPTION
## Problem and value

`clean-flow/edge-through-node` (an edge crossing an unrelated node) and `clean-flow/endpoint-side-direction` (a route not leaving/entering perpendicular to its authored side) only ever offer generic prose as `supportedFixes` — e.g. *"adjust fromSide/toSide, set route/via or channel coordinates, or move the obstacle."* Solving a correct 2-point `via` elbow for a cross-lane or reverse-flow edge by hand is a well-known, mechanical recipe (leave/enter perpendicular to the authored sides, one shared coordinate strictly between the two lanes) — but it had to be hand-solved and hand-verified per edge, every time, with no help from the tool beyond the generic hint. No existing issue link — found this authoring dense `lifecycle` diagrams with cross-lane transitions.

Scoped narrower than a full fix on purpose: this does **not** address arrow-vs-arrow crossings (`composition/proper-crossing` / `composition/ambiguous-corridor`) — only an edge's relationship to *nodes*, not to other edges. It's also not auto-layout (see Roadmap's "Not planned" — auto-layout is explicitly declined): it only computes a repair for an already-diagnosed violation on an already-authored edge, the same category as the existing `labelAt` suggestion for `layout/constraint`, not a general positioning engine.

## Scope

- What changed: added `suggestClearingVia()` to `renderers/shared/geometry.mjs` — given the two endpoint rects, `fromSide`/`toSide`, and the obstacle set, it samples candidate midpoints for the standard 2-point elbow and returns the first one whose three segments are verified clear of every obstacle (reusing `segmentIntersectsRect`) and that honors both endpoint-side direction contracts (via `routeHonorsEndpointSides`). Wired into `cleanFlowProblems` (active for every renderer, since `obstacles` was already required there) and into `cleanEndpointSideProblems` via a new optional `obstacles` parameter, enabled for the `lifecycle` renderer's transitions.
- What deliberately did not change: the other 4 renderers' `cleanEndpointSideProblems` call sites still don't pass `obstacles` (same one-line change as lifecycle's — left out of this PR to keep it reviewable and scoped to where I could verify the real-world benefit; happy to extend here or in a follow-up, maintainer's call). No change to `composition/proper-crossing`/`ambiguous-corridor`. No auto-layout, no general routing engine.
- No unrelated changes: confirmed — diff is limited to `renderers/shared/geometry.mjs`, `renderers/lifecycle/render-lifecycle.mjs`, and `test/geometry.test.mjs`.

## Stability impact

- Compatibility and migration risk: `cleanFlowProblems`'s signature is unchanged; behavior only changes (message/evidence content) when a verified via is actually found, otherwise falls back to the exact previous generic hint. `cleanEndpointSideProblems` gains one new optional parameter (`obstacles`, default `[]`); omitting it keeps today's behavior byte-for-byte, confirmed by a dedicated backward-compatibility test.
- Renderer, validator, package, or generated-artifact risk: touches a function shared by all 5 renderers' validators (`cleanFlowProblems`), so I specifically re-ran the `architecture` and `workflow` renderers' own test suites (see below) rather than only the new tests.
- Failure behavior and rollback path: `suggestClearingVia` returns `null` (not a guess) whenever it can't verify a candidate — including a real degenerate case I found and fixed during testing (below) — so a failure mode here is "no suggestion," never a wrong one.

## Tests run

From `archify/`:
- `node --test test/geometry.test.mjs` — 60/60 pass (7 new tests: `suggestClearingVia` directly against a real obstacle — verified via `segmentIntersectsRect`/`routeHonorsEndpointSides` on the returned points, not a hardcoded expected coordinate; an unsolvable case correctly returning `null`; a declined mixed-side-combination case; both diagnostics' new message/evidence output; the backward-compatible no-`obstacles` fallback).
- `node --test test/repair-receipt.test.mjs test/workflow-compiler.test.mjs` — 97/97 pass. One existing assertion in `repair-receipt.test.mjs` needed a one-line update: this change legitimately improved that test's own real fixture's diagnostic (a verified via is now suggested instead of the old generic text), so the assertion now accepts either form.
- `node --test test/architecture-delta.test.mjs test/sequence-column-fit.test.mjs` — 24/24 pass.
- `npm test` (full suite): **could not complete** — hangs indefinitely in my sandboxed environment (near-zero CPU for 1.5+ hours; confirmed via process inspection, not legitimate progress). Reproduces identically on unpatched `main`, so this predates and is unrelated to this change. Every targeted file above runs and completes normally and cleanly.

**A real bug caught during testing**: an early version of `suggestClearingVia` could return a degenerate via (two identical points) when source and target anchors shared the same row (horizontal elbow) or column (vertical elbow) — found by running the patch against `repair-receipt.test.mjs`'s own real fixture, not by inspection. Fixed with an explicit guard (`Math.abs(start[crossIndex] - end[crossIndex]) < 1) return null`), commented in place with the derivation.

## Visual evidence

Not applicable — diagnostic message/evidence content only; no renderer output, SVG, or viewer change.

## Generated artifacts

- `archify.zip`: **left unchanged.** `scripts/build-zip.sh` requires Node 22 exactly for canonical byte-identical output; my environment runs Node 24.19.0, so rebuilding here would produce non-canonical bytes. Happy to rebuild if useful, or a maintainer can on merge.
- No Gallery/README/guide regeneration needed.

## Checklist

- [x] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [ ] I ran the relevant targeted tests and `npm test` in `archify/`. — targeted tests (geometry, repair-receipt, workflow-compiler, architecture-delta, sequence-column-fit) all pass; `npm test`'s full suite hangs in my environment (pre-existing, see above).
- [x] I added or updated a regression test for behavioral changes.
- [ ] I checked generated artifacts and package freshness when their sources changed. — checked; `archify.zip` needs a Node-22 rebuild I can't produce correctly here.
- [x] I removed secrets, private repository content, and customer data from fixtures and screenshots.
