### PR TITLE
fix: harden CLI receipts and preview watching

### DIFF
--- a/archify/bin/archify.mjs
+++ b/archify/bin/archify.mjs
@@ -1155,7 +1155,7 @@ async function commandPreview(args) {
 
 function commandCheck(args) {
   const [html] = args;
-  if (!html) fail(usage());
+  if (!html || args.length !== 1 || html.startsWith('--')) fail(usage());
   const result = runNode([path.join(skillRoot, 'scripts/check-render-output.mjs'), html]);
   if (result.status !== 0) exitFrom(result);
 }
@@ -1212,12 +1212,14 @@ async function commandVisualCheck(args) {
   process.exitCode = result.exitCode;
 }
 
-function commandExamples() {
+function commandExamples(args = []) {
+  if (args.length) fail(usage());
   const result = runNode([path.join(skillRoot, 'scripts/render-examples.mjs')], { cwd: skillRoot });
   if (result.status !== 0) exitFrom(result);
 }
 
-async function commandDoctor() {
+async function commandDoctor(args = []) {
+  if (args.length) fail(usage());
   const checks = [];
   const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
   checks.push({
@@ -1465,7 +1467,7 @@ async function commandBrands(args) {
 }
 
 function commandDemo(args) {
-  if (args.length > 1) fail(usage());
+  if (args.length > 1 || args[0]?.startsWith('--')) fail(usage());
 
   const outputDirectory = path.resolve(args[0] || process.cwd());
   const output = path.join(outputDirectory, 'archify-demo.html');
@@ -1984,10 +1986,10 @@ switch (command) {
     await commandBrands(args);
     break;
   case 'examples':
-    commandExamples();
+    commandExamples(args);
     break;
   case 'doctor':
-    await commandDoctor();
+    await commandDoctor(args);
     break;
   case 'demo':
     commandDemo(args);

--- a/archify/bin/preview.mjs
+++ b/archify/bin/preview.mjs
@@ -588,7 +588,10 @@ export async function startPreview(options) {
 
   if (options.watch !== false) {
     try {
-      watcher = fs.watch(path.dirname(inputPath), (event, filename) => {
+      const watchDirectory = process.platform === 'win32'
+        ? fs.realpathSync.native(path.dirname(inputPath))
+        : path.dirname(inputPath);
+      watcher = fs.watch(watchDirectory, (event, filename) => {
         if (!filename || filename.toString() === path.basename(inputPath)) observeSource();
       });
       watcher.on('error', () => {

--- a/archify/scripts/check-render-output.mjs
+++ b/archify/scripts/check-render-output.mjs
@@ -273,7 +273,7 @@ if (svgMatches.length === 1) {
 
 const ok = checks.every((check) => check.ok) && composition.status !== 'fail';
 console.log(JSON.stringify({ ok, file: htmlPath, checks, composition }, null, 2));
-process.exit(ok ? 0 : 1);
+process.exitCode = ok ? 0 : 1;
 
 function collectArrows(fragment) {
   const arrows = [];


### PR DESCRIPTION
## Summary

Fixes #311, #305, and #310:

- Preserve validation output larger than 64 KB.
- Reject invalid flags and extra positional arguments in `check`, `examples`, `doctor`, and `demo`.
- Normalize the watched directory before starting the Windows preview watcher.

## Validation

60 focused tests pass, including the CLI and preview regression suites. The required ablation experiment confirmed all three changes are necessary.
