### PR TITLE
docs(authoring-contract): add viewport height budget and concrete via direction contract

### DIFF
--- a/archify/references/authoring-contract.md
+++ b/archify/references/authoring-contract.md
@@ -104,12 +104,34 @@ in the generated viewer.
 ## Executable geometry rules
 
 - Node anchors start at side midpoints. `left`/`right` change the horizontal endpoint; `top`/`bottom` change the vertical endpoint. For an automatic Architecture relationship, unobstructed facing ports whose axis offset is under 16px may share one horizontal or vertical axis when both endpoints retain the 16px corner gutter. If exactly one endpoint belongs to a spread group, only its unshared counterpart moves; relationships spread at both endpoints keep their distinct ports and outside bridge.
-- A side is a direction contract. The first and final route segment must be perpendicular and outward/inward in the named direction.
+- A side is a direction contract. The first and final route segment must be perpendicular and outward/inward in the named direction. Concretely, for an explicit `via`: `via[0]` must share its x with the departure point when `fromSide` is `top`/`bottom` (vertical first segment) and share its y when `fromSide` is `left`/`right` (horizontal first segment); the same holds inverted for the arrival point and the last `via` entry. Departure and arrival points sit at side midpoints — they are not freely choosable positions on the edge.
 - Automatic Port Spread is a default renderer behavior for architecture, workflow, data-flow, and lifecycle diagrams. Shared automatic endpoints spread deterministically and symmetrically with a 16px corner gutter. It does not apply to sequence messages, single relationships, or explicit `via`, `channelX`, `channelY`, `labelAt`, or non-`auto` routes.
 - Showcase route rhythm: every nonzero segment must be at least 8px; every interior segment must be at least 16px. When spread ports are nearly parallel, the router uses a 24px endpoint stub and a 16px outside bridge instead of manufacturing a tiny dogleg.
 - Shared endpoint corridors are allowed only when they remain semantically unambiguous. Unrelated collinear overlap of 8px or more fails showcase.
 - Container borders are intentional pass-through geometry, but a long edge running along a structural border is not.
 - An edge crossing an unrelated opaque node is always a hard failure, independent of quality profile.
+
+### Viewport height budget
+
+`validate` proves SVG-internal geometry only; it does not estimate page overflow.
+The standalone viewer page stacks viewer chrome (~51px), the diagram panel, and
+the cards section. At a 1440-wide viewport the reader layout renders the SVG at
+roughly 930px wide, not 1440:
+
+```text
+page height ≈ viewer chrome (~51px) + 930 × viewBoxH / viewBoxW + cards height + margins
+cards height ≈ tallest card (items × ~24px + padding); three-column grid at ≥960px
+```
+
+Practical budget for a first-screen pass at 1440×900: author a viewBox with
+width/height ratio ≥ 2.0 and keep cards to ≤4 short items each (≤2 lines per
+item). When `visual-check` reports overflow, repair in this order: 1) tighten
+card copy while preserving every information point, 2) widen the x span by
+stretching node columns — more effective than compressing y, 3) compact
+vertical rhythm. Do not chase a "good aspect ratio" without this budget: an
+official example at ratio 1.84 (1080×588) can pass while a 1.89 candidate
+overflows, because the absolute rendered height, not the ratio, is the
+determinant.
 
 ### Spacing and labels
 


### PR DESCRIPTION
## Problem and value

Current-main trigger: a candidate that passes `validate --quality showcase` with 0 errors / 0 warnings can still overflow the 1440×900 first screen in `visual-check`. The docs describe the goal qualitatively ("over-compressed Y layout", "vertical rhythm") but give no quantitative budget, so an author rediscovers the page-height arithmetic by trial and error after the spec is already frozen. Separately, the via direction contract is enforced by `clean-flow/endpoint-side-direction` but stated only abstractly ("a side is a direction contract"), so the exact constraint on `via[0]` coordinates is learnable only by triggering the error.

Intended outcome: an author can budget the viewport height at authoring time and write compliant `via` waypoints on the first try.

Evidence from a real authoring session on 2.16: official example `web-app-rendered.html` at viewBox 1080×588 (ratio 1.84) passes all four viewports, while my candidate at 1225×648 (ratio 1.89) overflows 1440×900 by 79px. A higher ratio overflowing while a lower one passes proves "keep the ratio above a threshold" is the wrong mental model; the determinant is absolute rendered height (viewer chrome ~51px + 930px reader-width × viewBoxH/viewBoxW + cards). Tightening card copy recovered 34px; stretching node x-coordinates (viewBox 1225→1315) recovered the remaining 11px.

Approach: docs-only — one new subsection and one bullet extension (below). Narrow documentation correction; per CONTRIBUTING "Choose the right path", no separate planning issue needed.

## Stability impact

- Impact class: documentation only. No code, schema, defaults, or acceptance rules changed.
- Existing behavior preserved: all existing text unchanged except the one direction-contract bullet, which is strictly extended (original sentence retained verbatim).
- No unrelated changes: confirmed — single file, +23/−1.

## Tests run

- Comparison base: `main` @ 1072200. Candidate: this branch (1 commit).
- Markdown structure verified: "Viewport height budget" nests under "Executable geometry rules" alongside "Spacing and labels" / "Repair order"; no heading regressions.
- No automated checks apply to prose; `archify doctor` unaffected (docs not loaded by the CLI).

## Visual evidence

Not applicable — documentation-only change; no rendering path touched.

## Generated artifacts

None; no generated files reference `references/authoring-contract.md` content.