### PR TITLE
fix: emit JSON receipt for argument errors in validate/deliver

### DIFF
--- a/archify/bin/archify.mjs
+++ b/archify/bin/archify.mjs
@@ -35,7 +35,22 @@ Types:
 `;
 }
 
+let jsonMode = false;
+let currentCommand = '';
+
 function fail(message, code = 2) {
+  if (jsonMode) {
+    console.log(JSON.stringify({
+      schemaVersion: 1,
+      ok: false,
+      command: currentCommand,
+      stage: 'arguments',
+      error: message,
+      diagnostics: [{ code: 'arguments/invalid', severity: 'error', message }],
+    }, null, 2));
+    process.exitCode = code;
+    process.exit(code);
+  }
   console.error(message);
   process.exit(code);
 }
@@ -761,9 +776,10 @@ function engineeringProfileFromArtifact(artifact) {
 
 async function commandDeliver(args) {
   const { resolveOutputPath } = await import('../renderers/shared/output-path.mjs');
+  const json = args.includes('--json');
+  if (json) { jsonMode = true; currentCommand = 'deliver'; }
   const qualityArgs = extractQualityArgs(args);
   const repoArgs = extractRepoRootArgs(qualityArgs.rest);
-  const json = repoArgs.rest.includes('--json');
   const open = repoArgs.rest.includes('--open');
   const knownOptions = new Set(['--json', '--open']);
   const unknown = repoArgs.rest.filter((arg) => arg.startsWith('--') && !knownOptions.has(arg));
@@ -1820,6 +1836,8 @@ async function commandMigrate(args) {
 }
 
 function commandValidate(args) {
+  const json = args.includes('--json');
+  if (json) { jsonMode = true; currentCommand = 'validate'; }
   const qualityArgs = extractQualityArgs(args);
   const repoArgs = extractRepoRootArgs(qualityArgs.rest);
   args = repoArgs.rest;
@@ -1827,9 +1845,8 @@ function commandValidate(args) {
   const repoRoot = repoArgs.repoRoot;
   const knownOptions = new Set(['--json', '--layout-json']);
   const unknown = args.filter((arg) => arg.startsWith('--') && !knownOptions.has(arg));
-  if (unknown.length) fail(`Unknown validate option "${unknown[0]}".`);
-  const json = args.includes('--json');
   const layoutJson = args.includes('--layout-json');
+  if (unknown.length) fail(`Unknown validate option "${unknown[0]}".`);
   const rest = args.filter((arg) => !knownOptions.has(arg));
   const [type, input] = rest;
   if (!type || !input || rest.length !== 2) fail(usage());

--- a/archify/test/cli.test.mjs
+++ b/archify/test/cli.test.mjs
@@ -719,7 +719,15 @@ test('cli: rejects a quality flag without a value', () => {
   ]) {
     const result = run(args);
     assert.equal(result.status, 2);
-    assert.match(result.stderr, /--quality requires standard or showcase/);
+    if (args.includes('--json')) {
+      assert.equal(result.stderr, '');
+      const receipt = JSON.parse(result.stdout);
+      assert.equal(receipt.ok, false);
+      assert.equal(receipt.stage, 'arguments');
+      assert.match(receipt.error, /--quality requires standard or showcase/);
+    } else {
+      assert.match(result.stderr, /--quality requires standard or showcase/);
+    }
   }
 });
 
@@ -731,12 +739,18 @@ test('cli: validate rejects unknown flags, layout-json assignment typos, and ext
       pattern: /Unknown validate option "--bogus"/,
     },
     {
+      args: ['validate', 'workflow', input, '--layout-json', '--bogus', '--json'],
+      pattern: /Unknown validate option "--bogus"/,
+      json: true,
+    },
+    {
       args: ['validate', 'workflow', input, '--layout-json=true'],
       pattern: /Unknown validate option "--layout-json=true"/,
     },
     {
       args: ['validate', 'workflow', input, '--layout-json=true', '--json'],
       pattern: /Unknown validate option "--layout-json=true"/,
+      json: true,
     },
     {
       args: ['validate', 'workflow', input, 'unexpected-output.html', '--layout-json'],
@@ -744,11 +758,19 @@ test('cli: validate rejects unknown flags, layout-json assignment typos, and ext
     },
   ];
 
-  for (const { args, pattern } of cases) {
+  for (const { args, pattern, json } of cases) {
     const result = run(args);
     assert.equal(result.status, 2, `${args.join(' ')}\n${result.stderr}\n${result.stdout}`);
-    assert.equal(result.stdout, '');
-    assert.match(result.stderr, pattern);
+    if (json) {
+      assert.equal(result.stderr, '');
+      const receipt = JSON.parse(result.stdout);
+      assert.equal(receipt.ok, false);
+      assert.equal(receipt.stage, 'arguments');
+      assert.match(receipt.error, pattern);
+    } else {
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, pattern);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Argument validation errors now produce a machine-readable JSON receipt to stdout when `--json` is passed, instead of writing plain text to stderr and emitting nothing to stdout. The receipt has `stage: 'arguments'` and a stable `arguments/invalid` diagnostic code, matching the validate/deliver contract.

## What changed

- `fail()` now checks a `jsonMode` flag and emits a JSON receipt when set
- `commandValidate` and `commandDeliver` set `jsonMode = true` before any `fail()` can be called
- Updated `test/cli.test.mjs` to verify the new JSON receipt behavior

## Why this matters

The documented `--json` contract promises a single JSON document even on failure. Previously, argument errors violated this by writing plain text to stderr and nothing to stdout.

## Verification

- `node --test test/cli.test.mjs` — 43/43 pass
- Manual: `node bin/archify.mjs validate workflow examples/agent-tool-call.workflow.json --quality hero --json` now emits a JSON receipt with `stage: 'arguments'`

Fixes #330