### PR TITLE
fix(repository-evidence): resolve two Windows-only --repo-root path-identity defects (#274)

### DIFF
--- a/archify/renderers/shared/repository-evidence.mjs
+++ b/archify/renderers/shared/repository-evidence.mjs
@@ -6,6 +6,34 @@ import { throwDiagnosticError } from './diagnostics.mjs';
 const FULL_SHA_RE = /^[a-f0-9]{40}$/i;
 const CONTROL_CHARACTER_RE = /[\u0000-\u001f\u007f]/;
 
+// Two Windows-only path-identity defects, both fixed together below:
+//
+// 1. (#274) fs.realpathSync does not normalize drive-letter case: resolving
+//    "c:\work\repo" and "C:\work\repo" both succeed but each can return its
+//    own input case rather than a single on-disk canonical form, so two
+//    spellings of the identical directory compare unequal under strict
+//    `!==`. Windows volumes are case-insensitive (case-preserving only), so
+//    path identity there must be checked case-insensitively -- handled by
+//    sameResolvedDirectory() below. POSIX volumes are case-sensitive, where
+//    the original strict comparison remains correct.
+// 2. Plain fs.realpathSync does not resolve legacy 8.3 short-name aliases
+//    (e.g. "JULIAN~1") to their long canonical form, but external tools
+//    like `git rev-parse --show-toplevel` report the long form. Any
+//    Windows account whose profile directory contains a space or exceeds 8
+//    characters (short-name generation's usual trigger) gets a short alias
+//    for its user directory, so any evidence root under it -- including a
+//    default OS temp dir -- fails this check even with identical drive
+//    letter case and identical everything else. `fs.realpathSync.native`
+//    calls the real Win32 GetFinalPathNameByHandleW syscall instead of
+//    Node's own JS symlink-walking implementation, which does resolve
+//    short names to their long form on both inputs consistently -- used at
+//    both realpath call sites in verifyRepositoryEvidence() below instead
+//    of plain fs.realpathSync.
+export function sameResolvedDirectory(a, b, platform = process.platform) {
+  if (platform === 'win32') return a.toLowerCase() === b.toLowerCase();
+  return a === b;
+}
+
 function evidenceFailure(code, message, { subject = {}, evidence = {}, supportedFixes = [] } = {}) {
   throwDiagnosticError(message, [{
     code,
@@ -121,7 +149,7 @@ export function verifyRepositoryEvidence(diagramType, diagram, repoRootInput) {
   const requestedRoot = path.resolve(repoRootInput);
   let realRoot;
   try {
-    realRoot = fs.realpathSync(requestedRoot);
+    realRoot = fs.realpathSync.native(requestedRoot);
   } catch (error) {
     evidenceFailure('repository-evidence/root-unreadable', `Could not resolve evidence repository root "${requestedRoot}": ${error.message}`, {
       subject: { repoRoot: requestedRoot },
@@ -130,7 +158,7 @@ export function verifyRepositoryEvidence(diagramType, diagram, repoRootInput) {
     });
   }
   const gitRoot = gitValue(realRoot, ['rev-parse', '--show-toplevel'], `Evidence root "${realRoot}" is not a Git repository.`);
-  if (fs.realpathSync(gitRoot) !== realRoot) {
+  if (!sameResolvedDirectory(fs.realpathSync.native(gitRoot), realRoot)) {
     evidenceFailure('repository-evidence/root-not-top-level', `Evidence root must be the Git top-level directory: ${gitRoot}`, {
       subject: { repoRoot: realRoot },
       evidence: { gitTopLevel: gitRoot },

--- a/archify/test/repository-evidence.test.mjs
+++ b/archify/test/repository-evidence.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { startPreview } from '../bin/preview.mjs';
+import { sameResolvedDirectory } from '../renderers/shared/repository-evidence.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const skillRoot = path.resolve(here, '..');
@@ -54,6 +55,18 @@ function evidencePayload(html) {
   assert.ok(match, 'verified evidence payload missing');
   return JSON.parse(match[1]);
 }
+
+test('sameResolvedDirectory treats differently-cased Windows drive letters as the same directory (#274)', () => {
+  assert.equal(sameResolvedDirectory('c:\\work\\evidence-repo', 'C:\\work\\evidence-repo', 'win32'), true);
+  assert.equal(sameResolvedDirectory('C:\\Work\\Evidence-Repo', 'c:\\work\\evidence-repo', 'win32'), true);
+  assert.equal(sameResolvedDirectory('C:\\work\\repo-a', 'C:\\work\\repo-b', 'win32'), false);
+});
+
+test('sameResolvedDirectory stays case-sensitive on POSIX (real defect there, not a Windows quirk)', () => {
+  assert.equal(sameResolvedDirectory('/work/evidence-repo', '/work/evidence-repo', 'linux'), true);
+  assert.equal(sameResolvedDirectory('/work/Evidence-Repo', '/work/evidence-repo', 'linux'), false);
+  assert.equal(sameResolvedDirectory('/work/Evidence-Repo', '/work/evidence-repo', 'darwin'), false);
+});
 
 test('repository evidence accepts canonical HTTPS and common SSH remotes', () => {
   const data = fixture();


### PR DESCRIPTION
## Problem and value

Fixes #274. `verifyRepositoryEvidence()` rejects a valid `--repo-root` whenever its resolved directory doesn't compare byte-identical (`!==`) to Git's own reported top-level directory — even when both refer to the exact same directory on disk. On Windows this breaks in two independent, compounding ways (details below). #274 already has an exact repro and pinpoints the offending line; while reproducing it I found a second, related defect on my own machine.

## Scope

- What changed: added `sameResolvedDirectory(a, b, platform)` (case-insensitive on `win32`, unchanged strict `===` on POSIX) and used it for the one comparison #274 identifies; switched both `fs.realpathSync` calls in `verifyRepositoryEvidence` to `fs.realpathSync.native` (see "A second defect" below).
- What deliberately did not change: the POSIX comparison path (already correct — POSIX volumes are case-sensitive); nothing outside `repository-evidence.mjs` and its test file.
- No unrelated changes: confirmed — diff is limited to `renderers/shared/repository-evidence.mjs` and `test/repository-evidence.test.mjs`.

### Defect 1 (#274 as reported): drive-letter case
`fs.realpathSync` doesn't normalize drive-letter case — `c:\work\repo` and `C:\work\repo` both resolve successfully but each preserves its own input case. Fixed with the case-insensitive `sameResolvedDirectory` on `win32`.

### Defect 2 (found independently while reproducing #274): 8.3 short-name aliasing
Plain `fs.realpathSync` does not resolve legacy 8.3 short-name aliases (e.g. `JULIAN~1`) to their long canonical form, but `git rev-parse --show-toplevel` reports the long form. Any Windows account whose profile directory contains a space or exceeds 8 characters — short-name generation's usual trigger — gets a short alias for its user directory, so any evidence root under it (including a default OS temp dir) fails this check even with identical drive-letter case and identical everything else.

I hit this for real, unprompted, just running this repo's own existing test suite on my machine (Windows 11, multi-word username) — `evidence fails closed without a root, on wrong origin, missing blobs, or impossible lines` failed on unpatched `main` with exactly this "root-not-top-level" mismatch, purely because its fixture lives under the default temp directory. Verified the mechanism directly with a small repro script: the two `fs.realpathSync` outputs that compare unequal do compare byte-identical via `fs.realpathSync.native`, which calls the real Win32 `GetFinalPathNameByHandleW` syscall instead of Node's own JS-based symlink-walking implementation. Switched both realpath call sites to `.native`.

## Stability impact

- Compatibility and migration risk: none on POSIX (comparison logic unchanged there). On Windows, this only makes the check *more* permissive for genuinely-identical directories — it cannot cause a previously-passing case to now fail, since it only removes false-negative mismatches, never introduces new ones (still a real, verified mismatch for two actually-different directories — see the negative-case test).
- Renderer, validator, package, or generated-artifact risk: contained to repository-evidence verification; no renderer or schema touched.
- Failure behavior and rollback path: unchanged — a genuine top-level mismatch still fails closed with the same diagnostic code and message shape.

## Tests run

From `archify/`:
- `node --test test/repository-evidence.test.mjs` — **7/8 pass** (2 new unit tests: win32 case-insensitivity with a genuine-mismatch negative case still correctly rejected; POSIX case-sensitivity on both `linux` and `darwin`). Both tests that previously failed here for Defect 2 now pass. The 8th failure (`live preview forwards repo-root...`) is a **distinct, pre-existing** native libuv crash (`Assertion failed: !_wcsnicmp(filename, dir, dirlen)`, `src/win/fs-event.c:72`) in a completely different subsystem (`preview.mjs`'s `fs.watch`-based live-reload) — confirmed this fix doesn't cause it by reverting it and observing the *same* test file fail *earlier*, at Defect 2, before ever reaching the live-preview test at all. Filing this as its own separate issue rather than bundling it here or silently omitting it — I want to be upfront that running this repo's test suite on my machine surfaces it, but it's unrelated to this diff.
- `node --test test/repair-receipt.test.mjs test/cli.test.mjs` — 43/47 pass, 3 pre-existing skips, 1 pre-existing unrelated failure (`preview runs from an installed skill and exits cleanly`, a SIGTERM/exit-code flake already reported against unpatched `main` in a prior PR from this same environment) — confirms no regression outside `repository-evidence`'s own test file.
- `npm test` (full suite): could not complete in my sandboxed environment for reasons unrelated to this change (documented in my other open PRs from this environment) — every targeted file above runs and completes normally.

## Visual evidence

Not applicable — path-comparison logic only, no rendered diagram or viewer change.

## Generated artifacts

- `archify.zip`: left unchanged — rebuilding requires Node 22 exactly for canonical bytes; my environment runs Node 24.19.0. Happy to rebuild if useful, or a maintainer can on merge.
- No Gallery/README/guide regeneration needed.

## Checklist

- [x] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [ ] I ran the relevant targeted tests and `npm test` in `archify/`. — targeted tests pass (see above); `npm test`'s full suite doesn't complete in my environment for unrelated, previously-documented reasons.
- [x] I added or updated a regression test for behavioral changes.
- [ ] I checked generated artifacts and package freshness when their sources changed. — checked; `archify.zip` needs a Node-22 rebuild I can't produce correctly here.
- [x] I removed secrets, private repository content, and customer data from fixtures and screenshots.
