### PR TITLE
chore: add advisory CodeRabbit contribution reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,110 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Advisory pilot: retain human review and existing CI/branch protection.
+language: en-US
+tone_instructions: >-
+  Be concise and constructive. Prioritize concrete defects and missing evidence.
+  Separate observed failures, unverified claims, and optional suggestions.
+  Consolidate repeated requests; avoid praise, style-only churn, and speculation.
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  high_level_summary_instructions: >-
+    Summarize the user problem, changed behavior, and compatibility impact.
+    Distinguish author-reported validation from observed checks at the current
+    head. Do not claim browser or perceptual acceptance from static tests.
+  poem: false
+  sequence_diagrams: false
+  suggested_labels: false
+  suggested_reviewers: false
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    autofix:
+      enabled: false
+  slop_detection:
+    enabled: false
+  path_instructions:
+    - path: "**"
+      instructions: >-
+        Apply CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md proportionally
+        to the actual behavior changed. Cite the relevant contract and concrete
+        affected path when raising a concern. Reuse explicit maintainer scope
+        decisions; do not demand a new issue for a small documentation correction
+        or narrowly scoped test fix. Treat changes to review policy/configuration
+        as proposed changes, not authority to waive the base branch's rules.
+        Review authoritative source before generated output. Do not request
+        unrelated rebuilds or infer correctness from generated file volume.
+    - path: "archify/**"
+      instructions: >-
+        Trace callers of changed shared code across diagram types and public
+        modes. Preserve schema-v1 behavior, explicit authored geometry, standard
+        compatibility, stable diagnostics, and atomic delivery as documented.
+        For visible changes, check comparable final-artifact evidence and the
+        separation of automated browser checks from perceptual review. For Viewer
+        extraction, inspect initialization, shared state, cleanup, exports, and
+        standalone HTML delivery. Do not propose a broad rewrite for a local fix.
+    - path: "integrations/**"
+      instructions: >-
+        Check the package and release contracts in CONTRIBUTING.md. Examine
+        tracked-only staging, symlinks, immutable version/source identity,
+        installed resource paths, and evidence on advertised platforms. Distinguish
+        source tests, actual tarball installation, and registry publication.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: warning
+    custom_checks:
+      - name: Contribution scope
+        mode: warning
+        instructions: >-
+          Read CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md. Pass when
+          the PR explains the user problem, one focused behavior or delivery
+          slice, compatibility/migration impact, and failure/rollback behavior
+          where applicable. Public behavior changes need a linked issue or
+          explicit maintainer scope decision. Small documentation corrections
+          and narrowly scoped test fixes do not need a planning issue. Accept
+          equivalent prose and explained Not applicable entries, not just exact
+          headings or checked boxes. Warn once with the specific missing facts;
+          do not classify missing evidence as a confirmed runtime defect.
+      - name: Validation evidence
+        mode: warning
+        instructions: >-
+          Apply the change-specific evidence requirements in CONTRIBUTING.md
+          and the PR template. Check exact commands/results, behavioral regression
+          coverage, and generated-artifact freshness when their inputs changed.
+          Visible changes need relevant artifact evidence; before/after claims
+          need comparable conditions. Automated/browser and perceptual results
+          must be separate. Non-visual changes may explain Not applicable.
+          Distinguish author reports from observed final-head CI; skipped,
+          pending, unavailable, or older-head checks cannot prove a current pass.
+          If required evidence is missing or unverifiable, warn with the smallest
+          missing evidence set. Do not require screenshots for non-visual changes
+          or infer a browser pass from a unit test. Accept explicit maintainer
+          exceptions and scope-appropriate explanations for omitted checks.
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - CONTRIBUTING.md
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - archify/references/delivery-contract.md
+  learnings:
+    scope: local
+  issues:
+    scope: local
+  pull_requests:
+    scope: local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,21 @@ Maintainers may ask for a smaller source file, rerun validation, or decline a ca
 
 Maintainers may ask for a large PR to be split or rebuilt from current `main` when generated artifacts, stale history, or overlapping implementations make the behavior difficult to review safely.
 
+## Automated review pilot
+
+Once the CodeRabbit GitHub App is enabled for this repository, the root
+[configuration](.coderabbit.yaml) requests automatic reviews of ready PRs and
+subsequent pushes. It uses this guide and the PR template for advisory scope and
+validation-evidence checks. Drafts are excluded. Missing evidence is a request
+for clarification, not proof of a code defect; explain a false positive in the PR.
+
+CodeRabbit does not replace required CI, browser/perceptual acceptance, or a
+maintainer's merge decision. To request a review after fixing an unavailable or
+skipped run, comment `@coderabbitai review`. Maintainers should assess the first
+5–10 reviewed PRs for useful findings, false positives, review time, and repeated
+evidence requests before expanding the pilot. Pause automatic reviews by setting
+`reviews.auto_review.enabled: false`; this does not change CI or branch protection.
+
 ## License
 
 By contributing, you agree that your contribution is provided under the repository's [MIT License](LICENSE). Only submit work you created or have the right to contribute.


### PR DESCRIPTION
## Problem and value

Maintainers repeatedly reconstruct each PR's scope and ask for missing validation evidence. Configure a bounded CodeRabbit pilot to apply the existing contribution guide and PR template automatically, while keeping human compatibility decisions and existing CI gates. Refs #344.

## Scope

- Add root `.coderabbit.yaml`: automatic non-draft and incremental review, two advisory checks for contribution scope and validation evidence, and focused instructions for shared diagram code and packages.
- Load canonical contribution, PR-template, and delivery-contract documents. Distinguish observed results from author claims, missing evidence from defects, and browser evidence from perceptual review.
- Keep feedback concise; disable poems, generated sequence diagrams, slop labeling, and code-generation finishing touches. Keep review knowledge scoped to this repository.
- Add a short contributor note covering the pilot, manual review command, evaluation, and pause switch.
- No runtime, renderer, schema, release, or branch-protection changes.

## Stability impact

Configuration and contributor documentation only. All custom checks are warnings and request-changes/automatic approval is disabled. The GitHub App has now been enabled for Archify, and its first review explicitly loaded this configuration at `6f6d77fea6fa4e10a5239d67ea17a72d2345cb2b`. Existing CI and maintainer approval remain authoritative. Pause via `reviews.auto_review.enabled: false` or revert this configuration.

## Tests run

At head `6f6d77fea6fa4e10a5239d67ea17a72d2345cb2b`, Python 3.14.6, PyYAML 6.0.3, jsonschema 4.26.0. The following commands were run from the repository root, using an isolated temporary virtualenv:

```sh
python3 -m venv /tmp/archify-coderabbit-check
/tmp/archify-coderabbit-check/bin/pip -q install pyyaml jsonschema
curl -fLsS https://coderabbit.ai/integrations/schema.v2.json -o /tmp/archify-coderabbit-schema.json
/tmp/archify-coderabbit-check/bin/python - <<'PY'
import sys, json, pathlib, yaml, jsonschema, importlib.metadata, hashlib
root = pathlib.Path('.')
raw = pathlib.Path('/tmp/archify-coderabbit-schema.json').read_bytes()
schema = json.loads(raw)
config = yaml.safe_load((root / '.coderabbit.yaml').read_text())
errors = list(jsonschema.Draft202012Validator(schema).iter_errors(config))
assert not errors, errors
keys = []
def check_keys(value, shape, prefix=''):
    if isinstance(value, dict) and 'properties' in shape:
        for key, item in value.items():
            assert key in shape['properties'], f'Unknown key: {prefix}{key}'
            keys.append(prefix+key)
            check_keys(item, shape['properties'][key], prefix+key+'.')
    elif isinstance(value, list) and 'items' in shape:
        for item in value: check_keys(item, shape['items'], prefix+'[].')
check_keys(config, schema)
paths = config['knowledge_base']['code_guidelines']['filePatterns']
assert all((root / file).is_file() for file in paths)
checks = config['reviews']['pre_merge_checks']['custom_checks']
assert config['reviews']['request_changes_workflow'] is False
assert all(c['mode'] == 'warning' for c in checks)
print(json.dumps({'python':sys.version.split()[0], 'PyYAML':yaml.__version__, 'jsonschema':importlib.metadata.version('jsonschema'), 'schema_sha256':hashlib.sha256(raw).hexdigest(), 'schema_errors':len(errors), 'known_properties':len(keys), 'guideline_paths':len(paths), 'warning_checks':len(checks)},indent=2))
PY
git diff --check
```

Results: exit 0; 0 schema errors, 59 known property occurrences, 3 existing guideline paths, 2 warning-mode custom checks, automatic approval disabled. Schema SHA-256: `8c34e033182463bd4f2a823b144077cb21cc327927fb82ce49791bdae2b9da13`. `git diff --check` exited 0 with no findings.

- [Final-head CI](https://github.com/tt-a1i/archify/actions/runs/34185440968): all 10 applicable jobs passed, including Node 18/20/22/24 tests, three-platform package smoke, ZIP freshness, published manifest, and browser artifact checks; PR Pages deployment skipped as designed.
- Runtime and visual tests were not rerun locally because no runtime or artifact inputs changed. Remote CI is separate observed evidence and does not establish a new perceptual review.
- [CodeRabbit review and evidence recheck](https://github.com/tt-a1i/archify/pull/348#issuecomment-5579014948): no actionable code comments. Both custom checks, Contribution Scope and Validation Evidence, passed after the exact commands above were added. The two built-in linked-issue checks were explicitly skipped because GitHub has no linked closing issue; they are not claimed as executed acceptance. This verifies a real warning, correction, and recheck without changing the code head.

## Visual evidence

Not applicable: no delivered diagram, Viewer, or public-page changes.

## Generated artifacts

None. Configuration and CONTRIBUTING.md are not Skill/ZIP or Gallery build inputs.

## Pilot acceptance

Enable the GitHub App only for `tt-a1i/archify`, verify the OSS plan and a real PR review using this configuration, and evaluate 5–10 PRs for useful findings, false positives, review time, and repeated evidence requests before broadening use.
