### PR TITLE
test: make clean staging mode checks portable

### DIFF
--- a/archify/test/clean-skill-staging.test.mjs
+++ b/archify/test/clean-skill-staging.test.mjs
@@ -87,17 +87,30 @@ test('clean staging rejects byte-identical but incomplete repository and package
   }
 });
 
-test('clean staging preserves index modes and strips repository-only package metadata', () => {
+test('clean staging preserves index modes and strips repository-only package metadata', (t) => {
   const root = repositoryFixture();
   const destination = path.join(root, 'staged-skill');
   try {
-    write(root, 'archify/bin/executable.mjs', '#!/usr/bin/env node\n', 0o755);
-    write(root, 'archify/runtime/test/required.dat', 'runtime fixture\n');
+    write(root, 'archify/bin/executable.mjs', '#!/usr/bin/env node\n', 0o644);
+    write(root, 'archify/runtime/test/required.dat', 'runtime fixture\n', 0o755);
     git(root, ['add', 'archify']);
+    // Index modes must win over working-tree permissions, including on Windows.
+    git(root, ['update-index', '--chmod=+x', 'archify/bin/executable.mjs']);
+    git(root, ['update-index', '--chmod=-x', 'archify/runtime/test/required.dat']);
+    const chmod = t.mock.method(fs, 'chmodSync');
 
     stageCleanSkill({ repoRoot: root, destination });
 
-    assert.equal(fs.statSync(path.join(destination, 'bin', 'executable.mjs')).mode & 0o777, 0o755);
+    const executable = path.join(destination, 'bin', 'executable.mjs');
+    const runtimeFixture = path.join(destination, 'runtime', 'test', 'required.dat');
+    const appliedModes = new Map(chmod.mock.calls.map(({ arguments: args }) => args));
+    assert.equal(appliedModes.get(executable), 0o755);
+    assert.equal(appliedModes.get(runtimeFixture), 0o644);
+    // Windows chmod cannot expose Unix executable bits through stat.
+    if (process.platform !== 'win32') {
+      assert.equal(fs.statSync(executable).mode & 0o777, 0o755);
+      assert.equal(fs.statSync(runtimeFixture).mode & 0o777, 0o644);
+    }
     assert.equal(fs.existsSync(path.join(destination, 'test')), false);
     assert.equal(
       fs.readFileSync(path.join(destination, 'runtime', 'test', 'required.dat'), 'utf8'),


### PR DESCRIPTION
## Problem and value

The clean-staging mode regression fails on Windows because `stat` reports `0666`, not the expected Unix `0755`. Its fixture also depends on Git detecting executable bits from the working tree. This lets the same regression run on Windows while checking that staging follows the Git index, including when its modes differ from the source files.

## Scope

- What changed: one test sets both executable and non-executable index modes explicitly, observes real `chmodSync` calls, and retains filesystem mode assertions on POSIX.
- What deliberately did not change: production code, package contents and public behavior.
- No unrelated changes: confirmed. The separate fixture additions in #208 do not overlap this test.

## Stability impact

- Compatibility and migration risk: no public contract changes; verified with Node 18 and 24.
- Renderer, validator, package, or generated-artifact risk: none; their inputs are unchanged.
- Failure behavior and rollback path: wrong executable or non-executable staging modes still fail the test. Reverting this commit restores the previous fixture and assertions.

## Tests run

Against `2ead014`, commands below run from `archify/`:

- Windows, Node 24.14.0: `node --test --test-name-pattern='clean staging preserves index modes' test/clean-skill-staging.test.mjs` failed before the change with `438 !== 493`.
- Windows, Node 24.14.0: `node --test test/clean-skill-staging.test.mjs` — 7 passed, 0 failed, 1 existing file-symlink permission skip.
- Ubuntu 24.04, Node 18.19.1: `node --test test/clean-skill-staging.test.mjs` — 8 passed, 0 failed, 0 skipped. The focused mode test also passes with `core.fileMode=false` supplied through Git's environment configuration.
- Controlled mutations in an isolated copy: discarding executable index mode and selecting working-tree mode instead of index mode both fail the revised regression. Production source was restored afterward.
- Ubuntu 24.04, Node 18.19.1: `npm test` — 1,018 passed, 2 failed, 31 skipped (1,051 tests). Brand-mark, validator, release-identity and golden checks pass. Both failures are in unchanged update-notifier tests: `an empty precheck snapshot cannot start a second concurrent network request` and `a last-good notice remains acknowledgeable after the refresh commits a new candidate`. Both reproduce together on a pristine `2ead014` checkout with `node --test --test-name-pattern='an empty precheck snapshot|a last-good notice remains acknowledgeable' test/update-notifier.test.mjs`.
- `git diff --check` — passed. Local review found no actionable findings. Remote CI has not yet run on this branch.

## Visual evidence

Not applicable. This changes a packaging test's fixture and assertions, with no generated diagram or UI changes. Automated browser checks and perceptual visual review are not applicable.

## Generated artifacts

None. The changed file is under the repository-only test tree, which the Skill stager excludes. No published input changed, so an archive or Gallery rebuild is unnecessary.

## Checklist

- [x] I used a minimal focused change and preserved existing typed JSON behavior.
- [x] I ran the relevant targeted tests and `npm test` in `archify/`; full-suite failures are recorded above.
- [x] I updated the existing regression and verified that it detects incorrect staging modes.
- [x] I checked generated-artifact and package relevance; their inputs are unchanged.
- [x] I removed secrets, private repository content, customer data and local paths from this contribution.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes only a repository test. The PR remains draft while upstream CI and review are pending.
