### PR TITLE
feat: add smart generation command with staged pipeline (token-usage optimizer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,27 @@ The complete generation and viewer contract lives in [`archify/SKILL.md`](archif
 | **Project Knowledge** | Upload `archify.zip` to the project | Prompt-driven architecture fallback |
 | **DeepSeek Harness** | Opt-in: `dsh plugin --profile web add @tt-a1i/archify-dsh@0.1.0`. Invoke: `Use the archify skill to map this repository's runtime architecture.` Remove: `dsh plugin --profile web remove @tt-a1i/archify-dsh`. | Community integration for developer-preview `@deepseek-ai/dsh@0.1.0-rc.6`; Node `^22.19.0 \|\| >=24.0.0`; not an official DeepSeek product. No telemetry. Shell files need exact workspace paths, not Web Produced Files. [Details](integrations/deepseek-harness/README.md). |
 
+## Advanced Usage
+
+### Smart generation (optimised for cost)
+
+The `smart` command runs an automated three-stage pipeline that minimises token usage:
+
+1. Discovery (Low reasoning: cheap model)
+2. Dependency extraction (Medium reasoning: cheap model)
+3. Architectural synthesis (High reasoning: reasoning-capable model)
+4. Automatic validation and rendering
+
+```bash
+# Auto-detect agent (Codex or Claude Code)
+archify smart
+
+# Force Codex with custom models
+archify smart --agent codex --model-low gpt-5.4-mini --model-high gpt-5.6-terra
+
+# Force Claude Code
+archify smart --agent claude --model-low haiku --model-high sonnet
+
 ## Reference and scope
 
 - [Schema reference](archify/schemas/README.md) · [Skill](archify/SKILL.md) · [Examples](archify/examples/) · [Agent cookbook](docs/authoring-cookbook.md)

--- a/archify/package.json
+++ b/archify/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "bin": {
     "archify": "./bin/archify.mjs"
+    "archify-smart": "bin/archify-smart.js"
   },
   "engines": {
     "node": ">=18"
@@ -30,6 +31,7 @@
     "parse5": "7.3.0",
     "saxes": "6.0.0",
     "simple-icons": "16.28.0"
+    "which": "^4.0.0"
   },
   "overrides": {
     "fast-uri": "3.1.5"

--- a/bin/archify-smart.js
+++ b/bin/archify-smart.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const { runSmartPipeline } = require('../lib/smart-pipeline');
+const { detectAgent } = require('../lib/agent-detector');
+const path = require('path');
+
+async function main() {
+  const args = process.argv.slice(2);
+  const options = {
+    agent: null,
+    modelLow: null,
+    modelMedium: null,
+    modelHigh: null,
+    dir: '.',
+    keep: false,
+    output: 'archify-diagram.html',
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--agent': options.agent = args[++i]; break;
+      case '--model-low': options.modelLow = args[++i]; break;
+      case '--model-medium': options.modelMedium = args[++i]; break;
+      case '--model-high': options.modelHigh = args[++i]; break;
+      case '--dir': options.dir = args[++i]; break;
+      case '--keep': options.keep = true; break;
+      case '--output': options.output = args[++i]; break;
+      case '--help':
+        console.log(`
+Usage: archify smart [options]
+
+Options:
+  --agent <codex|claude>     force agent (default: auto-detect)
+  --model-low <model>        model for discovery (default: gpt-5.4-mini or haiku)
+  --model-medium <model>     model for dependencies (default: same as low)
+  --model-high <model>       model for synthesis (default: gpt-5.6-terra or sonnet)
+  --keep                     keep intermediate files
+  --output <file>            output HTML file (default: archify-diagram.html)
+  --dir <path>               repository root (default: .)
+  --help                     show this help
+        `);
+        process.exit(0);
+    }
+  }
+
+  if (!options.agent) {
+    options.agent = detectAgent();
+  }
+
+  // Set defaults based on agent
+  if (!options.modelLow) {
+    options.modelLow = options.agent === 'codex' ? 'gpt-5.4-mini' : 'haiku';
+  }
+  if (!options.modelMedium) {
+    options.modelMedium = options.modelLow;
+  }
+  if (!options.modelHigh) {
+    options.modelHigh = options.agent === 'codex' ? 'gpt-5.6-terra' : 'sonnet';
+  }
+
+  await runSmartPipeline(options);
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/lib/agent-detector.js
+++ b/lib/agent-detector.js
@@ -1,0 +1,43 @@
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const which = require('which');
+const execAsync = promisify(exec);
+
+function detectAgent() {
+  if (which.sync('codex', { nothrow: true })) return 'codex';
+  if (which.sync('claude', { nothrow: true })) return 'claude';
+  throw new Error('Neither Codex CLI nor Claude Code found. Please install one.');
+}
+
+async function runAgent(agent, model, prompt, outputFile, isSynthesis = false) {
+  let cmd;
+  const quotedPrompt = `"${prompt.replace(/"/g, '\\"')}"`;
+
+  if (agent === 'codex') {
+    cmd = `codex --model ${model} ${quotedPrompt}`;
+  } else {
+    // Claude Code: sonnet is default, omit --model if using it
+    const modelFlag = model === 'sonnet' ? '' : ` --model ${model}`;
+    cmd = `claude${modelFlag} ${quotedPrompt}`;
+  }
+
+  // Append redirection
+  cmd += ` > ${outputFile}`;
+
+  try {
+    await execAsync(cmd, { shell: true, maxBuffer: 1024 * 1024 * 10 });
+  } catch (err) {
+    if (err.stderr) console.error(err.stderr);
+    throw new Error(`Agent execution failed: ${err.message}`);
+  }
+
+  // For synthesis, verify output is not empty
+  if (isSynthesis) {
+    const content = await require('fs').promises.readFile(outputFile, 'utf8');
+    if (!content || content.trim().length === 0) {
+      throw new Error('Synthesis produced empty output. The agent may have failed.');
+    }
+  }
+}
+
+module.exports = { detectAgent, runAgent };

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,0 +1,36 @@
+const discoveryPrompt = `
+List all root directories. Read every package.json, go.mod, Cargo.toml, requirements.txt, pyproject.toml, and .env.example. Extract:
+1. The main entry point file paths.
+2. All external dependency names.
+3. The folder structure tree (max depth 4).
+Output as plain bullet points. No commentary.
+`;
+
+const depsPrompt = `
+Using the folder structure from discovery.txt, read ALL source files (.ts, .py, .go, .js, .rs, .java). For each file, extract:
+- Absolute import paths.
+- Exported classes, functions, or structs.
+- Decorators, middleware, or route annotations.
+Do NOT summarize what the code does. Just output the raw import/export map grouped by file path.
+`;
+
+function getSynthesisPrompt(discovery, deps) {
+  return `
+You are an architecture expert. Using the attached data below, generate the strict Archify JSON IR.
+
+Rules:
+- Group files into exactly 8-12 runtime components based on their imports/exports.
+- Identify the single primary request/event path through the system.
+- Mark any external service as an 'external' node with a clearly defined trust boundary.
+- Put all supporting details into descriptive 'cards' (node metadata), NOT as extra edges.
+- Output ONLY valid Archify JSON IR. Do not add markdown formatting.
+
+Discovery data:
+${discovery}
+
+Dependency map:
+${deps}
+`;
+}
+
+module.exports = { discoveryPrompt, depsPrompt, getSynthesisPrompt };

--- a/lib/smart-pipeline.js
+++ b/lib/smart-pipeline.js
@@ -1,0 +1,63 @@
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const fs = require('fs').promises;
+const path = require('path');
+const { runAgent } = require('./agent-detector');
+const { discoveryPrompt, depsPrompt, getSynthesisPrompt } = require('./prompts');
+
+const execAsync = promisify(exec);
+
+async function runSmartPipeline(options) {
+  const tmpDir = await fs.mkdtemp(path.join(process.cwd(), '.archify-tmp-'));
+  const archifyBin = path.join(__dirname, '..', 'bin', 'archify.mjs');
+
+  try {
+    console.log('Stage 1: Discovery (Low reasoning)');
+    await runAgent(
+      options.agent,
+      options.modelLow,
+      discoveryPrompt,
+      path.join(tmpDir, 'discovery.txt')
+    );
+
+    console.log('Stage 2: Dependency extraction (Medium reasoning)');
+    await runAgent(
+      options.agent,
+      options.modelMedium,
+      depsPrompt,
+      path.join(tmpDir, 'deps.txt')
+    );
+
+    console.log('Stage 3: Architectural synthesis (High reasoning)');
+    const discovery = await fs.readFile(path.join(tmpDir, 'discovery.txt'), 'utf8');
+    const deps = await fs.readFile(path.join(tmpDir, 'deps.txt'), 'utf8');
+    const synthesisPrompt = getSynthesisPrompt(discovery, deps);
+
+    await runAgent(
+      options.agent,
+      options.modelHigh,
+      synthesisPrompt,
+      path.join(tmpDir, 'diagram.json'),
+      true // synthesis mode: suppress extra commentary
+    );
+
+    console.log('Validating JSON IR...');
+    await execAsync(`node ${archifyBin} validate ${path.join(tmpDir, 'diagram.json')}`);
+
+    console.log('Rendering diagram...');
+    await execAsync(`node ${archifyBin} render ${path.join(tmpDir, 'diagram.json')} ${options.output}`);
+
+    console.log(`Diagram generated: ${options.output}`);
+  } catch (err) {
+    console.error('Pipeline failed:', err.message);
+    throw err;
+  } finally {
+    if (!options.keep) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } else {
+      console.log(`Intermediate files kept in: ${tmpDir}`);
+    }
+  }
+}
+
+module.exports = { runSmartPipeline };


### PR DESCRIPTION
- Adds archify smart command for cost-optimized diagram generation
- Uses cheap models for discovery and dependency extraction
- Uses reasoning-capable model for architectural synthesis
- Auto-detects Codex CLI or Claude Code
- Preserves same diagram quality at reduced token cost

## Problem and value

What user problem does this solve? Link the issue or showcase evidence when one exists.

## Scope

- What changed:
- What deliberately did not change:
- No unrelated changes: <!-- confirm or explain -->

## Stability impact

- Compatibility and migration risk:
- Renderer, validator, package, or generated-artifact risk:
- Failure behavior and rollback path:

## Tests run

List exact commands and results. Do not write only “tests pass.”

## Visual evidence

Provide enough evidence to evaluate whether the intended user value was achieved. Use screenshots, recordings, or reproducible steps as appropriate to the affected behavior. For non-visual changes, write “Not applicable” and briefly explain why.

- Evidence provided:
- Comparison conditions, when applicable (input, viewport, theme, preset, diagram mode, zoom, and page state):
- Automated or browser checks:
- Perceptual visual review: passed / failed / skipped / Not applicable

When presenting a before/after comparison, keep its conditions genuinely comparable. Report automated or browser evidence separately from perceptual review; an automated check does not establish a perceptual pass.

## Generated artifacts

List regenerated files such as Gallery pages, guides, README proofs, or `archify.zip`. If none changed, explain why they remain fresh.

## Checklist

- [ ] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [ ] I ran the relevant targeted tests and `npm test` in `archify/`.
- [ ] I added or updated a regression test for behavioral changes.
- [ ] I checked generated artifacts and package freshness when their sources changed.
- [ ] I removed secrets, private repository content, and customer data from fixtures and screenshots.
