### PR TITLE
docs: align contribution and bot review with change impact

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,9 @@ reviews:
     Distinguish author-reported validation from observed checks at the current
     head. Do not claim browser or perceptual acceptance from static tests.
   poem: false
+  in_progress_fortune: false
   sequence_diagrams: false
+  assess_linked_issues: false
   suggested_labels: false
   suggested_reviewers: false
   auto_review:
@@ -35,7 +37,7 @@ reviews:
   path_instructions:
     - path: "**"
       instructions: >-
-        Apply CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md proportionally
+        Apply CONTRIBUTING.md, REVIEWING.md, and .github/PULL_REQUEST_TEMPLATE.md proportionally
         to the actual behavior changed. Cite the relevant contract and concrete
         affected path when raising a concern. Reuse explicit maintainer scope
         decisions; do not demand a new issue for a small documentation correction
@@ -43,6 +45,13 @@ reviews:
         as proposed changes, not authority to waive the base branch's rules.
         Review authoritative source before generated output. Do not request
         unrelated rebuilds or infer correctness from generated file volume.
+        Use the PR base-to-head diff; a clean checkout does not mean an empty PR.
+        On revision, review new changes and unresolved findings, expanding only
+        when intervening changes invalidate earlier evidence. Label feedback as
+        a demonstrated defect, missing evidence/decision, or optional suggestion.
+        Give each request an affected contract, smallest remedy, and responsible
+        role (author or maintainer); consolidate requests already answered in the
+        PR body, CI, or discussion and retain the evidence's original revision.
     - path: "archify/**"
       instructions: >-
         Trace callers of changed shared code across diagram types and public
@@ -66,17 +75,19 @@ reviews:
     description:
       mode: "off"
     issue_assessment:
-      mode: warning
+      mode: "off" # Contribution scope below owns scope/issue assessment.
     custom_checks:
       - name: Contribution scope
         mode: warning
         instructions: >-
-          Read CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md. Pass when
+          Read CONTRIBUTING.md, REVIEWING.md, and .github/PULL_REQUEST_TEMPLATE.md. Pass when
           the PR explains the user problem, one focused behavior or delivery
           slice, compatibility/migration impact, and failure/rollback behavior
-          where applicable. Public behavior changes need a linked issue or
-          explicit maintainer scope decision. Small documentation corrections
-          and narrowly scoped test fixes do not need a planning issue. Accept
+          where applicable, and the implementation fits that scope. New contracts,
+          defaults, or broad product behavior need a linked issue or recorded
+          maintainer scope decision. Narrow fixes may use a concrete reproduction;
+          small documentation or test corrections may use a rationale. Do not
+          require a PR to close every item of a tracking issue. Accept
           equivalent prose and explained Not applicable entries, not just exact
           headings or checked boxes. Warn once with the specific missing facts;
           do not classify missing evidence as a confirmed runtime defect.
@@ -89,17 +100,26 @@ reviews:
           Visible changes need relevant artifact evidence; before/after claims
           need comparable conditions. Automated/browser and perceptual results
           must be separate. Non-visual changes may explain Not applicable.
+          Repository-only prose/policy and focused test fixes may use justified
+          targeted checks under CONTRIBUTING.md; packaged Skill instructions and
+          shared test infrastructure are not a documentation/test-only shortcut.
+          Reuse linked archive manifests, source comparisons, and freshness CI;
+          an excluded binary diff alone is not evidence of unrelated changes.
           Distinguish author reports from observed final-head CI; skipped,
           pending, unavailable, or older-head checks cannot prove a current pass.
           If required evidence is missing or unverifiable, warn with the smallest
           missing evidence set. Do not require screenshots for non-visual changes
           or infer a browser pass from a unit test. Accept explicit maintainer
           exceptions and scope-appropriate explanations for omitted checks.
+          When fork CI awaits approval, identify maintainer action after inspecting
+          the workflow changes; do not ask the author to obtain unavailable rights.
+          A bot pass or exception never waives required CI or branch protection.
 knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
       - CONTRIBUTING.md
+      - REVIEWING.md
       - .github/PULL_REQUEST_TEMPLATE.md
       - archify/references/delivery-contract.md
   learnings:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,42 +1,30 @@
+<!-- Authors: follow CONTRIBUTING.md. Reviewers and Agents: follow REVIEWING.md. -->
+
 ## Problem and value
 
-What user problem does this solve? Link the issue or showcase evidence when one exists.
-
-## Scope
-
-- What changed:
-- What deliberately did not change:
-- No unrelated changes: <!-- confirm or explain -->
+Current-main trigger or rationale, intended outcome, approach, and linked issue/agreed scope:
 
 ## Stability impact
 
-- Compatibility and migration risk:
-- Renderer, validator, package, or generated-artifact risk:
-- Failure behavior and rollback path:
+- Impact class and changed behavior/shared callers: <!-- CONTRIBUTING.md#choose-evidence-by-impact -->
+- Existing behavior preserved / intended compatibility changes / failure behavior:
+- No unrelated changes: <!-- confirm or explain -->
 
 ## Tests run
 
-List exact commands and results. Do not write only “tests pass.”
+Comparison base and candidate head; applicable commands/results or evidence links. Explain omitted checks and identify reused evidence by its original revision. Follow CONTRIBUTING.md#choose-evidence-by-impact; required remote CI still applies.
 
 ## Visual evidence
 
-Provide enough evidence to evaluate whether the intended user value was achieved. Use screenshots, recordings, or reproducible steps as appropriate to the affected behavior. For non-visual changes, write “Not applicable” and briefly explain why.
+For non-visual changes, replace this section with "Not applicable" and why.
 
-- Evidence provided:
-- Comparison conditions, when applicable (input, viewport, theme, preset, diagram mode, zoom, and page state):
+- Evidence provided: <!-- screenshots, recordings, or reproducible steps; intended and unexpected differences -->
+- Comparison conditions: <!-- same input, viewport, theme, preset, mode, zoom, page state -->
 - Automated or browser checks:
 - Perceptual visual review: passed / failed / skipped / Not applicable
 
-When presenting a before/after comparison, keep its conditions genuinely comparable. Report automated or browser evidence separately from perceptual review; an automated check does not establish a perceptual pass.
+Report automated or browser evidence separately from perceptual review.
 
 ## Generated artifacts
 
-List regenerated files such as Gallery pages, guides, README proofs, or `archify.zip`. If none changed, explain why they remain fresh.
-
-## Checklist
-
-- [ ] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
-- [ ] I ran the relevant targeted tests and `npm test` in `archify/`.
-- [ ] I added or updated a regression test for behavioral changes.
-- [ ] I checked generated artifacts and package freshness when their sources changed.
-- [ ] I removed secrets, private repository content, and customer data from fixtures and screenshots.
+Regenerated files or linked build evidence; if none, explain why outputs remain fresh.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,105 +1,85 @@
 # Contributing to Archify
 
-Thank you for helping Archify make engineering diagrams more trustworthy and useful. Archify is Agent-first: people describe the system they want to explain, while the Skill, typed JSON contract, renderers, validators, and delivery receipts make the result reproducible.
-
-Stability comes before feature count. A small change with a real reproduction, an explicit contract, and evidence from the final artifact is easier to review and safer to ship than a broad rewrite.
+Archify is Agent-first: people describe systems, and the Skill, typed JSON, renderers, validators, and delivery receipts produce reproducible diagrams. Keep each contribution focused on one user-visible behavior or one tightly related delivery slice. Maintainers and Agents reviewing a PR or a revised head follow [Reviewing](REVIEWING.md).
 
 ## Choose the right path
 
-- Found a renderer, validator, package, or viewer problem? Use [the bug report form](.github/ISSUE_TEMPLATE/bug-report.yml).
-- Made a useful real-world diagram? Use [the showcase form](.github/ISSUE_TEMPLATE/showcase.yml).
-- Want to change a schema, renderer contract, validation rule, installation path, export, or other product behavior? Open or link an issue before implementing it. Agree on the user value, compatibility boundary, and non-goals first.
-- Found a security vulnerability? Follow [the security policy](SECURITY.md). Do not publish exploit details or secrets.
+- Renderer, validator, package, or Viewer defect: use the [bug report form](.github/ISSUE_TEMPLATE/bug-report.yml).
+- Reproducible real-world diagram: use the [showcase form](.github/ISSUE_TEMPLATE/showcase.yml).
+- New schema fields, defaults, acceptance rules, installation/export contracts, or broad product behavior: agree on value, compatibility, and non-goals before substantial implementation. Link the issue or recorded maintainer decision; reuse an existing agreed scope.
+- Narrow fixes and small documentation or test corrections can proceed with a concrete reproduction or rationale; a separate planning issue is unnecessary.
+- Security vulnerabilities: follow [SECURITY.md](SECURITY.md).
 
-Small documentation corrections and narrowly scoped test fixes do not require a planning issue. Large documentation surfaces do: prefer improving the canonical Skill, contract, diagnostic, or existing guide over creating a second explanation of the same behavior.
+Do not include secrets, access tokens, credentials, private repository content, personal data, or customer data in fixtures, logs, screenshots, artifacts, or package tests.
 
-Do not include secrets, access tokens, credentials, private repository content, personal data, or customer data in prompts, JSON fixtures, logs, screenshots, generated artifacts, or package tests.
+## Prepare a reviewable change
 
-## Before writing code
+Start from the latest `main`. Check whether its existing controls already solve the reported case. Record the comparison base and candidate head.
 
-Start from the latest `main`. Recheck it before final review: a concurrent change may already solve the problem or alter the relevant contract. A test result from an old base is not integration evidence.
+Use Draft for unresolved scope or early implementation feedback. At this stage, provide the smallest reproduction and relevant checks. Prepare broad integration evidence and generated artifacts once the approach is settled.
 
-Keep one pull request focused on one behavior or one tightly related delivery slice. The PR should state:
+Before requesting final review, explain:
 
-- the user problem and linked issue, when one exists;
-- what changes and what deliberately does not;
-- compatibility and migration impact;
-- failure behavior and rollback path;
-- exact tests and final-artifact evidence.
+- The current-main trigger, intended outcome, and why the approach is worth maintaining.
+- The changed behavior and shared callers, existing behavior that must remain stable, and any intended compatibility changes.
+- The applicable checks, actual results, and reproducible evidence links.
 
-Draft PRs are welcome for early technical feedback. Mark the PR ready only when its scope is stable, it is current with `main`, its generated artifacts are intentional, and the stated checks have actually run.
+Use [the PR template](.github/PULL_REQUEST_TEMPLATE.md); link existing receipts or CI output instead of transcribing long logs. Classify impact by behavior and callers, not file extension or diff size.
+
+## Choose evidence by impact
+
+| Impact | Typical change | Evidence to prepare |
+| --- | --- | --- |
+| Text or review policy | Explanatory prose, links, contributor/reviewer procedure | Content, links, affected documentation checks; exercise changed procedure branches. No local renderer suite for repository-only prose. |
+| Local behavior | One CLI path, focused test correction | Reproduction or rationale, affected tests, and relevant failure/compatibility cases. |
+| Shared behavior | Geometry, text measurement, shared Viewer, evidence or delivery helpers | Trace callers; identify affected modes and contracts; compare fixed representative inputs on base and candidate, including relevant historical failures. |
+| Contract change | Schema, defaults, validation acceptance, Skill or authoring instructions | Agreed scope and explicit allowed/preserved behavior, plus local/shared evidence appropriate to the implementation. |
+
+Skill instructions, authored examples, build inputs, and generated-site sources are behavioral inputs even when they look like documentation. Policy changes need process review; runtime evidence depends on whether they affect runtime inputs.
+
+During iteration, run the narrowest relevant checks. Before final review, run `npm test` from `archify/` for changes to runtime, schemas, packaged Skill/authoring behavior, generated content, or shared test infrastructure. Repository-only documentation and focused test-only changes may use targeted checks with an explanation. These local choices do not waive remote CI or branch-protection requirements.
 
 ## Product and compatibility contracts
 
-Archify's public behavior is larger than a renderer function. Treat these as contracts:
-
 - Existing schema-v1 typed JSON remains valid unless a reviewed change explicitly introduces a breaking rule and migration path.
-- Explicit authored geometry such as `via`, named routes, channels, sides, and label placement remains authoritative unless the contract says otherwise. Do not silently rewrite topology or authored intent.
-- `standard` preserves broad compatibility. A new `showcase` failure must identify a real, repairable defect, avoid rejecting necessary routing, and return a stable machine-readable diagnostic.
-- Agent-facing failures belong in `diagnostics[]`: use a stable `code`, precise `subject`, concrete `evidence`, and executable `supportedFixes`. Do not require ordinary users or Agents to scrape prose from logs.
-- Agent-first does not mean documentation-free. It means one canonical contract per behavior. Link to that source instead of copying evolving CLI stages, receipt fields, or error-code tables into parallel manuals.
-- A valid SVG is not automatically a good diagram. Geometry, projected text, z-order, masks, interaction, export, and real browser layout can fail independently.
+- Explicit authored geometry such as `via`, named routes, channels, sides, and label placement remains authoritative unless the contract says otherwise. Preserve authored topology and intent.
+- `standard` preserves broad compatibility. A new `showcase` failure must identify a real, repairable defect and avoid rejecting necessary routing.
+- Agent-facing failures belong in `diagnostics[]`: use a stable `code`, precise `subject`, concrete `evidence`, and executable `supportedFixes`. Preserve non-zero CLI exits and machine-readable receipts for failed stages.
+- A validation rule expressing taste should begin with evidence or a warning. Before making it a hard error, check legitimate obstacles, shared ports, explicit routes, nested boundaries, and existing examples.
+- Keep one canonical contract per behavior. Link the existing source instead of copying CLI stages, receipt fields, or error tables.
 
-If a validation rule expresses taste rather than correctness, begin with evidence or a warning. Before making it a hard error, test legitimate exceptions such as obstacles, shared ports, explicit routing, nested boundaries, and existing checked-in examples.
+## Local setup and verification
 
-## Local setup
+The renderer package is in `archify/`; its Node range and commands are defined in `archify/package.json`.
 
-The renderer package lives in `archify/` and supports Node.js 18 and later. CI covers Node.js 18, 20, 22, and 24.
-
-```bash
+```sh
 cd archify
 npm ci
 npm test
 ```
 
-During development, run the narrowest relevant test first, then the full suite before requesting final review. Behavioral fixes should include a failing regression test that demonstrates the problem before the implementation changes.
+Test through public behavior such as `render`, `validate`, `deliver`, `visual-check`, or final SVG/HTML. Behavioral fixes should include a regression that demonstrates the original failure. Private helper checks can supplement that evidence.
 
-Test public behavior through a supported seam whenever possible: `archify render`, `validate`, `deliver`, `visual-check`, or the final SVG/HTML. Private helper tests are useful for edge cases, but they do not replace a CLI or artifact-level regression.
+For geometry and layout changes, use the smallest redacted JSON reproduction, relevant checked-in examples, and frozen compatibility fixtures. Compare base and candidate with the same input and browser conditions. Identify intended changes and investigate unexpected ones; updating golden files alone does not establish visual or compatibility acceptance.
 
-## Evidence by change type
+A visual PR must provide enough evidence to evaluate whether the intended user value was achieved, using screenshots, recordings, or reproducible steps. Keep viewport, theme, preset, diagram mode, zoom, and page state comparable. Report automated or browser evidence separately from perceptual review. A non-visual pull request must write `Not applicable` in its Visual evidence section and explain why.
 
-### Renderer, layout, and validation
+Static SVG/XML checks cannot establish browser layout, font settling, or interaction behavior. When the adaptive reader or Viewer layout changes, run the real browser test with Chrome available:
 
-Include the smallest redacted typed JSON that reproduces the behavior. Verify both the intended fix and plausible exceptions. At minimum:
-
-1. Run the focused regression tests.
-2. Run the candidate against relevant checked-in examples and frozen compatibility fixtures.
-3. Run `npm test` from `archify/`.
-4. For visible changes, render the final HTML and run `visual-check`.
-5. Inspect the generated screenshots or HTML in a capable visual surface.
-
-Static SVG/XML checks cannot prove desktop readability, stacking order, font settling, or interaction. When the adaptive reader or viewer layout changes, run the real browser test with Chrome available:
-
-```bash
+```sh
 cd archify
 ARCHIFY_CHROME="/path/to/chrome" node --test test/desktop-reader-browser.test.mjs
 ```
 
-A browser test that was skipped because Chrome was unavailable is **skipped**, not passed. Report automated browser evidence independently from perceptual visual review. Follow the [delivery contract](archify/references/delivery-contract.md) when recording supplementary manual browser work; an unconstrained glance supports only perceptual review.
+A browser test skipped because Chrome was unavailable is **skipped**, not passed. Follow [the delivery contract](archify/references/delivery-contract.md) for visual evidence, receipts, and failure stages. Successful validation, atomic delivery, browser checks, and perceptual review establish different claims.
 
-### CLI, receipts, and delivery
+## Packages and generated artifacts
 
-Preserve non-zero exit behavior and machine-readable receipts. A successful `validate` does not prove atomic delivery, and a successful `deliver` does not prove perceptual quality. Follow [the delivery contract](archify/references/delivery-contract.md) and test the failure stage you changed.
+Published artifacts must be reproducible from tracked content. Use a tracked-only, symlink-safe staging path or explicit allowlist, with negative coverage for untracked files and external symlinks. Test the extracted package outside the repository on the affected advertised hosts.
 
-### Packages, plugins, and releases
+Review source and focused tests before regenerating artifacts. Regenerate only outputs whose authoritative inputs changed, from the final combined source:
 
-Published artifacts must be reproducible from tracked repository content.
-
-- Never recursively package the live working tree with an unrestricted `cp`, `rsync`, or equivalent operation.
-- Use a tracked-only, symlink-safe staging path or an explicit allowlist.
-- Add a negative test proving that an untracked file and an external symlink cannot enter the archive.
-- Test the extracted package outside the repository and, when applicable, on every advertised host or operating-system shape.
-- Treat a published version as immutable. If host-visible plugin or Skill bytes change, use the agreed next release identity and keep every relevant manifest synchronized. Do not reuse a tag or version for different content.
-
-Do not change release versions, tags, or distribution identities in an ordinary feature PR unless the issue or a maintainer explicitly includes release work in scope.
-
-## Generated artifacts
-
-Review source and tests before flooding a PR with generated output. Regenerate only artifacts whose authoritative inputs changed, ideally once after the implementation is accepted.
-
-From the repository root, the main builders are:
-
-```bash
+```sh
 node scripts/build-gallery.mjs docs
 node scripts/build-guide.mjs docs/guide.html
 node scripts/build-start.mjs docs/start.html
@@ -107,48 +87,20 @@ node scripts/build-readme-showcase.mjs
 scripts/build-zip.sh /tmp/archify-contrib.zip
 ```
 
-The runtime follows the Node range in `archify/package.json`, but canonical
-`archify.zip` container bytes are built only with Node 22. The builder rejects
-other Node majors so a different bundled zlib cannot publish a second byte
-representation of the same package contents.
+Canonical ZIP bytes require Node 22; the builder rejects other majors to avoid different zlib representations. Skill runtime, schema, renderer, and published Skill-instruction changes require checking ZIP freshness. Bundled example or Viewer changes normally require a Gallery rebuild.
 
-Bundled example or viewer changes normally require the Gallery rebuild. Skill runtime, schema, renderer, or published `SKILL.md` changes require checking `archify.zip` freshness and committing a rebuilt archive when the checked-in package contents differ.
+List regenerated files and explain why unchanged outputs remain fresh. Resolve generated conflicts by rebuilding from combined source. Keep unrelated generated output out of the diff.
 
-List every regenerated file in the PR description. Do not regenerate unrelated HTML, GIFs, screenshots, manifests, or archives merely to make the branch look current. Generated artifacts are evidence and delivery payloads, not a substitute for reviewing the source change.
+Treat published versions as immutable. Ordinary feature PRs do not change versions, tags, or distribution identities unless release work is explicitly in scope.
 
-## Bug fixes
+## Final integration and follow-up
 
-A useful bug report or fix contains:
+Refresh `main` and the PR head before final integration; account for relevant base changes and resolve conflicts. Rerun local checks whose evidence was invalidated. Unchanged evidence may be linked with its original revision and reuse rationale; do not relabel it as a new-head run. Verify that required remote CI actually ran on the final head and obey branch protection; zero checks is not green.
 
-1. The exact Archify version or commit, installation method, command, and environment.
-2. The smallest redacted typed JSON that still reproduces the failure.
-3. The complete machine-readable validation receipt or exact error.
-4. Expected versus actual behavior.
-5. Enough visual evidence to evaluate the problem when it is visual. Use screenshots, recordings, or reproducible steps as appropriate, mark subtle defects when useful, and describe the expected visual result. Media is not required when it would not add useful context.
+On revision, summarize what changed since the reviewed head and which findings it addresses. This lets reviewers focus on the new diff and outstanding decisions.
 
-Do not replace deterministic evidence with visual evidence. For visual defects, keep both the validator result and final rendered evidence.
-
-A pull request that changes the final diagram, Viewer, or public page appearance or interaction must provide enough evidence to evaluate whether the intended user value was achieved. Use screenshots, recordings, or reproducible steps as appropriate to the affected behavior. When presenting a before/after comparison, generate both states from the same input and keep the viewport, theme, preset, diagram mode, zoom, and page state comparable. Report automated or browser evidence separately from perceptual review; an automated check does not establish a perceptual pass. A non-visual pull request must write `Not applicable` in its Visual evidence section and briefly explain why. Remove sensitive data from every submitted artifact.
-
-## Community showcase submissions
-
-Showcase cases should be reproducible proof, not promotional screenshots. Submit the original prompt, agent/client, exact model, Archify version, redacted typed JSON, artifact, validation receipt, and truthful visual-review status through `.github/ISSUE_TEMPLATE/showcase.yml`.
-
-Maintainers may ask for a smaller source file, rerun validation, or decline a case that cannot be safely published. Inclusion is not guaranteed. Accepted cases should preserve author attribution and must not be presented as proof of model quality without a controlled benchmark protocol.
-
-## Before requesting review
-
-- Rebase or merge the latest `main`, resolve generated-artifact conflicts by rebuilding from the final source, and rerun affected checks.
-- Complete `.github/PULL_REQUEST_TEMPLATE.md` with exact commands and numeric results; do not write only “tests pass.”
-- Add or update a regression test for behavioral changes.
-- Confirm existing public examples and compatibility fixtures still behave as intended.
-- Provide enough evidence to evaluate the intended user value, using screenshots, recordings, or reproducible steps as appropriate, or explain why visual evidence is not applicable.
-- Report automated or browser evidence separately from perceptual review, and state each result truthfully.
-- Confirm remote CI actually ran on the current head. Local green checks do not mean GitHub CI passed, and zero checks is not green.
-- Remove unrelated files, debug output, local paths, generated noise, and sensitive data from the diff.
-
-Maintainers may ask for a large PR to be split or rebuilt from current `main` when generated artifacts, stale history, or overlapping implementations make the behavior difficult to review safely.
+Showcase submissions should include the prompt, agent/client, model, Archify version, redacted JSON, artifact, receipts, and truthful visual-review status. Maintainers may request a smaller safe reproduction. Preserve attribution; showcase acceptance is not a controlled model-quality benchmark.
 
 ## License
 
-By contributing, you agree that your contribution is provided under the repository's [MIT License](LICENSE). Only submit work you created or have the right to contribute.
+By contributing, you agree to the repository's [MIT License](LICENSE). Submit only work you created or have the right to contribute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,15 +103,34 @@ Showcase submissions should include the prompt, agent/client, model, Archify ver
 
 ## Automated review pilot
 
-Once the CodeRabbit GitHub App is enabled for this repository, the root
+The CodeRabbit GitHub App is enabled for this repository. The root
 [configuration](.coderabbit.yaml) requests automatic reviews of ready PRs and
-subsequent pushes. It uses this guide and the PR template for advisory scope and
+subsequent pushes. It uses this guide, REVIEWING.md, and the PR template for advisory scope and
 validation-evidence checks. Drafts are excluded. Missing evidence is a request
 for clarification, not proof of a code defect; explain a false positive in the PR.
 
 CodeRabbit does not replace required CI, browser/perceptual acceptance, or a
-maintainer's merge decision. To request a review after fixing an unavailable or
-skipped run, comment `@coderabbitai review`. Maintainers should assess the first
+maintainer's merge decision. Two warning checks cover contribution scope and
+validation evidence; overlapping built-in issue assessment is disabled. Authors
+can answer with evidence or explain why a request does not apply; maintainers
+settle disputed scope and acceptance requirements.
+
+Use these [review commands](https://docs.coderabbit.ai/reference/review-commands)
+instead of pushing an empty commit to retrigger the bot:
+
+| Situation | PR comment |
+| --- | --- |
+| Review new commits when automatic review did not run | `@coderabbitai review` |
+| Updated only the PR description, evidence links, or completed CI | `@coderabbitai run pre-merge checks` |
+| A fresh review of the entire PR is needed | `@coderabbitai full review` |
+| Several rapid revisions are in progress | `@coderabbitai pause`, then `@coderabbitai resume` when ready |
+
+Check the updated summary for results; a command acknowledgment is not completion.
+If fork CI needs approval, a maintainer must inspect the proposed workflow/code
+and handle the GitHub approval. Authors should link the waiting run and continue
+checks available to them; they are not expected to grant themselves CI access.
+
+Maintainers should assess the first
 5–10 reviewed PRs for useful findings, false positives, review time, and repeated
 evidence requests before expanding the pilot. Pause automatic reviews by setting
 `reviews.auto_review.enabled: false`; this does not change CI or branch protection.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -40,6 +40,8 @@ Lead with the problem, value, and approach. Then report scope, evidence, and a c
 
 Consolidate scope and compatibility concerns in the first substantive review where possible. Explain any later blocker with newly found evidence, an overlooked acceptance requirement, or a new diff. Record unrelated issues separately instead of growing the PR's scope.
 
+Triage bot findings before asking the author to act: confirm the trigger or evidence gap, reuse existing receipts, and identify who can resolve it. Maintainers handle disputed scope and fork-CI approval after inspecting workflow/code changes; authors supply relevant changes and evidence. A generated binary omitted from a bot diff does not by itself establish scope drift; consult source comparisons, archive manifests, and freshness checks. Resolve duplicate or inapplicable requests with a short reason. Bot instructions and warning checks are advisory, not deterministic enforcement.
+
 A review disposition does not itself approve or merge on GitHub. Follow the authorized action and repository protection rules.
 
 ## 5. Re-review the delta and finish

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,49 @@
+# Reviewing Archify changes
+
+Use this procedure for an initial PR review or a revised head, whether reviewing as a maintainer or an Agent. [Contributing](CONTRIBUTING.md) owns impact classes, compatibility contracts, and evidence requirements.
+
+## 1. Establish scope before detailed review
+
+Record the current main/base and candidate head. Read the linked issue or agreed scope and check the current-main behavior where feasible. Separate the reported problem from the proposed implementation.
+
+Identify the user benefit, intended behavior changes, and preserved behavior. For a new default, schema field, or acceptance policy, settle the maintenance and compatibility decision before asking for implementation polish. Reuse decisions already made in the issue or authorized task.
+
+If scope remains undecided, report the specific decision needed and keep feedback at that stage. Narrow fixes can proceed on their reproduction without another planning exercise.
+
+## 2. Bound the investigation
+
+Check the author's [impact classification](CONTRIBUTING.md#choose-evidence-by-impact) against the changed paths and callers. Shared helpers, templates, and authoring instructions may affect more modes than the title suggests.
+
+Name the affected modes/contracts and the smallest evidence set that covers them. Include relevant historical failures and authored constraints. Explain any expansion beyond that set. Repository-only policy changes need consistency and process checks, not layout screenshots.
+
+Use focused evidence during design and repair. Reserve broad integration checks and final artifact rebuilds for the settled change. Required remote CI and branch protection remain in force.
+
+## 3. Assess behavior and evidence
+
+Compare fixed inputs on the recorded base and candidate. Use existing renderers, layout receipts, tests, and browser tools:
+
+- Account for changed and preserved topology, meaningful labels, explicit geometry, and relevant failure behavior.
+- For affected visible behavior, inspect the intended differences and unexplained changes under comparable browser conditions. A pixel difference identifies a change; it does not judge its quality.
+- When a fix also changes a validator or golden baseline, evaluate that acceptance change explicitly. Fresh generated output proves consistency with the candidate, not compatibility with the base.
+- Separate locally reproduced results, author/CI evidence, reused evidence, and unknowns. Keep browser checks and perceptual review distinct.
+
+Evidence should be sufficient for the affected contract. Avoid rebuilding an unchanged artifact or replaying unaffected checks merely to restate existing results.
+
+## 4. Give actionable feedback
+
+Lead with the problem, value, and approach. Then report scope, evidence, and a clear disposition:
+
+- **Blocking defect:** trigger, impact, supporting evidence, and the behavior that must be corrected.
+- **Required evidence or scope decision:** the unresolved claim, why it matters to acceptance, and the smallest check or decision that would settle it. An unverified risk is not a reproduced defect.
+- **Suggestion:** a worthwhile improvement outside the acceptance conditions; personal preference alone does not block.
+- **Ready:** the agreed behavior is delivered, relevant evidence is sufficient, and no acceptance blocker remains.
+
+Consolidate scope and compatibility concerns in the first substantive review where possible. Explain any later blocker with newly found evidence, an overlooked acceptance requirement, or a new diff. Record unrelated issues separately instead of growing the PR's scope.
+
+A review disposition does not itself approve or merge on GitHub. Follow the authorized action and repository protection rules.
+
+## 5. Re-review the delta and finish
+
+Compare against the last reviewed head, resolve outstanding findings, and inspect added changes. Check intervening main changes for effects on the earlier assessment. Expand review when those changes invalidate scope or evidence; do not treat an old pass as proof of new behavior.
+
+Completion requires the agreed outcome, preserved contracts, sufficient applicable evidence, and no unresolved acceptance blockers. Before an authorized merge, recheck the live head and required gates. Record remaining non-blocking limitations explicitly; arbitrary inputs outside the supported contract are not a demand for unlimited testing.


### PR DESCRIPTION
## Problem and value

Reviewers currently rediscover impact and acceptance boundaries, while repository-only prose and focused test corrections inherit a local full-suite requirement. Bot checks can also duplicate requests: on [PR #351](https://github.com/tt-a1i/archify/pull/351#issuecomment-5579941402), scope assessment requested archive evidence while Validation Evidence had already inspected that archive.

Bound review by changed behavior and callers, settle scope before expensive integration work, and re-review new changes plus unresolved findings. CONTRIBUTING.md owns author requirements; REVIEWING.md owns reviewer procedure; the shorter template collects decision-relevant evidence. Align CodeRabbit with these same rules. Refs #344.

## Stability impact

- Repository review policy only: CONTRIBUTING.md, REVIEWING.md, the PR template, and .coderabbit.yaml. No runtime, packaged Skill, schema, CI workflow, or generated-source changes relative to main.
- Keep full local checks for runtime, schema, packaged authoring behavior, generated content, and shared test infrastructure. Repository-only prose/policy and focused test-only changes may explain targeted evidence. Remote CI and branch protection remain unchanged.
- Preserve compatibility, authored geometry, stable diagnostics, and separate browser/perceptual evidence. Historical evidence retains its revision.
- Bot: keep chill, ready-PR/incremental review and two warning checks; include REVIEWING.md; disable overlapping built-in issue assessment and in-progress fortune messages. Check the PR diff rather than checkout dirtiness, accept evidence already supplied, and distinguish author work from maintainer CI approval. Narrow fixes can use reproduction; new contracts/defaults need agreed scope.
- Document incremental/full review, pre-merge rechecks after evidence-only edits, and pause/resume. Bot guidance is probabilistic and advisory; it cannot grant merge authority.
- Rollback: revert these four policy/config changes. No data migration or artifact rebuild is needed.

## Tests run

Comparison base: `06bd6fea5752bc06b8170a1f09085c798df5aa13`. Candidate: `a3bdf15` (full SHA in PR head).

On the candidate content with Node 22.23.2:

- `node --test archify/test/community-proof-intake.test.mjs`: 3 passed, 0 failed, 0 skipped.
- `git diff --check origin/main`: clean.
- PyYAML 6.0.3 + jsonschema 4.26.0 validation against the official v2 schema: zero errors; all four guideline paths exist. Ten relative Markdown links/anchors resolve.

Reproduce schema validation (Python environment with PyYAML/jsonschema):

```sh
curl -fsSL https://coderabbit.ai/integrations/schema.v2.json -o /tmp/coderabbit-schema.json
python - <<'PY'
import json, pathlib, yaml
from jsonschema import Draft7Validator
config = yaml.safe_load(pathlib.Path('.coderabbit.yaml').read_text())
schema = json.loads(pathlib.Path('/tmp/coderabbit-schema.json').read_text())
errors = list(Draft7Validator(schema).iter_errors(config))
for error in errors:
    print(error.json_path, error.message)
assert not errors
for path in config['knowledge_base']['code_guidelines']['filePatterns']:
    assert pathlib.Path(path).is_file(), path
print('Schema errors: 0; guideline paths: 4')
PY
```

No local renderer suite: the four changed files do not affect renderer, package or site inputs. Current-head remote checks and bot review must be read separately; older CI is not a current pass.

Historical procedure pilots at the previous policy candidate `e9a6fe67545a0433c72c49facdfaf851ed339292` (reused design evidence, not new-head executions):

- PR #255 at `ab4908b1618002f3c1372303d1106f0c56f4b4ca`: contract/shared change needs a scope decision on automatic v2 lane sizing versus public lane.height semantics before another full implementation review. No new browser/full-suite claim.
- PR #319 at `16ef0cd3e6c4031be906f89de1d92e0e46c069b7`: focused test-only change fits targeted verification; Windows base-fail/head-pass remained author-reported and remote CI required action. No merge acceptance inferred.

Current policy review scenarios: repository prose needs content/link checks; shared geometry needs caller tracing and comparable relevant artifacts; fork CI awaiting approval needs maintainer action; reused archive evidence should not be requested again solely because a binary diff is excluded. These are manual policy-consistency checks, not proof of future LLM behavior or measured review-time savings. Observe the first 5–10 reviewed PRs before expanding enforcement.

## Visual evidence

Not applicable: repository review policy only; no diagram, Viewer or public-page appearance/interaction changes.

## Generated artifacts

None. These root/GitHub policy files are outside packaged archify/ and generated site inputs; ZIP and Gallery sources are unchanged.
