### PR TITLE
fix(deps): unstick the fast-uri override from a version that is itself vulnerable

### DIFF
--- a/archify/package-lock.json
+++ b/archify/package-lock.json
@@ -38,23 +38,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -74,6 +57,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/archify/package.json
+++ b/archify/package.json
@@ -32,6 +32,6 @@
     "simple-icons": "16.28.0"
   },
   "overrides": {
-    "fast-uri": "3.1.5"
+    "fast-uri": "^3.1.7"
   }
 }


### PR DESCRIPTION
## Problem and value

`npm audit` on current `main` reports **2 high-severity vulnerabilities** through `ajv > fast-uri`:

```
fast-uri  3.0.0 - 3.1.5   (high)
  GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp
node_modules/ajv/node_modules/fast-uri
  ajv  → depends on vulnerable versions of fast-uri
```

The override added in #209 did the right thing at the time, but it pins an **exact** version. That froze the tree at `3.1.5`, and four advisories published since cover `3.0.0 - 3.1.5` — so the mechanism that was meant to keep `fast-uri` patched is now the reason it is not. Every future advisory in that line needs another manual bump.

This supersedes the stale #141, which is conflicting, has an unfilled description, and also touches `archify.zip`, `bin/archify.mjs`, and `test/cli.test.mjs`.

## Scope

- **What changed:** `archify/package.json` override `"fast-uri": "3.1.5"` → `"fast-uri": "^3.1.7"`, and the resulting `archify/package-lock.json`. Two files, 18 insertions, 18 deletions.
- **What deliberately did not change:** no source, no renderer, no schema, no test, no generated artifact, no release identity or version. `ajv` itself stays at `8.20.0`.
- **No unrelated changes:** confirmed — `git diff --stat` is exactly the two dependency files.

Deliberately `^3.1.7` rather than an exact `3.1.7`: a caret keeps the security floor the override exists to provide while letting the resolver take future patches on its own. It also sits inside `ajv`'s own declared `^3.0.1`, so nothing is forced out of range — `npm ls fast-uri` no longer reports the dependency as `overridden`. `4.x` was not used; it would force a major outside that range for no security benefit.

## Stability impact

- **Compatibility and migration risk:** none for consumers. `fast-uri` is reached only through `ajv`, a `devDependency` used by `scripts/generate-validators.mjs`; it is not in any published runtime path. `3.1.5 → 3.1.7` is a patch bump within the same major.
- **Renderer, validator, package, or generated-artifact risk:** the generated validators are the one surface that could move, and `npm run check:validators` (part of `npm test`) passes, so the checked-in output is unchanged.
- **Failure behavior and rollback path:** revert the single commit; `npm ci` restores `3.1.5`. Nothing is written outside `node_modules` and the lockfile.

## Tests run

Node.js v26.8.1, macOS. Run from `archify/`.

```
npm ci
npm test
→ ℹ tests 1051 / ℹ pass 1020 / ℹ fail 0 / ℹ skipped 31   (exit 0)

npm audit
→ found 0 vulnerabilities

npm ls fast-uri
→ archify@2.17.0-dev.1
  └─┬ ajv@8.20.0
    └── fast-uri@3.1.7
```

The same suite was run on unmodified `main` (`920543b`) in a separate clean clone as a baseline: **1051 / 1020 pass / 0 fail / 31 skipped**, identical. No test changed state.

All 31 skips are environmental and identical on both sides — 25 gated on `ARCHIFY_CHROME`, 5 on `canonical ZIP builds require Node 22`, 1 on `ARCHIFY_MCO_REPO_ROOT`. Per CONTRIBUTING, those are reported as **skipped, not passed**; none of them exercises dependency resolution.

## Visual evidence

Not applicable — no rendering, layout, or viewer behavior is touched.

## Generated artifacts

None regenerated. `check:brand-marks`, `check:validators`, and `check:release-identity` all pass against the checked-in artifacts, which is the evidence that their inputs did not change. `archify.zip` is deliberately untouched: no host-visible plugin or Skill bytes change here, and CONTRIBUTING asks that release identity stay out of an ordinary PR.

## Checklist

- [x] I used a minimal focused change and preserved existing typed JSON behavior unless the issue requires a contract change.
- [x] I ran the relevant targeted tests and `npm test` in `archify/`.
- [x] I added or updated a regression test for behavioral changes. — *not applicable; no behavior changes. `npm audit` is the check that fails before this change and passes after.*
- [x] I checked generated artifacts and package freshness when their sources changed.
- [x] I removed secrets, private repository content, and customer data from fixtures and screenshots.


## Maintainer integration update

Candidate `f110d0dae85f08d3477e133d81255850e04b9967` includes main `3d972342c52127b0fd81e9c4d8f4237d2e9f848b`. Local official Node 22.23.2: npm ci succeeds, check:validators passes, and npm audit reports 0 vulnerabilities.

Correction to the original artifact assessment: the package stager retains package.json overrides, so the canonical ZIP must also change. Rebuilt it with official Node 22; the archive entry list is identical and its only changed entry is archify/package.json, whose only changed field is the fast-uri override. Renderer and Viewer bytes are unchanged. The initial integration CI caught the stale ZIP; the corrected final-head CI is required before merge.
