### PR TITLE
chore(governance): add advisory triage controls and maintenance roadmap

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,9 @@
 /.github/CODEOWNERS @tt-a1i
 /.github/workflows/** @tt-a1i
 /.github/actions/** @tt-a1i
+/.github/scripts/** @tt-a1i
+/.github/triage-allowlist.json @tt-a1i
+/.github/CURRENT_FOCUS.md @tt-a1i
+/CONTRIBUTING.md @tt-a1i
+/REVIEWING.md @tt-a1i
 /SECURITY.md @tt-a1i

--- a/.github/CURRENT_FOCUS.md
+++ b/.github/CURRENT_FOCUS.md
@@ -1,0 +1,45 @@
+# Current focus
+
+Stability and first-diagram reliability: an ordinary Agent's path from a bounded system description to a readable, verified diagram. Tracking issue: [#344](https://github.com/tt-a1i/archify/issues/344). Follow the **Active sequence** recorded there; this file states what is deferred and what would reopen it.
+
+## Not now
+
+| Item | Why deferred | What evidence would reopen it |
+| --- | --- | --- |
+| New diagram types (erd [#115](https://github.com/tt-a1i/archify/issues/115), cognition [#149](https://github.com/tt-a1i/archify/issues/149)) | Each renderer adds a Viewer/validator/golden surface that must stay reliable before the five existing types are. | A repository-scale real scenario that cannot be expressed by the five existing types, and a contributor who commits to owning that renderer's Viewer regressions. |
+| New export formats and CLI export surfaces beyond the chosen SVG contract ([#241](https://github.com/tt-a1i/archify/issues/241), [#264](https://github.com/tt-a1i/archify/pull/264), [#272](https://github.com/tt-a1i/archify/pull/272), [#328](https://github.com/tt-a1i/archify/pull/328)) | Three parallel implementations exist for one need; the command and receipt contract is not yet agreed. | One public command/receipt contract agreed on the issue; then one primary implementation. |
+| Plugin marketplaces ([#87](https://github.com/tt-a1i/archify/pull/87), [#88](https://github.com/tt-a1i/archify/issues/88)) | The ZIP distribution contract and marketplace identity/immutability rules conflict. | An issue that reconciles the ZIP contract with marketplace identity and immutability. |
+| Cross-diagram drill-down / nested architecture as a large implementation ([#230](https://github.com/tt-a1i/archify/issues/230), [#262](https://github.com/tt-a1i/archify/issues/262), [#269](https://github.com/tt-a1i/archify/pull/269), [#280](https://github.com/tt-a1i/archify/issues/280), [#281](https://github.com/tt-a1i/archify/pull/281)) | The need is acknowledged; the implementations proposed so far are large and disagree on child identity. | A small agreed contract for stable child identity and evidence, before implementation. |
+| Viewer broad rewrite or framework migration | Single-file deterministic delivery and installed-Skill compatibility are the constraint. [#343](https://github.com/tt-a1i/archify/issues/343) stays a bounded extraction proposal. | One concrete extraction boundary with compatibility evidence, per #343. |
+| Default typography changes ([#340](https://github.com/tt-a1i/archify/issues/340), [#282](https://github.com/tt-a1i/archify/issues/282)) | Deferred by maintainer decision recorded in #344; existing zoom stays. | A maintainer decision in #344 reopening the item. |
+| Broad forge adapters beyond GitHub/Gitee/local-only | [#354](https://github.com/tt-a1i/archify/pull/354) closed the bounded scope. | A hosted-forge case that local-only validation cannot cover, with a maintainer decision. |
+
+## How work moves
+
+- **Primary implementation:** one issue, one maintainer-designated primary PR (label `primary-implementation`), not first-come. Other PRs for the same issue are welcome as reproduction, tests, or a clearly labeled stage. Primary status lapses after 7 days without an author response to review; a maintainer may then designate another PR.
+- **Small fixes:** narrow fixes and documentation/test corrections proceed without `accepted`. New schema fields, defaults, acceptance rules, install/export contracts, diagram types, or export formats need a linked issue carrying `accepted` or a recorded maintainer decision.
+- **Stale:** only PRs labeled `awaiting-author` (a collaborator requested changes on the current head) age. 14 days → `stale` and a reminder; 7 more days → closed with resume instructions. Reopening is fine. Waiting on maintainer review is never stale.
+- **Weekly decision window:** maintainers batch merge, close, request-evidence, and primary-designation decisions once a week; the rest of the week is asynchronous.
+- **Generated artifacts:** Phase 1 active. CI rebuilds the Gallery and ZIP per PR and reports differences; the contributor contract in [CONTRIBUTING.md](../CONTRIBUTING.md#packages-and-generated-artifacts) is unchanged. Phases are defined in [docs/maintenance-roadmap.md](../docs/maintenance-roadmap.md).
+
+## Labels
+
+- `accepted` — maintainer agreed scope; feature/contract PRs may proceed. Maintainer-only.
+- `primary-implementation` — on a PR: the maintainer-designated main implementation for its linked issue. Maintainer-only.
+- `awaiting-author` — a maintainer requested changes on the current head; the stale clock runs only on this label.
+- `needs-repro` — bug report lacks the minimal typed JSON reproduction or receipt.
+- `not-now` — deferred per this file; reconsideration conditions apply.
+- `generated-artifacts` — PR touches generated-site, package, or golden-example paths; set and removed by the triage card.
+- `stale` — set by the stale workflow.
+
+Last reviewed: 2026-09-09. Maintainers update this file directly; a PR that changes the rules it is itself subject to does not update it.
+
+## 中文摘要
+
+- 当前焦点：稳定性与首张图的可靠性，跟踪 issue #344，按其中的 Active sequence 推进。
+- 暂不做（Not now）：新图类型（erd、cognition）；SVG 之外的新导出格式与 CLI 导出面；插件市场；跨图下钻/嵌套架构的大型实现；Viewer 大规模重写或框架迁移；默认字体排版调整；GitHub/Gitee/local-only 之外的代码托管适配。每项的重开条件见上表。
+- 四条规则：
+  1. 主实现：一个 issue 只有一个维护者指定的主 PR（`primary-implementation`），不按先到先得；作者 7 天未回应评审则失效。
+  2. 小修复与文档/测试修正无需 `accepted`；新 schema 字段、默认值、接受规则、安装/导出契约、新图类型、新导出格式需要带 `accepted` 的 issue 或维护者书面决定。
+  3. 过期：仅对 `awaiting-author` 的 PR 计时，14 天提醒，再 7 天关闭，可重开；等待维护者评审永不算过期。
+  4. 每周一次决策窗口集中处理合并/关闭/补证据/指定主实现，其余时间异步。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 Current-main trigger or rationale, intended outcome, approach, and linked issue/agreed scope:
 
+Linked issue and scope status (accepted / narrow fix / recorded decision):
+
 ## Stability impact
 
 - Impact class and changed behavior/shared callers: <!-- CONTRIBUTING.md#choose-evidence-by-impact -->
@@ -28,3 +30,5 @@ Report automated or browser evidence separately from perceptual review.
 ## Generated artifacts
 
 Regenerated files or linked build evidence; if none, explain why outputs remain fresh.
+
+- Changed golden examples and the behavior change behind each:

--- a/.github/scripts/ensure-labels.mjs
+++ b/.github/scripts/ensure-labels.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Create or update the governance label set with `gh label create --force`.
+// Usage: node .github/scripts/ensure-labels.mjs [--dry-run]
+// Label names are fixed by CONTRIBUTING.md and .github/CURRENT_FOCUS.md.
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const LABELS = [
+  {
+    name: "accepted",
+    color: "2EA043",
+    description: "Maintainer agreed scope; feature or contract PRs may proceed. Maintainer-only.",
+  },
+  {
+    name: "primary-implementation",
+    color: "1D76DB",
+    description: "Maintainer-designated main implementation PR for its linked issue. Maintainer-only.",
+  },
+  {
+    name: "awaiting-author",
+    color: "FBCA04",
+    description: "A maintainer requested changes on the current head; the stale clock runs only on this label.",
+  },
+  {
+    name: "needs-repro",
+    color: "E99695",
+    description: "Bug report lacks the minimal typed JSON reproduction or validation receipt.",
+  },
+  {
+    name: "not-now",
+    color: "BFD4F2",
+    description: "Deferred per .github/CURRENT_FOCUS.md; reconsideration conditions apply.",
+  },
+  {
+    name: "generated-artifacts",
+    color: "C5DEF5",
+    description: "PR touches generated-site, package, or golden-example paths; set and removed by the triage card.",
+  },
+  {
+    name: "stale",
+    color: "EDEDED",
+    description: "No author response on an awaiting-author PR for 14 days; closes after 7 more.",
+  },
+];
+
+export function renderCommand(label) {
+  return [
+    "gh",
+    "label",
+    "create",
+    label.name,
+    "--color",
+    label.color,
+    "--description",
+    label.description,
+    "--force",
+  ];
+}
+
+function quote(arg) {
+  return /^[\w./=-]+$/.test(arg) ? arg : `"${arg.replace(/"/g, '\\"')}"`;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const dryRun = argv.includes("--dry-run");
+  for (const label of LABELS) {
+    const [bin, ...args] = renderCommand(label);
+    if (dryRun) {
+      console.log([bin, ...args].map(quote).join(" "));
+      continue;
+    }
+    execFileSync(bin, args, { stdio: "inherit" });
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.github/scripts/ensure-labels.test.mjs
+++ b/.github/scripts/ensure-labels.test.mjs
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { LABELS, renderCommand } from "./ensure-labels.mjs";
+
+test("label names are unique and cover the governance set", () => {
+  const names = LABELS.map((label) => label.name);
+  assert.equal(new Set(names).size, names.length);
+  assert.deepEqual(names.slice().sort(), [
+    "accepted",
+    "awaiting-author",
+    "generated-artifacts",
+    "needs-repro",
+    "not-now",
+    "primary-implementation",
+    "stale",
+  ]);
+});
+
+test("colors are 6-digit hex without a leading hash", () => {
+  for (const label of LABELS) {
+    assert.match(label.color, /^[0-9A-Fa-f]{6}$/, label.name);
+  }
+});
+
+test("descriptions are non-empty single sentences", () => {
+  for (const label of LABELS) {
+    assert.ok(label.description.trim().length > 0, label.name);
+    assert.ok(label.description.length <= 100, `${label.name}: GitHub caps descriptions at 100 chars`);
+  }
+});
+
+test("renderCommand produces the gh label create argv", () => {
+  const label = LABELS.find((entry) => entry.name === "awaiting-author");
+  assert.deepEqual(renderCommand(label), [
+    "gh",
+    "label",
+    "create",
+    "awaiting-author",
+    "--color",
+    label.color,
+    "--description",
+    label.description,
+    "--force",
+  ]);
+});

--- a/.github/scripts/generated-artifacts-report.mjs
+++ b/.github/scripts/generated-artifacts-report.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Phase 1 generated-artifacts report (docs/maintenance-roadmap.md).
+//
+// Compares the committed generated site against a rebuild from the same
+// source and renders a markdown summary. Informational only: this script
+// always exits 0 when it can read its inputs; the zip-freshness job in
+// ci.yml keeps the blocking ZIP contract.
+//
+// Usage:
+//   node .github/scripts/generated-artifacts-report.mjs \
+//     --committed docs --rebuilt "$RUNNER_TEMP/docs-rebuilt" \
+//     --owned gallery,gallery.html,guide.html,start.html \
+//     --zip identical|differs|unavailable \
+//     [--skipped "$RUNNER_TEMP/skipped.tsv"]
+//
+// --owned lists the paths (files or directories, relative to both roots)
+// that the site builders write. Only those are compared, so hand-maintained
+// pages under docs/ never count as "identical". --skipped points at a
+// tab-separated file with one `builder<TAB>reason` line per skipped builder.
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const MAX_LISTED_PATHS = 30;
+
+const ZIP_LINES = Object.freeze({
+  identical: 'archify.zip: identical to rebuild',
+  differs: 'archify.zip: differs from rebuild (zip-freshness is the blocking check)',
+  unavailable: 'archify.zip: rebuild unavailable (see the build step log)',
+});
+
+// committed / rebuilt: { [relativePath]: sha256 }. Returns sorted entries with
+// null for the side where the file is absent.
+export function compareTrees(committed, rebuilt) {
+  const paths = new Set([...Object.keys(committed), ...Object.keys(rebuilt)]);
+  return [...paths].sort().map((file) => ({
+    path: file,
+    committed: committed[file] ?? null,
+    rebuilt: rebuilt[file] ?? null,
+  }));
+}
+
+export function fileStatus(entry) {
+  if (entry.committed === null) return 'only in rebuild';
+  if (entry.rebuilt === null) return 'only in checkout';
+  return entry.committed === entry.rebuilt ? 'identical' : 'differs';
+}
+
+export function parseSkipped(text) {
+  return String(text ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [builder, ...rest] = line.split('\t');
+      return { builder: builder.trim(), reason: rest.join('\t').trim() || 'no reason recorded' };
+    });
+}
+
+// model: { zip: 'identical'|'differs'|'unavailable', files: compareTrees(...), skipped: [{ builder, reason }] }
+export function renderReport(model) {
+  const files = model.files ?? [];
+  const counts = { identical: 0, differs: 0, 'only in rebuild': 0, 'only in checkout': 0 };
+  const listed = [];
+  for (const entry of files) {
+    const status = fileStatus(entry);
+    counts[status] += 1;
+    if (status !== 'identical') listed.push(`- ${status}: \`${entry.path}\``);
+  }
+
+  const lines = [
+    '## Generated artifacts (Phase 1: informational)',
+    '',
+    'This job never blocks a pull request. It rebuilds the generated site and package from this source and reports whether the committed outputs match; the rebuilt outputs are attached as workflow artifacts.',
+    '',
+    `- ${ZIP_LINES[model.zip] ?? ZIP_LINES.unavailable}`,
+    `- Generated site: ${counts.identical} files identical, ${counts.differs} differ, ${counts['only in rebuild']} only in rebuild, ${counts['only in checkout']} only in checkout`,
+  ];
+  if (listed.length > 0) {
+    lines.push('', ...listed.slice(0, MAX_LISTED_PATHS));
+    if (listed.length > MAX_LISTED_PATHS) lines.push(`- … and ${listed.length - MAX_LISTED_PATHS} more`);
+  }
+
+  const skipped = model.skipped ?? [];
+  lines.push('', skipped.length === 0
+    ? 'Skipped: none'
+    : `Skipped: ${skipped.map((item) => `${item.builder} (${item.reason})`).join('; ')}`);
+
+  lines.push('', 'Contributors may stop committing rebuilt Gallery once Phase 2 in docs/maintenance-roadmap.md is complete; until then CONTRIBUTING.md#packages-and-generated-artifacts applies.', '');
+  return lines.join('\n');
+}
+
+// IO shell -------------------------------------------------------------------
+
+function sha256(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function hashOwned(root, owned) {
+  const hashes = {};
+  const visit = (absolute) => {
+    let stat;
+    try {
+      stat = fs.statSync(absolute);
+    } catch {
+      return;
+    }
+    if (stat.isDirectory()) {
+      for (const child of fs.readdirSync(absolute)) visit(path.join(absolute, child));
+    } else if (stat.isFile()) {
+      hashes[path.relative(root, absolute).split(path.sep).join('/')] = sha256(absolute);
+    }
+  };
+  for (const item of owned) visit(path.join(root, item));
+  return hashes;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (!argv[i].startsWith('--')) throw new Error(`unexpected argument ${argv[i]}`);
+    args[argv[i].slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  for (const required of ['committed', 'rebuilt', 'owned', 'zip']) {
+    if (!args[required]) throw new Error(`--${required} is required`);
+  }
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  const owned = args.owned.split(',').map((item) => item.trim()).filter(Boolean);
+  const skippedText = args.skipped && fs.existsSync(args.skipped) ? fs.readFileSync(args.skipped, 'utf8') : '';
+  const report = renderReport({
+    zip: args.zip,
+    files: compareTrees(hashOwned(args.committed, owned), hashOwned(args.rebuilt, owned)),
+    skipped: parseSkipped(skippedText),
+  });
+  if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
+  process.stdout.write(report);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2));
+}

--- a/.github/scripts/generated-artifacts-report.test.mjs
+++ b/.github/scripts/generated-artifacts-report.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  MAX_LISTED_PATHS,
+  compareTrees,
+  fileStatus,
+  parseSkipped,
+  renderReport,
+} from './generated-artifacts-report.mjs';
+
+test('compareTrees pairs paths from both sides, sorted, with null for missing files', () => {
+  const entries = compareTrees(
+    { 'gallery.html': 'aaa', 'gallery/manifest.json': 'bbb', 'gallery/artifacts/old.html': 'ccc' },
+    { 'gallery.html': 'aaa', 'gallery/manifest.json': 'bbb2', 'gallery/artifacts/new.html': 'ddd' },
+  );
+  assert.deepEqual(entries, [
+    { path: 'gallery.html', committed: 'aaa', rebuilt: 'aaa' },
+    { path: 'gallery/artifacts/new.html', committed: null, rebuilt: 'ddd' },
+    { path: 'gallery/artifacts/old.html', committed: 'ccc', rebuilt: null },
+    { path: 'gallery/manifest.json', committed: 'bbb', rebuilt: 'bbb2' },
+  ]);
+  assert.deepEqual(entries.map(fileStatus), ['identical', 'only in rebuild', 'only in checkout', 'differs']);
+});
+
+test('parseSkipped reads tab-separated builder/reason lines and tolerates blanks', () => {
+  assert.deepEqual(parseSkipped('build-readme-showcase.mjs\tneeds Chrome\n\nbuild-x.mjs\n'), [
+    { builder: 'build-readme-showcase.mjs', reason: 'needs Chrome' },
+    { builder: 'build-x.mjs', reason: 'no reason recorded' },
+  ]);
+  assert.deepEqual(parseSkipped(''), []);
+  assert.deepEqual(parseSkipped(undefined), []);
+});
+
+test('renderReport states the non-blocking contract, counts, zip status, skips, and closing line', () => {
+  const report = renderReport({
+    zip: 'differs',
+    files: compareTrees(
+      { 'gallery.html': 'a', 'guide.html': 'g', 'gallery/artifacts/old.html': 'o' },
+      { 'gallery.html': 'a2', 'guide.html': 'g', 'gallery/artifacts/new.html': 'n' },
+    ),
+    skipped: [{ builder: 'build-readme-showcase.mjs', reason: 'needs Chrome and ffmpeg' }],
+  });
+  const lines = report.split('\n');
+  assert.equal(lines[0], '## Generated artifacts (Phase 1: informational)');
+  assert.match(report, /never blocks a pull request/);
+  assert.ok(report.includes('- archify.zip: differs from rebuild (zip-freshness is the blocking check)'));
+  assert.ok(report.includes('- Generated site: 1 files identical, 1 differ, 1 only in rebuild, 1 only in checkout'));
+  assert.ok(report.includes('- differs: `gallery.html`'));
+  assert.ok(report.includes('- only in rebuild: `gallery/artifacts/new.html`'));
+  assert.ok(report.includes('- only in checkout: `gallery/artifacts/old.html`'));
+  assert.ok(!report.includes('`guide.html`'), 'identical files are not listed');
+  assert.ok(report.includes('Skipped: build-readme-showcase.mjs (needs Chrome and ffmpeg)'));
+  assert.ok(report.endsWith('Contributors may stop committing rebuilt Gallery once Phase 2 in docs/maintenance-roadmap.md is complete; until then CONTRIBUTING.md#packages-and-generated-artifacts applies.\n'));
+});
+
+test('renderReport handles the all-identical case and an unknown zip status', () => {
+  const report = renderReport({
+    zip: 'unavailable',
+    files: compareTrees({ 'gallery.html': 'a' }, { 'gallery.html': 'a' }),
+    skipped: [],
+  });
+  assert.ok(report.includes('- archify.zip: rebuild unavailable (see the build step log)'));
+  assert.ok(report.includes('- Generated site: 1 files identical, 0 differ, 0 only in rebuild, 0 only in checkout'));
+  assert.ok(report.includes('\nSkipped: none\n'));
+  assert.ok(renderReport({ zip: 'identical', files: [], skipped: [] }).includes('- archify.zip: identical to rebuild'));
+  assert.ok(renderReport({ zip: 'bogus', files: [] }).includes('rebuild unavailable'));
+});
+
+test('renderReport caps the listed paths and reports the remainder', () => {
+  const committed = {};
+  const rebuilt = {};
+  for (let i = 0; i < MAX_LISTED_PATHS + 5; i += 1) {
+    committed[`gallery/artifacts/${String(i).padStart(3, '0')}.html`] = 'x';
+    rebuilt[`gallery/artifacts/${String(i).padStart(3, '0')}.html`] = 'y';
+  }
+  const report = renderReport({ zip: 'identical', files: compareTrees(committed, rebuilt), skipped: [] });
+  const listed = report.split('\n').filter((line) => line.startsWith('- differs: '));
+  assert.equal(listed.length, MAX_LISTED_PATHS);
+  assert.ok(report.includes('- … and 5 more'));
+});

--- a/.github/scripts/pr-triage-card.mjs
+++ b/.github/scripts/pr-triage-card.mjs
@@ -1,0 +1,466 @@
+// PR triage card: an advisory evidence index for reviewers plus review-state
+// label maintenance. Pure functions are exported for tests; the IO shell at
+// the bottom only reads the event payload, calls the GitHub REST API, and
+// upserts one comment. It never executes PR-supplied code.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const CARD_MARKER = '<!-- archify-triage-card -->';
+export const GENERATED_CLASSES = new Set(['generated-site', 'package', 'golden-examples', 'generated-source']);
+export const LABEL_CLASSES = new Set(['generated-site', 'package', 'golden-examples']);
+export const CLASS_ORDER = ['source', 'tests', 'docs', 'governance', 'generated-source', 'golden-examples', 'generated-site', 'package'];
+export const TEMPLATE_HEADINGS = [
+  'Problem and value',
+  'Stability impact',
+  'Tests run',
+  'Visual evidence',
+  'Generated artifacts',
+];
+const MAX_LINKED_ISSUES = 5;
+const MAX_FILES = 300;
+const MAX_LISTED_PATHS = 15;
+const MAX_TITLE = 100;
+
+// --- Path classification (mirrors the table in the governance brief) --------
+
+export function classifyPath(path) {
+  const p = String(path).replace(/^\.\//, '');
+  if (
+    p.startsWith('docs/gallery/') ||
+    p.startsWith('docs/assets/') ||
+    /^docs\/(gallery|guide|start|index)\.html$/.test(p) ||
+    /^docs\/cases\/[^/]+\.html$/.test(p)
+  ) return 'generated-site';
+  if (p === 'archify.zip') return 'package';
+  if (/^(archify\/)?examples\/[^/]+\.html$/.test(p)) return 'golden-examples';
+  if (/^archify\/renderers\/shared\/generated-[^/]+\.mjs$/.test(p)) return 'generated-source';
+  if (p.startsWith('archify/test/') || p.startsWith('benchmarks/')) return 'tests';
+  if (
+    p.startsWith('.github/') ||
+    ['CONTRIBUTING.md', 'REVIEWING.md', 'SECURITY.md', '.coderabbit.yaml'].includes(p)
+  ) return 'governance';
+  if (p.endsWith('.md') || p.startsWith('docs/')) return 'docs';
+  return 'source';
+}
+
+export function summarizeFiles(files, totals = {}) {
+  const byClass = Object.fromEntries(CLASS_ORDER.map((c) => [c, []]));
+  let generatedAdditions = 0;
+  let generatedDeletions = 0;
+  let sumAdditions = 0;
+  let sumDeletions = 0;
+  for (const file of files) {
+    const cls = classifyPath(file.filename);
+    byClass[cls].push(file.filename);
+    const add = Number(file.additions) || 0;
+    const del = Number(file.deletions) || 0;
+    sumAdditions += add;
+    sumDeletions += del;
+    if (GENERATED_CLASSES.has(cls)) {
+      generatedAdditions += add;
+      generatedDeletions += del;
+    }
+  }
+  const additions = Number.isFinite(totals.additions) ? totals.additions : sumAdditions;
+  const deletions = Number.isFinite(totals.deletions) ? totals.deletions : sumDeletions;
+  return {
+    byClass,
+    counts: Object.fromEntries(CLASS_ORDER.map((c) => [c, byClass[c].length])),
+    additions,
+    deletions,
+    additionsExcludingGenerated: Math.max(0, additions - generatedAdditions),
+    deletionsExcludingGenerated: Math.max(0, deletions - generatedDeletions),
+    hasLabelClass: [...LABEL_CLASSES].some((c) => byClass[c].length > 0),
+  };
+}
+
+// --- Linked issues ----------------------------------------------------------
+
+export function stripCodeAndUrls(text) {
+  return String(text ?? '')
+    .replace(/```[\s\S]*?(```|$)/g, ' ')
+    .replace(/`[^`\n]*`/g, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/\bhttps?:\/\/\S+/gi, ' ');
+}
+
+const CLOSING_RE = /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\b:?\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+const REF_RE = /(?<![\w/&])#(\d+)\b/g;
+
+export function extractLinkedIssues(title, body) {
+  const cleanTitle = stripCodeAndUrls(title);
+  const cleanBody = stripCodeAndUrls(body);
+  const ordered = [];
+  const seen = new Set();
+  const push = (n) => {
+    const num = Number(n);
+    if (num > 0 && !seen.has(num)) {
+      seen.add(num);
+      ordered.push(num);
+    }
+  };
+  for (const text of [cleanTitle, cleanBody]) {
+    for (const m of text.matchAll(CLOSING_RE)) push(m[1]);
+  }
+  for (const m of cleanTitle.matchAll(/\(#(\d+)\)/g)) push(m[1]);
+  for (const text of [cleanTitle, cleanBody]) {
+    for (const m of text.matchAll(REF_RE)) push(m[1]);
+  }
+  return ordered;
+}
+
+export function referencesIssue(text, number) {
+  const clean = stripCodeAndUrls(text);
+  const re = new RegExp(`(?<![\\w/&])#${Number(number)}\\b`);
+  return re.test(clean);
+}
+
+// --- PR template sections ---------------------------------------------------
+
+function splitSections(markdown) {
+  const sections = new Map();
+  const text = String(markdown ?? '').replace(/\r\n/g, '\n');
+  const headingRe = /^##\s+(.+?)\s*$/gm;
+  const found = [...text.matchAll(headingRe)];
+  for (let i = 0; i < found.length; i += 1) {
+    const name = found[i][1].trim();
+    const start = found[i].index + found[i][0].length;
+    const end = i + 1 < found.length ? found[i + 1].index : text.length;
+    if (!sections.has(name)) sections.set(name, text.slice(start, end));
+  }
+  return sections;
+}
+
+function contentLines(section) {
+  return String(section ?? '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+// Returns null when none of the template headings appear in the body;
+// otherwise an array of { name, present, filled } for each template heading.
+export function detectTemplateSections(body, templateText = '') {
+  const bodySections = splitSections(body);
+  const templateSections = splitSections(templateText);
+  const present = TEMPLATE_HEADINGS.filter((h) => bodySections.has(h));
+  if (present.length === 0) return null;
+  const placeholders = new Set();
+  for (const section of templateSections.values()) {
+    for (const line of contentLines(section)) placeholders.add(line);
+  }
+  return TEMPLATE_HEADINGS.map((name) => {
+    if (!bodySections.has(name)) return { name, present: false, filled: false };
+    const lines = contentLines(bodySections.get(name)).filter((line) => !placeholders.has(line));
+    return { name, present: true, filled: lines.length > 0 };
+  });
+}
+
+// --- Comment lookup ---------------------------------------------------------
+
+export function findCardComment(comments) {
+  return (comments ?? []).find((c) => typeof c?.body === 'string' && c.body.includes(CARD_MARKER)) ?? null;
+}
+
+// --- Rendering --------------------------------------------------------------
+
+export function escapeInline(value, max = MAX_TITLE) {
+  let text = String(value ?? '').replace(/\s+/g, ' ').trim();
+  if (text.length > max) text = `${text.slice(0, max - 1)}…`;
+  return text.replace(/</g, '&lt;').replace(/^#/, '\\#');
+}
+
+export function shortSha(sha) {
+  return String(sha ?? '').slice(0, 7) || 'unknown';
+}
+
+function code(path) {
+  return `\`${String(path).replace(/`/g, '')}\``;
+}
+
+function listPaths(paths) {
+  const shown = paths.slice(0, MAX_LISTED_PATHS).map(code).join(', ');
+  const rest = paths.length - MAX_LISTED_PATHS;
+  return rest > 0 ? `${shown} … +${rest} more` : shown;
+}
+
+export function renderCard(model) {
+  const {
+    headSha,
+    draft,
+    files,
+    linkedIssues = [],
+    linkedIssuesTruncated = 0,
+    overlaps = [],
+    overlapError = false,
+    templateSections = null,
+    filesTruncated = false,
+    notes = [],
+  } = model;
+  const lines = [CARD_MARKER, '### Triage card'];
+  lines.push(
+    `Head \`${shortSha(headSha)}\` · ${draft ? 'draft' : 'ready'} · ` +
+      `+${files.additions}/−${files.deletions} total, ` +
+      `+${files.additionsExcludingGenerated}/−${files.deletionsExcludingGenerated} excluding generated paths`,
+  );
+
+  lines.push('', '**Linked issues**');
+  if (linkedIssues.length === 0) {
+    lines.push(
+      'No linked issue. Narrow fixes may proceed on their reproduction; contract-level changes need a linked issue or a recorded maintainer decision (CONTRIBUTING.md#choose-the-right-path).',
+    );
+  } else {
+    for (const issue of linkedIssues) {
+      if (issue.error) {
+        lines.push(`- #${issue.number} — not fetched (${escapeInline(issue.error, 60)})`);
+        continue;
+      }
+      const labels = (issue.labels ?? []).map((l) => escapeInline(l, 40));
+      const accepted = labels.includes('accepted') ? 'carries `accepted`' : 'no `accepted` label';
+      lines.push(
+        `- #${issue.number} ${escapeInline(issue.title)} — labels: ${labels.length ? labels.join(', ') : 'none'} — ${accepted}`,
+      );
+    }
+    if (linkedIssuesTruncated > 0) lines.push(`- … +${linkedIssuesTruncated} more referenced issues not fetched`);
+  }
+
+  lines.push('', '**Overlapping open PRs**');
+  if (overlapError) {
+    lines.push('Overlap check unavailable (search API error)');
+  } else if (linkedIssues.length === 0 || overlaps.length === 0) {
+    lines.push('No other open PR references these issues.');
+  } else {
+    for (const pr of overlaps) {
+      const primary = pr.primary ? ' — carries `primary-implementation`' : '';
+      lines.push(`- #${pr.number} ${escapeInline(pr.title)} (references #${pr.issues.join(', #')})${primary}`);
+    }
+  }
+
+  lines.push('', '**Changed paths by class**');
+  lines.push(CLASS_ORDER.map((c) => `${c} ${files.counts[c]}`).join(' · ') + (filesTruncated ? ` · only the first ${MAX_FILES} files were classified` : ''));
+  for (const cls of ['generated-site', 'package', 'golden-examples', 'generated-source']) {
+    const paths = files.byClass[cls];
+    if (paths.length > 0) lines.push(`- ${cls} (${paths.length}): ${listPaths(paths)}`);
+  }
+  if (files.byClass['golden-examples'].length > 0) {
+    lines.push('Each changed golden must be explained by the behavior change that produced it (CONTRIBUTING.md#packages-and-generated-artifacts).');
+  }
+
+  lines.push('');
+  if (templateSections === null) {
+    lines.push('PR template not used.');
+  } else {
+    const parts = templateSections.map((s) => {
+      if (!s.present) return `${s.name} — missing`;
+      return s.filled ? `${s.name} ✓` : `${s.name} — empty`;
+    });
+    lines.push(`Template sections: ${parts.join(' · ')}`);
+  }
+
+  if (notes.length > 0) {
+    lines.push('', `Notes: ${notes.map((n) => escapeInline(n, 160)).join('; ')}`);
+  }
+
+  lines.push('', 'Advisory index for reviewers; it makes no acceptance decision. See REVIEWING.md and .github/CURRENT_FOCUS.md.');
+  return lines.join('\n');
+}
+
+// --- IO shell ---------------------------------------------------------------
+
+const API = 'https://api.github.com';
+
+export function createGhFetch({ token, fetchImpl = globalThis.fetch, sleep = (ms) => new Promise((r) => setTimeout(r, ms)) }) {
+  return async function ghFetch(path, init = {}) {
+    const url = path.startsWith('http') ? path : `${API}${path}`;
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'archify-pr-triage-card',
+      ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init.headers ?? {}),
+    };
+    let response = await fetchImpl(url, { ...init, headers });
+    if (response.status >= 500) {
+      await sleep(1500);
+      response = await fetchImpl(url, { ...init, headers });
+    }
+    const allow = init.allow ?? [];
+    if (!response.ok && !allow.includes(response.status)) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`${init.method ?? 'GET'} ${path} → ${response.status} ${text.replace(/\s+/g, ' ').slice(0, 200)}`);
+    }
+    let json = null;
+    if (response.status !== 204) {
+      const text = await response.text();
+      json = text ? JSON.parse(text) : null;
+    }
+    return { status: response.status, headers: response.headers, json };
+  };
+}
+
+export async function paginate(ghFetch, path, { maxPages = 10 } = {}) {
+  const results = [];
+  const sep = path.includes('?') ? '&' : '?';
+  for (let page = 1; page <= maxPages; page += 1) {
+    const { json, headers } = await ghFetch(`${path}${sep}per_page=100&page=${page}`);
+    const items = Array.isArray(json) ? json : [];
+    results.push(...items);
+    const link = headers?.get?.('link') ?? '';
+    if (items.length < 100 || !/rel="next"/.test(link)) break;
+  }
+  return results;
+}
+
+function readEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set');
+  const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+  const number = event?.pull_request?.number;
+  if (!Number.isInteger(number)) throw new Error('event payload has no pull_request.number');
+  return event;
+}
+
+function hasWriteAccess(permissionPayload) {
+  const permission = permissionPayload?.permission;
+  const role = permissionPayload?.role_name;
+  return ['admin', 'write', 'maintain'].includes(permission) || ['admin', 'write', 'maintain'].includes(role);
+}
+
+async function main() {
+  const event = readEvent();
+  const eventName = process.env.GITHUB_EVENT_NAME ?? '';
+  const repo = process.env.GITHUB_REPOSITORY ?? event?.repository?.full_name;
+  if (!repo) throw new Error('GITHUB_REPOSITORY is not set');
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is not set');
+  const ghFetch = createGhFetch({ token });
+  const number = event.pull_request.number;
+  const base = `/repos/${repo}`;
+  const notes = [];
+
+  let pr = event.pull_request;
+  if (eventName === 'pull_request_review' || !Number.isFinite(pr?.additions)) {
+    ({ json: pr } = await ghFetch(`${base}/pulls/${number}`));
+  }
+  const labelNames = new Set((pr.labels ?? []).map((l) => l.name));
+
+  async function addLabel(name) {
+    if (labelNames.has(name)) return;
+    await ghFetch(`${base}/issues/${number}/labels`, { method: 'POST', body: JSON.stringify({ labels: [name] }) });
+    labelNames.add(name);
+  }
+  async function removeLabel(name) {
+    if (!labelNames.has(name)) return;
+    await ghFetch(`${base}/issues/${number}/labels/${encodeURIComponent(name)}`, { method: 'DELETE', allow: [404] });
+    labelNames.delete(name);
+  }
+
+  // 1. Review-state labels.
+  try {
+    if (eventName === 'pull_request_review' && event.review?.state === 'changes_requested') {
+      const reviewer = event.review?.user?.login;
+      const { json } = await ghFetch(`${base}/collaborators/${encodeURIComponent(reviewer)}/permission`);
+      if (hasWriteAccess(json)) await addLabel('awaiting-author');
+    } else if (eventName === 'pull_request_target' && event.action === 'synchronize') {
+      await removeLabel('awaiting-author');
+    }
+  } catch (error) {
+    notes.push(`awaiting-author label not updated (${error.message})`);
+  }
+
+  // 2. Changed files.
+  let rawFiles = [];
+  let filesTruncated = false;
+  try {
+    rawFiles = await paginate(ghFetch, `${base}/pulls/${number}/files`, { maxPages: MAX_FILES / 100 });
+    filesTruncated = (pr.changed_files ?? rawFiles.length) > rawFiles.length;
+  } catch (error) {
+    notes.push(`changed files not listed (${error.message})`);
+  }
+  const files = summarizeFiles(rawFiles, { additions: pr.additions, deletions: pr.deletions });
+
+  try {
+    if (files.hasLabelClass) await addLabel('generated-artifacts');
+    else await removeLabel('generated-artifacts');
+  } catch (error) {
+    notes.push(`generated-artifacts label not synced (${error.message})`);
+  }
+
+  // 3. Linked issues and overlapping PRs.
+  const allLinked = extractLinkedIssues(pr.title, pr.body).filter((n) => n !== number);
+  const linkedNumbers = allLinked.slice(0, MAX_LINKED_ISSUES);
+  const linkedIssues = [];
+  for (const n of linkedNumbers) {
+    try {
+      const { json } = await ghFetch(`${base}/issues/${n}`);
+      if (json?.pull_request) {
+        linkedIssues.push({ number: n, error: 'is a pull request, not an issue' });
+        continue;
+      }
+      linkedIssues.push({ number: n, title: json.title, labels: (json.labels ?? []).map((l) => l.name) });
+    } catch (error) {
+      linkedIssues.push({ number: n, error: error.message });
+    }
+  }
+
+  const overlaps = new Map();
+  let overlapError = false;
+  for (const issue of linkedIssues) {
+    if (issue.error) continue;
+    try {
+      const q = encodeURIComponent(`repo:${repo} is:pr is:open ${issue.number}`);
+      const { json } = await ghFetch(`/search/issues?q=${q}&per_page=50`);
+      for (const item of json?.items ?? []) {
+        if (item.number === number) continue;
+        if (!referencesIssue(`${item.title}\n${item.body ?? ''}`, issue.number)) continue;
+        const entry = overlaps.get(item.number) ?? {
+          number: item.number,
+          title: item.title,
+          primary: (item.labels ?? []).some((l) => l.name === 'primary-implementation'),
+          issues: [],
+        };
+        entry.issues.push(issue.number);
+        overlaps.set(item.number, entry);
+      }
+    } catch {
+      overlapError = true;
+    }
+  }
+
+  // 4. Template sections.
+  const templatePath = '.github/PULL_REQUEST_TEMPLATE.md';
+  const templateText = existsSync(templatePath) ? readFileSync(templatePath, 'utf8') : '';
+  const templateSections = detectTemplateSections(pr.body, templateText);
+
+  // 5. Upsert the card.
+  const body = renderCard({
+    headSha: pr.head?.sha,
+    draft: Boolean(pr.draft),
+    files,
+    filesTruncated,
+    linkedIssues,
+    linkedIssuesTruncated: Math.max(0, allLinked.length - linkedNumbers.length),
+    overlaps: [...overlaps.values()],
+    overlapError,
+    templateSections,
+    notes,
+  });
+  const comments = await paginate(ghFetch, `${base}/issues/${number}/comments`);
+  const existing = findCardComment(comments);
+  if (existing) {
+    await ghFetch(`${base}/issues/comments/${existing.id}`, { method: 'PATCH', body: JSON.stringify({ body }) });
+  } else {
+    await ghFetch(`${base}/issues/${number}/comments`, { method: 'POST', body: JSON.stringify({ body }) });
+  }
+  console.log(`pr-triage-card: ${existing ? 'updated' : 'created'} card on #${number}${notes.length ? ` with ${notes.length} note(s)` : ''}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`pr-triage-card: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/pr-triage-card.test.mjs
+++ b/.github/scripts/pr-triage-card.test.mjs
@@ -1,0 +1,307 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import {
+  CARD_MARKER,
+  classifyPath,
+  createGhFetch,
+  detectTemplateSections,
+  escapeInline,
+  extractLinkedIssues,
+  findCardComment,
+  paginate,
+  referencesIssue,
+  renderCard,
+  summarizeFiles,
+} from './pr-triage-card.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE = readFileSync(path.join(here, '..', 'PULL_REQUEST_TEMPLATE.md'), 'utf8');
+
+test('classifyPath follows the governance classification table', () => {
+  const cases = {
+    'docs/assets/x.png': 'generated-site',
+    'docs/gallery/foo/index.html': 'generated-site',
+    'docs/gallery.html': 'generated-site',
+    'docs/guide.html': 'generated-site',
+    'docs/start.html': 'generated-site',
+    'docs/index.html': 'generated-site',
+    'docs/cases/one.html': 'generated-site',
+    'docs/cases/nested/one.html': 'docs',
+    'docs/foo.md': 'docs',
+    'docs/research/report.json': 'docs',
+    'archify.zip': 'package',
+    'archify/examples/web-app.html': 'golden-examples',
+    'examples/web-app.html': 'golden-examples',
+    'archify/examples/nested/web-app.html': 'source',
+    'archify/renderers/shared/generated-validators.mjs': 'generated-source',
+    'archify/renderers/shared/validator.mjs': 'source',
+    'archify/test/x.test.mjs': 'tests',
+    'benchmarks/run.mjs': 'tests',
+    '.github/workflows/ci.yml': 'governance',
+    '.github/CURRENT_FOCUS.md': 'governance',
+    'CONTRIBUTING.md': 'governance',
+    'REVIEWING.md': 'governance',
+    'SECURITY.md': 'governance',
+    '.coderabbit.yaml': 'governance',
+    'README.md': 'docs',
+    'archify/README.md': 'docs',
+    'archify/cli.mjs': 'source',
+    'scripts/build-zip.sh': 'source',
+  };
+  for (const [file, expected] of Object.entries(cases)) {
+    assert.equal(classifyPath(file), expected, file);
+  }
+});
+
+test('summarizeFiles counts per class and subtracts generated churn', () => {
+  const files = [
+    { filename: 'archify/cli.mjs', additions: 10, deletions: 2 },
+    { filename: 'archify/test/cli.test.mjs', additions: 5, deletions: 0 },
+    { filename: 'docs/gallery/a.html', additions: 100, deletions: 50 },
+    { filename: 'archify.zip', additions: 0, deletions: 0 },
+    { filename: 'archify/examples/web-app.html', additions: 7, deletions: 7 },
+    { filename: 'archify/renderers/shared/generated-validators.mjs', additions: 3, deletions: 1 },
+  ];
+  const summary = summarizeFiles(files);
+  assert.equal(summary.counts.source, 1);
+  assert.equal(summary.counts.tests, 1);
+  assert.equal(summary.counts['generated-site'], 1);
+  assert.equal(summary.counts.package, 1);
+  assert.equal(summary.counts['golden-examples'], 1);
+  assert.equal(summary.counts['generated-source'], 1);
+  assert.equal(summary.additions, 125);
+  assert.equal(summary.deletions, 60);
+  assert.equal(summary.additionsExcludingGenerated, 15);
+  assert.equal(summary.deletionsExcludingGenerated, 2);
+  assert.equal(summary.hasLabelClass, true);
+
+  const withTotals = summarizeFiles(files.slice(0, 1), { additions: 500, deletions: 400 });
+  assert.equal(withTotals.additions, 500);
+  assert.equal(withTotals.additionsExcludingGenerated, 500);
+  assert.equal(withTotals.hasLabelClass, false);
+
+  const sourceOnly = summarizeFiles([{ filename: 'archify/renderers/shared/generated-x.mjs', additions: 1, deletions: 1 }]);
+  assert.equal(sourceOnly.hasLabelClass, false, 'generated-source alone does not trigger the label');
+});
+
+test('extractLinkedIssues prioritises closing keywords and dedupes', () => {
+  const linked = extractLinkedIssues(
+    'Tighten validator (#12)',
+    'Fixes #7 and closes #12. Related to #99 and tt-a1i/archify#7.\nResolves: #8',
+  );
+  assert.deepEqual(linked, [7, 12, 8, 99]);
+});
+
+test('extractLinkedIssues ignores code fences, inline code, comments and URLs', () => {
+  const body = [
+    'See https://github.com/tt-a1i/archify/pull/12 and https://example.com/#55',
+    '```',
+    'fixes #31',
+    '```',
+    'Inline `#32` is code. <!-- fixes #33 -->',
+    'Real: #34',
+  ].join('\n');
+  assert.deepEqual(extractLinkedIssues('No refs here', body), [34]);
+  assert.deepEqual(extractLinkedIssues('', 'issue#41 is not a ref, but #42 is'), [42]);
+  assert.deepEqual(extractLinkedIssues('', 'nothing'), []);
+  assert.deepEqual(extractLinkedIssues(null, undefined), []);
+});
+
+test('referencesIssue matches the exact number only', () => {
+  assert.equal(referencesIssue('Follow-up for #12', 12), true);
+  assert.equal(referencesIssue('Follow-up for #120', 12), false);
+  assert.equal(referencesIssue('Follow-up for #1', 12), false);
+  assert.equal(referencesIssue('see https://x.test/#12', 12), false);
+  assert.equal(referencesIssue('`#12`', 12), false);
+});
+
+test('detectTemplateSections distinguishes filled, empty and missing sections', () => {
+  const body = [
+    '## Problem and value',
+    '',
+    'Current-main trigger or rationale, intended outcome, approach, and linked issue/agreed scope:',
+    'Fixes the layout drift described in #12.',
+    '',
+    '## Stability impact',
+    '',
+    '- Impact class and changed behavior/shared callers: <!-- CONTRIBUTING.md#choose-evidence-by-impact -->',
+    '- Existing behavior preserved / intended compatibility changes / failure behavior:',
+    '- No unrelated changes: <!-- confirm or explain -->',
+    '',
+    '## Tests run',
+    '',
+    '<!-- I will fill this in later -->',
+    '',
+    '## Visual evidence',
+    '',
+    'Not applicable: CLI-only change.',
+    '',
+  ].join('\n');
+  const sections = detectTemplateSections(body, TEMPLATE);
+  assert.deepEqual(sections, [
+    { name: 'Problem and value', present: true, filled: true },
+    { name: 'Stability impact', present: true, filled: false },
+    { name: 'Tests run', present: true, filled: false },
+    { name: 'Visual evidence', present: true, filled: true },
+    { name: 'Generated artifacts', present: false, filled: false },
+  ]);
+});
+
+test('detectTemplateSections treats an untouched template as all empty', () => {
+  const sections = detectTemplateSections(TEMPLATE, TEMPLATE);
+  assert.ok(sections.every((s) => s.present && !s.filled));
+});
+
+test('detectTemplateSections returns null when the template is not used', () => {
+  assert.equal(detectTemplateSections('Just a sentence.', TEMPLATE), null);
+  assert.equal(detectTemplateSections('', TEMPLATE), null);
+  assert.equal(detectTemplateSections(null, TEMPLATE), null);
+  assert.equal(detectTemplateSections('## Unrelated heading\ntext', TEMPLATE), null);
+});
+
+test('findCardComment locates the marker among other comments', () => {
+  const comments = [
+    { id: 1, body: 'Looks good.' },
+    { id: 2, body: null },
+    { id: 3, body: `${CARD_MARKER}\n### Triage card` },
+    { id: 4, body: `${CARD_MARKER}\nold duplicate` },
+  ];
+  assert.equal(findCardComment(comments).id, 3);
+  assert.equal(findCardComment([{ id: 9, body: 'no marker' }]), null);
+  assert.equal(findCardComment([]), null);
+  assert.equal(findCardComment(undefined), null);
+});
+
+test('escapeInline truncates and neutralises heading injection', () => {
+  const long = 'x'.repeat(150);
+  assert.equal(escapeInline(long).length, 100);
+  assert.ok(escapeInline(long).endsWith('…'));
+  assert.equal(escapeInline('# fake heading\n## another'), '\\# fake heading ## another');
+  assert.equal(escapeInline('<!-- marker -->'), '&lt;!-- marker -->');
+});
+
+function baseModel(overrides = {}) {
+  return {
+    headSha: 'abcdef1234567890',
+    draft: false,
+    files: summarizeFiles([{ filename: 'archify/cli.mjs', additions: 3, deletions: 1 }]),
+    linkedIssues: [],
+    overlaps: [],
+    overlapError: false,
+    templateSections: null,
+    notes: [],
+    ...overrides,
+  };
+}
+
+test('renderCard with no linked issue and no template', () => {
+  const card = renderCard(baseModel());
+  assert.ok(card.startsWith(CARD_MARKER));
+  assert.match(card, /^### Triage card$/m);
+  assert.match(card, /Head `abcdef1` · ready · \+3\/−1 total, \+3\/−1 excluding generated paths/);
+  assert.match(card, /No linked issue\. Narrow fixes may proceed on their reproduction/);
+  assert.match(card, /No other open PR references these issues\./);
+  assert.match(card, /^PR template not used\.$/m);
+  assert.ok(!card.includes('Each changed golden'));
+  assert.ok(!card.includes('Notes:'));
+  assert.match(card, /Advisory index for reviewers; it makes no acceptance decision\./);
+  assert.ok(card.split('\n').length <= 40);
+});
+
+test('renderCard lists linked issues, overlaps, template state and notes', () => {
+  const card = renderCard(
+    baseModel({
+      draft: true,
+      linkedIssues: [
+        { number: 12, title: '# Heading-like title', labels: ['bug', 'accepted'] },
+        { number: 13, title: 'Plain', labels: [] },
+        { number: 14, error: 'GET /repos/x/issues/14 → 404' },
+      ],
+      linkedIssuesTruncated: 2,
+      overlaps: [{ number: 40, title: 'Other PR', primary: true, issues: [12] }],
+      templateSections: [
+        { name: 'Problem and value', present: true, filled: true },
+        { name: 'Stability impact', present: true, filled: false },
+        { name: 'Tests run', present: false, filled: false },
+      ],
+      notes: ['changed files not listed (GET → 500)'],
+    }),
+  );
+  assert.match(card, /· draft ·/);
+  assert.match(card, /- #12 \\# Heading-like title — labels: bug, accepted — carries `accepted`/);
+  assert.match(card, /- #13 Plain — labels: none — no `accepted` label/);
+  assert.match(card, /- #14 — not fetched/);
+  assert.match(card, /\+2 more referenced issues not fetched/);
+  assert.match(card, /- #40 Other PR \(references #12\) — carries `primary-implementation`/);
+  assert.match(card, /Template sections: Problem and value ✓ · Stability impact — empty · Tests run — missing/);
+  assert.match(card, /^Notes: changed files not listed/m);
+  assert.ok(!/^#{1,6} /m.test(card.replace('### Triage card', '')), 'no injected headings');
+});
+
+test('renderCard reports search failure and caps generated path lists', () => {
+  const generated = Array.from({ length: 20 }, (_, i) => ({ filename: `docs/gallery/case-${i}.html`, additions: 1, deletions: 1 }));
+  const files = summarizeFiles([
+    ...generated,
+    { filename: 'archify/examples/web-app.html', additions: 2, deletions: 2 },
+    { filename: 'archify/cli.mjs', additions: 5, deletions: 0 },
+  ]);
+  const card = renderCard(
+    baseModel({
+      files,
+      filesTruncated: true,
+      linkedIssues: [{ number: 1, title: 'x', labels: [] }],
+      overlapError: true,
+    }),
+  );
+  assert.match(card, /Overlap check unavailable \(search API error\)/);
+  assert.match(card, /- generated-site \(20\): `docs\/gallery\/case-0\.html`, .* … \+5 more$/m);
+  assert.equal((card.match(/docs\/gallery\/case-/g) ?? []).length, 15);
+  assert.match(card, /- golden-examples \(1\): `archify\/examples\/web-app\.html`/);
+  assert.match(card, /Each changed golden must be explained by the behavior change that produced it/);
+  assert.match(card, /only the first 300 files were classified/);
+  assert.match(card, /\+27\/−22 total, \+5\/−0 excluding generated paths/);
+});
+
+test('ghFetch sets headers, retries once on 5xx and honours allowed statuses', async () => {
+  const calls = [];
+  let attempt = 0;
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    attempt += 1;
+    if (attempt === 1) return { ok: false, status: 502, text: async () => 'bad gateway', headers: new Map() };
+    if (url.endsWith('/missing')) return { ok: false, status: 404, text: async () => '', headers: new Map() };
+    return { ok: true, status: 200, text: async () => '{"ok":true}', headers: new Map() };
+  };
+  const ghFetch = createGhFetch({ token: 't', fetchImpl, sleep: async () => {} });
+  const first = await ghFetch('/repos/o/r/pulls/1');
+  assert.equal(first.status, 200);
+  assert.deepEqual(first.json, { ok: true });
+  assert.equal(calls.length, 2, 'retried once after 502');
+  assert.equal(calls[0].url, 'https://api.github.com/repos/o/r/pulls/1');
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer t');
+  assert.equal(calls[0].init.headers.Accept, 'application/vnd.github+json');
+  assert.equal(calls[0].init.headers['X-GitHub-Api-Version'], '2022-11-28');
+
+  const missing = await ghFetch('/missing', { method: 'DELETE', allow: [404] });
+  assert.equal(missing.status, 404);
+  await assert.rejects(() => ghFetch('/missing'), /404/);
+});
+
+test('paginate follows Link headers until the last page', async () => {
+  const pages = {
+    1: { items: Array.from({ length: 100 }, (_, i) => i), link: '<x>; rel="next"' },
+    2: { items: [100, 101], link: '' },
+  };
+  const ghFetch = async (p) => {
+    const page = Number(new URL(`https://x${p}`).searchParams.get('page'));
+    return { json: pages[page].items, headers: new Map([['link', pages[page].link]]) };
+  };
+  const all = await paginate(ghFetch, '/repos/o/r/issues/1/comments');
+  assert.equal(all.length, 102);
+  const capped = await paginate(ghFetch, '/repos/o/r/pulls/1/files?x=1', { maxPages: 1 });
+  assert.equal(capped.length, 100);
+});

--- a/.github/scripts/triage-commands.mjs
+++ b/.github/scripts/triage-commands.mjs
@@ -1,0 +1,255 @@
+// Comment-command triage proxy. Pure logic is exported for tests; the IO shell
+// at the bottom only reads the issue_comment payload, calls the GitHub REST
+// API, and never runs code from the commented PR.
+//
+// Commands (one per line, outside code fences):
+//   /label a, b          add settable labels
+//   /unlabel a, b        remove labels
+//   /dup #N              add `duplicate` and post a candidate-duplicate note
+//   /duplicate #N        alias of /dup
+//   /needs-repro         add `needs-repro` and post the reproduction checklist
+// There is deliberately no close command; closing stays with collaborators.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const MARKER = '<!-- archify-triage-commands -->';
+export const UNAUTHORIZED_REPLY =
+  'Triage commands are limited to listed triagers and collaborators (.github/triage-allowlist.json).';
+
+const WRITE_PERMISSIONS = new Set(['write', 'admin', 'maintain']);
+const API = 'https://api.github.com';
+
+function splitNames(text) {
+  return text
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+export function parseCommands(body) {
+  const commands = [];
+  let inFence = false;
+  for (const rawLine of String(body ?? '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (/^(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || !line.startsWith('/')) continue;
+    const match = /^\/([a-z-]+)(?:\s+(.*))?$/i.exec(line);
+    if (!match) continue;
+    const name = match[1].toLowerCase();
+    const rest = (match[2] ?? '').trim();
+    if (name === 'label' || name === 'unlabel') {
+      commands.push({ command: name, args: splitNames(rest) });
+    } else if (name === 'dup' || name === 'duplicate') {
+      commands.push({ command: 'dup', args: rest ? [rest] : [] });
+    } else if (name === 'needs-repro') {
+      commands.push({ command: 'needs-repro', args: [] });
+    }
+    // Any other slash line is ignored so ordinary text such as "/tmp/foo" does nothing.
+  }
+  return commands;
+}
+
+export function authorize(actor, allowlist, permission, actorType = 'User') {
+  if (!actor || actorType === 'Bot') return false;
+  const users = (allowlist?.users ?? []).map((user) => user.toLowerCase());
+  if (users.includes(actor.toLowerCase())) return true;
+  return WRITE_PERMISSIONS.has(String(permission ?? '').toLowerCase());
+}
+
+export function needsReproReply(actor, repository) {
+  const blob = `https://github.com/${repository}/blob/main`;
+  return [
+    `Labelled \`needs-repro\` by @${actor}. To make this report actionable, add the fields the bug report form requires (${blob}/.github/ISSUE_TEMPLATE/bug-report.yml):`,
+    '- exact Archify version or commit, and the installation method',
+    '- the exact command, with private path segments replaced by placeholders',
+    '- the smallest redacted typed JSON that still reproduces the problem',
+    '- the machine-readable receipt (`validate --json` or `deliver --json`) or the exact error',
+    '- expected behavior vs actual behavior',
+    `Local setup and verification steps: ${blob}/CONTRIBUTING.md#local-setup-and-verification`,
+  ].join('\n');
+}
+
+export function plan(commands, allowlist, currentLabels, context = {}) {
+  const { actor = '', issueNumber = 0, repository = '' } = context;
+  const settable = new Set(allowlist?.settableLabels ?? []);
+  const present = new Set(currentLabels ?? []);
+  const add = new Set();
+  const remove = new Set();
+  const replies = [];
+  const rejected = [];
+
+  for (const { command, args } of commands) {
+    if (command === 'label' || command === 'unlabel') {
+      if (args.length === 0) {
+        rejected.push({ command: `/${command}`, reason: 'no label names given' });
+        continue;
+      }
+      for (const name of args) {
+        if (!settable.has(name)) {
+          rejected.push({ command: `/${command} ${name}`, reason: 'not settable via command' });
+        } else if (command === 'label') {
+          add.add(name);
+        } else {
+          remove.add(name);
+        }
+      }
+    } else if (command === 'dup') {
+      const match = /^#?(\d+)$/.exec(args[0] ?? '');
+      if (!match) {
+        rejected.push({ command: '/dup', reason: 'expected an issue number, for example /dup #123' });
+        continue;
+      }
+      const target = Number(match[1]);
+      if (target === Number(issueNumber)) {
+        rejected.push({ command: `/dup #${target}`, reason: 'an issue cannot be a duplicate of itself' });
+        continue;
+      }
+      add.add('duplicate');
+      replies.push(
+        `Marked as a candidate duplicate of #${target} by @${actor}. A maintainer will confirm and close; if this is not a duplicate, say why here.`,
+      );
+    } else if (command === 'needs-repro') {
+      add.add('needs-repro');
+      replies.push(needsReproReply(actor, repository));
+    }
+  }
+
+  for (const name of [...add]) {
+    if (remove.has(name)) {
+      add.delete(name);
+      remove.delete(name);
+      rejected.push({ command: `/label ${name}`, reason: 'requested both add and remove' });
+    }
+  }
+  // Adding a label that is already present is a no-op; skip the API call.
+  // Removing an absent label is kept: the DELETE returns 404, which is ignored.
+  return {
+    add: [...add].filter((name) => !present.has(name)),
+    remove: [...remove],
+    replies,
+    rejected,
+  };
+}
+
+export function formatSummary(actor, result) {
+  const code = (names) => names.map((name) => `\`${name}\``).join(', ');
+  const lines = [MARKER, `Triage command from @${actor}:`];
+  if (result.add.length) lines.push(`- Added: ${code(result.add)}`);
+  if (result.remove.length) lines.push(`- Removed: ${code(result.remove)}`);
+  for (const { command, reason } of result.rejected) lines.push(`- Rejected \`${command}\`: ${reason}`);
+  if (!result.add.length && !result.remove.length && !result.rejected.length) lines.push('- No label changes.');
+  for (const reply of result.replies) lines.push('', reply);
+  return lines.join('\n');
+}
+
+export async function ghFetch(url, { method = 'GET', token, body, fetchImpl = globalThis.fetch } = {}) {
+  const init = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'archify-triage-commands',
+    },
+  };
+  if (body !== undefined) {
+    init.headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(body);
+  }
+  let response = await fetchImpl(url, init);
+  if (response.status >= 500) response = await fetchImpl(url, init);
+  return response;
+}
+
+async function expectOk(response, what, allowed = []) {
+  if (response.ok || allowed.includes(response.status)) return response;
+  throw new Error(`${what} failed: ${response.status} ${await response.text()}`);
+}
+
+async function main() {
+  let event;
+  try {
+    event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+  } catch (error) {
+    console.error(`Unreadable event payload: ${error.message}`);
+    process.exit(1);
+  }
+  const comment = event.comment;
+  const issue = event.issue;
+  const repository = event.repository?.full_name ?? process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  if (typeof comment?.body !== 'string' || !issue?.number || !repository || !token) {
+    console.error('Event payload is missing comment.body, issue.number, repository, or GITHUB_TOKEN.');
+    process.exit(1);
+  }
+
+  const commands = parseCommands(comment.body);
+  if (commands.length === 0) {
+    console.log('No recognised triage command; nothing to do.');
+    return;
+  }
+
+  const allowlistPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'triage-allowlist.json');
+  const allowlist = JSON.parse(fs.readFileSync(allowlistPath, 'utf8'));
+  const actor = comment.user?.login ?? '';
+  const issueUrl = `${API}/repos/${repository}/issues/${issue.number}`;
+  const gh = (url, options = {}) => ghFetch(url, { ...options, token });
+
+  let permission = 'none';
+  if (actor) {
+    const response = await gh(`${API}/repos/${repository}/collaborators/${actor}/permission`);
+    if (response.ok) permission = (await response.json()).permission ?? 'none';
+    else if (response.status !== 404) await expectOk(response, 'Permission lookup');
+  }
+
+  if (!authorize(actor, allowlist, permission, comment.user?.type)) {
+    await expectOk(
+      await gh(`${issueUrl}/comments`, { method: 'POST', body: { body: `${MARKER}\n${UNAUTHORIZED_REPLY}` } }),
+      'Unauthorized reply',
+    );
+    console.log(`@${actor} is not authorised (permission: ${permission}); replied and stopped.`);
+    return;
+  }
+
+  try {
+    await gh(`${API}/repos/${repository}/issues/comments/${comment.id}/reactions`, {
+      method: 'POST',
+      body: { content: 'eyes' },
+    });
+  } catch (error) {
+    console.warn(`Reaction failed (ignored): ${error.message}`);
+  }
+
+  const currentLabels = (issue.labels ?? []).map((label) => label.name);
+  const result = plan(commands, allowlist, currentLabels, { actor, issueNumber: issue.number, repository });
+
+  if (result.add.length) {
+    await expectOk(await gh(`${issueUrl}/labels`, { method: 'POST', body: { labels: result.add } }), 'Add labels');
+  }
+  for (const name of result.remove) {
+    await expectOk(
+      await gh(`${issueUrl}/labels/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+      `Remove label ${name}`,
+      [404],
+    );
+  }
+  await expectOk(
+    await gh(`${issueUrl}/comments`, { method: 'POST', body: { body: formatSummary(actor, result) } }),
+    'Summary reply',
+  );
+  console.log(
+    `Applied for @${actor}: +${JSON.stringify(result.add)} -${JSON.stringify(result.remove)} rejected=${result.rejected.length}`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/triage-commands.test.mjs
+++ b/.github/scripts/triage-commands.test.mjs
@@ -1,0 +1,151 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MARKER,
+  authorize,
+  formatSummary,
+  ghFetch,
+  parseCommands,
+  plan,
+} from './triage-commands.mjs';
+
+const allowlist = {
+  users: ['tt-a1i', 'YunyueLi'],
+  settableLabels: ['bug', 'documentation', 'duplicate', 'needs-repro', 'question', 'good first issue'],
+};
+const context = { actor: 'triager', issueNumber: 42, repository: 'tt-a1i/archify' };
+
+test('parseCommands reads multiple command lines and comma-separated names', () => {
+  const body = 'Looks like a renderer defect.\n/label bug, good first issue\n/unlabel question\n/needs-repro';
+  assert.deepEqual(parseCommands(body), [
+    { command: 'label', args: ['bug', 'good first issue'] },
+    { command: 'unlabel', args: ['question'] },
+    { command: 'needs-repro', args: [] },
+  ]);
+});
+
+test('parseCommands ignores commands inside code fences and unknown slash lines', () => {
+  const body = ['/label bug', '```sh', '/label documentation', '```', '/tmp/output.svg', '/close', '~~~', '/dup #3', '~~~'].join(
+    '\n',
+  );
+  assert.deepEqual(parseCommands(body), [{ command: 'label', args: ['bug'] }]);
+  assert.deepEqual(parseCommands('/tmp/foo\n/close\n/approve'), []);
+  assert.deepEqual(parseCommands(''), []);
+  assert.deepEqual(parseCommands(undefined), []);
+});
+
+test('parseCommands accepts /duplicate as an alias and keeps a number-less /dup for plan to reject', () => {
+  assert.deepEqual(parseCommands('/duplicate #17'), [{ command: 'dup', args: ['#17'] }]);
+  assert.deepEqual(parseCommands('/DUP 17'), [{ command: 'dup', args: ['17'] }]);
+  assert.deepEqual(parseCommands('/dup'), [{ command: 'dup', args: [] }]);
+  const result = plan(parseCommands('/dup'), allowlist, [], context);
+  assert.deepEqual(result.add, []);
+  assert.equal(result.rejected.length, 1);
+  assert.equal(result.rejected[0].command, '/dup');
+});
+
+test('authorize accepts allowlisted users and write collaborators, refuses read-only users and bots', () => {
+  assert.equal(authorize('tt-a1i', allowlist, 'none'), true);
+  assert.equal(authorize('yunyueli', allowlist, 'read'), true, 'logins compare case-insensitively');
+  assert.equal(authorize('stranger', allowlist, 'write'), true);
+  assert.equal(authorize('stranger', allowlist, 'admin'), true);
+  assert.equal(authorize('stranger', allowlist, 'maintain'), true);
+  assert.equal(authorize('stranger', allowlist, 'read'), false);
+  assert.equal(authorize('stranger', allowlist, 'none'), false);
+  assert.equal(authorize('tt-a1i', allowlist, 'admin', 'Bot'), false);
+  assert.equal(authorize('', allowlist, 'admin'), false);
+});
+
+test('plan applies settable labels and rejects the rest with a reason', () => {
+  const result = plan(parseCommands('/label bug, accepted, awaiting-author'), allowlist, [], context);
+  assert.deepEqual(result.add, ['bug']);
+  assert.deepEqual(result.remove, []);
+  assert.deepEqual(result.rejected, [
+    { command: '/label accepted', reason: 'not settable via command' },
+    { command: '/label awaiting-author', reason: 'not settable via command' },
+  ]);
+  assert.deepEqual(result.replies, []);
+});
+
+test('plan handles /dup: adds duplicate with a reply, rejects a self-reference', () => {
+  const ok = plan(parseCommands('/dup #7'), allowlist, [], context);
+  assert.deepEqual(ok.add, ['duplicate']);
+  assert.equal(ok.replies.length, 1);
+  assert.match(ok.replies[0], /candidate duplicate of #7 by @triager/);
+  assert.match(ok.replies[0], /A maintainer will confirm and close/);
+
+  const self = plan(parseCommands('/dup #42'), allowlist, [], context);
+  assert.deepEqual(self.add, []);
+  assert.deepEqual(self.replies, []);
+  assert.equal(self.rejected[0].command, '/dup #42');
+
+  const junk = plan(parseCommands('/dup something'), allowlist, [], context);
+  assert.deepEqual(junk.add, []);
+  assert.equal(junk.rejected.length, 1);
+});
+
+test('plan handles /needs-repro with the fixed checklist reply', () => {
+  const result = plan(parseCommands('/needs-repro'), allowlist, [], context);
+  assert.deepEqual(result.add, ['needs-repro']);
+  assert.equal(result.replies.length, 1);
+  const reply = result.replies[0];
+  assert.match(reply, /tt-a1i\/archify\/blob\/main\/\.github\/ISSUE_TEMPLATE\/bug-report\.yml/);
+  assert.match(reply, /CONTRIBUTING\.md#local-setup-and-verification/);
+  for (const phrase of ['version or commit', 'installation method', 'exact command', 'redacted typed JSON', 'receipt', 'expected behavior vs actual']) {
+    assert.ok(reply.includes(phrase), `reply mentions "${phrase}"`);
+  }
+});
+
+test('plan dedupes combined adds/removes and drops labels requested both ways', () => {
+  const body = '/label bug, bug\n/dup #7\n/unlabel question, question\n/label documentation\n/unlabel documentation';
+  const result = plan(parseCommands(body), allowlist, ['bug'], context);
+  assert.deepEqual(result.add, ['duplicate'], 'bug is already present and documentation was also removed');
+  assert.deepEqual(result.remove, ['question'], 'removing an absent label stays planned; DELETE 404 is ignored');
+  assert.deepEqual(result.rejected, [{ command: '/label documentation', reason: 'requested both add and remove' }]);
+});
+
+test('formatSummary starts with the hidden marker and lists changes, rejections, and replies', () => {
+  const result = plan(parseCommands('/label bug, accepted\n/unlabel question\n/dup #7'), allowlist, [], context);
+  const summary = formatSummary('triager', result);
+  assert.ok(summary.startsWith(`${MARKER}\n`));
+  assert.match(summary, /- Added: `bug`, `duplicate`/);
+  assert.match(summary, /- Removed: `question`/);
+  assert.match(summary, /- Rejected `\/label accepted`: not settable via command/);
+  assert.match(summary, /candidate duplicate of #7/);
+  assert.match(formatSummary('triager', { add: [], remove: [], replies: [], rejected: [] }), /No label changes\./);
+});
+
+test('ghFetch sends GitHub headers, serialises the body, and retries once on 5xx', async () => {
+  const calls = [];
+  let attempt = 0;
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    attempt += 1;
+    return { status: attempt === 1 ? 502 : 201, ok: attempt !== 1 };
+  };
+  const response = await ghFetch('https://api.github.com/x', {
+    method: 'POST',
+    token: 't0k3n',
+    body: { labels: ['bug'] },
+    fetchImpl,
+  });
+  assert.equal(response.status, 201);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].init.method, 'POST');
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer t0k3n');
+  assert.equal(calls[0].init.headers.Accept, 'application/vnd.github+json');
+  assert.ok(calls[0].init.headers['X-GitHub-Api-Version']);
+  assert.equal(calls[0].init.body, '{"labels":["bug"]}');
+
+  const once = [];
+  await ghFetch('https://api.github.com/y', {
+    token: 't',
+    fetchImpl: async (url, init) => {
+      once.push(init);
+      return { status: 404, ok: false };
+    },
+  });
+  assert.equal(once.length, 1, '4xx is not retried');
+  assert.equal(once[0].body, undefined);
+});

--- a/.github/triage-allowlist.json
+++ b/.github/triage-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "Users who may run /label, /unlabel, /dup, /needs-repro via issue comments. Collaborators with write access are always allowed. Owned by CODEOWNERS.",
+  "users": ["tt-a1i", "YunyueLi", "sunsunsun-java"],
+  "settableLabels": ["bug", "documentation", "enhancement", "question", "duplicate", "needs-repro", "not-now", "invalid", "good first issue", "help wanted"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,19 @@ jobs:
       - name: Validate packaged skill without installing dependencies
         run: node scripts/package-smoke.mjs
 
+  governance-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Syntax-check and test every .github/scripts module
+        run: |
+          set -euo pipefail
+          for script in .github/scripts/*.mjs; do node --check "$script"; done
+          node --test .github/scripts/*.test.mjs
+
   deploy-pages:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [test, webm-artifact, zip-freshness, published-update-manifest, package-smoke]

--- a/.github/workflows/generated-artifacts-report.yml
+++ b/.github/workflows/generated-artifacts-report.yml
@@ -1,0 +1,95 @@
+name: Generated artifacts report
+
+# Phase 1 of docs/maintenance-roadmap.md. Rebuilds the generated site and the
+# package from the pull request source, reports whether the committed outputs
+# match, and uploads the rebuild as workflow artifacts. Informational only:
+# nothing in this workflow fails the pull request. The zip-freshness job in
+# ci.yml keeps the blocking ZIP contract. Runs PR code, so it needs no secrets
+# and only read permission.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    name: Rebuild and compare
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      # Builders and what they need:
+      # - build-gallery.mjs <output-root>: renders archify/examples through
+      #   archify/renderers and writes <root>/gallery/** and <root>/gallery.html.
+      # - build-guide.mjs <output-file> and build-start.mjs <output-file>: template
+      #   fills from archify/recipes.
+      # All three read only scripts/ and archify/ and import nothing from
+      # node_modules, so no npm install, Chrome, fonts, or network is needed and
+      # building into a copy of docs/ leaves the checkout untouched.
+      # - build-readme-showcase.mjs is skipped: it screenshots the gallery in Chrome
+      #   and encodes a GIF with ffmpeg, which is not byte-reproducible, so a
+      #   comparison would always report a difference.
+      # A failing builder is recorded in skipped.tsv instead of failing the job.
+      - name: Rebuild the generated site into a scratch copy of docs/
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          rebuilt="$RUNNER_TEMP/docs-rebuilt"
+          skipped="$RUNNER_TEMP/skipped.tsv"
+          rm -rf "$rebuilt"
+          cp -R docs "$rebuilt"
+          printf 'build-readme-showcase.mjs\tnot compared: Chrome screenshots encoded to GIF are not byte-reproducible\n' > "$skipped"
+          run_builder() {
+            local name="$1"
+            shift
+            local status=0
+            "$@" || status=$?
+            if [[ "$status" -ne 0 ]]; then
+              printf '%s\tfailed with exit %s; see the rebuild step log\n' "$name" "$status" >> "$skipped"
+            fi
+          }
+          run_builder build-gallery.mjs node scripts/build-gallery.mjs "$rebuilt"
+          run_builder build-guide.mjs node scripts/build-guide.mjs "$rebuilt/guide.html"
+          run_builder build-start.mjs node scripts/build-start.mjs "$rebuilt/start.html"
+
+      - name: Rebuild archify.zip and compare bytes
+        id: zip
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          scripts/build-zip.sh "$RUNNER_TEMP/rebuilt.zip"
+          if cmp -s "$RUNNER_TEMP/rebuilt.zip" archify.zip; then
+            echo 'status=identical' >> "$GITHUB_OUTPUT"
+          else
+            echo 'status=differs' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write the report to the job summary
+        env:
+          ZIP_STATUS: ${{ steps.zip.outputs.status || 'unavailable' }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/generated-artifacts-report.mjs \
+            --committed docs \
+            --rebuilt "$RUNNER_TEMP/docs-rebuilt" \
+            --owned gallery,gallery.html,guide.html,start.html \
+            --zip "$ZIP_STATUS" \
+            --skipped "$RUNNER_TEMP/skipped.tsv"
+
+      - name: Upload the rebuilt site and package
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-artifacts-rebuild
+          path: |
+            ${{ runner.temp }}/docs-rebuilt
+            ${{ runner.temp }}/rebuilt.zip
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/pr-triage-card.yml
+++ b/.github/workflows/pr-triage-card.yml
@@ -1,0 +1,34 @@
+name: PR triage card
+
+# Advisory evidence index for reviewers. Reads PR metadata only, posts one
+# upserted comment, and keeps the review-state labels in sync. It never runs
+# PR-supplied code: the checkout below is the base repository default ref.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: pr-triage-card-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  card:
+    name: Refresh triage card
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Sync review-state labels and upsert the card
+        run: node .github/scripts/pr-triage-card.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/stale-awaiting-author.yml
+++ b/.github/workflows/stale-awaiting-author.yml
@@ -1,0 +1,48 @@
+name: Stale awaiting-author PRs
+
+# The stale clock runs only on PRs labelled `awaiting-author`. That label is
+# set by pr-triage-card.yml when a collaborator submits a Changes Requested
+# review on the current head, and removed when the author pushes again.
+# 14 days without a new commit or reply adds `stale` and a reminder; 7 more
+# days closes the PR with instructions to resume. Waiting on maintainer
+# review is never stale, and issues are never touched by this workflow.
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Mark and close PRs waiting on their author
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          only-pr-labels: awaiting-author
+          stale-pr-label: stale
+          remove-stale-when-updated: true
+          exempt-draft-pr: false
+          operations-per-run: 100
+          stale-pr-message: >
+            A maintainer requested changes on this PR 14 days ago and there has
+            been no new commit or reply since. Pushing a commit or replying here
+            stops the clock and removes the `stale` label. If it is still waiting
+            in 7 days it will be closed; reopening later is welcome. Current
+            maintainer priorities are listed in
+            ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/CURRENT_FOCUS.md
+          close-pr-message: >
+            Closed because this PR waited on its author for 21 days after
+            Changes Requested. To resume, push to the branch and reopen this PR,
+            or open a fresh PR against current main and link back here. If the
+            PR was the primary implementation for its issue, that status may be
+            reassigned per
+            ${{ github.server_url }}/${{ github.repository }}/blob/main/CONTRIBUTING.md

--- a/.github/workflows/triage-commands.yml
+++ b/.github/workflows/triage-commands.yml
@@ -1,0 +1,35 @@
+name: Triage commands
+
+# Comment-command proxy for triage. The repository lives on a personal
+# account, so GitHub's Triage role cannot be granted. Users listed in
+# .github/triage-allowlist.json, and collaborators with write access, may run
+# /label, /unlabel, /dup #N and /needs-repro in issue or PR comments; the
+# labels they can set are bounded by that file. Every run replies in the
+# thread so the change is auditable. There is no close command: closing stays
+# with collaborators. The checkout below is the base repository default ref,
+# only to load .github/scripts/; PR-supplied code never runs here.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    name: Apply comment command
+    # The command must be on the first line; ordinary comments skip the job.
+    if: startsWith(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Parse, authorise, and apply the command
+        run: node .github/scripts/triage-commands.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Archify is Agent-first: people describe systems, and the Skill, typed JSON, rend
 - Narrow fixes and small documentation or test corrections can proceed with a concrete reproduction or rationale; a separate planning issue is unnecessary.
 - Security vulnerabilities: follow [SECURITY.md](SECURITY.md).
 
+The current not-now list and the evidence that would reopen each item are in [.github/CURRENT_FOCUS.md](.github/CURRENT_FOCUS.md); check it before proposing a deferred feature.
+
+**Primary implementation.** Each issue has at most one maintainer-designated primary PR, marked with the label `primary-implementation`; designation is by maintainer decision, not first-come. Other PRs for the same issue are welcome as a reproduction, tests, or a clearly labeled stage of the primary. Primary status lapses when the author has not responded to a review for 7 days; a maintainer may then designate another PR. Before opening an implementation PR, check whether the issue already has an open PR and, if so, contribute there or open a clearly scoped complementary PR.
+
 Do not include secrets, access tokens, credentials, private repository content, personal data, or customer data in fixtures, logs, screenshots, artifacts, or package tests.
 
 ## Prepare a reviewable change
@@ -93,11 +97,15 @@ List regenerated files and explain why unchanged outputs remain fresh. Resolve g
 
 Treat published versions as immutable. Ordinary feature PRs do not change versions, tags, or distribution identities unless release work is explicitly in scope.
 
+Generated-artifact handling is phased. Phase 1 is active: CI rebuilds the Gallery and ZIP for every PR and reports differences, and the contract in this section still applies until Phase 2 in [docs/maintenance-roadmap.md](docs/maintenance-roadmap.md). Golden examples are separate from that phasing: each changed golden example (`archify/examples/*.html`, `examples/*.html`) must be explained by the behavior change that produced it, and unexplained golden churn is a review blocker.
+
 ## Final integration and follow-up
 
 Refresh `main` and the PR head before final integration; account for relevant base changes and resolve conflicts. Rerun local checks whose evidence was invalidated. Unchanged evidence may be linked with its original revision and reuse rationale; do not relabel it as a new-head run. Verify that required remote CI actually ran on the final head and obey branch protection; zero checks is not green.
 
 On revision, summarize what changed since the reviewed head and which findings it addresses. This lets reviewers focus on the new diff and outstanding decisions.
+
+When a collaborator submits a Changes Requested review, the label `awaiting-author` is set automatically and removed on the next push. Only PRs carrying that label age: after 14 days without a push or reply the PR is labeled `stale` with a reminder; after 7 more days it is closed with instructions to resume. Reopening is welcome; push a commit or comment. Waiting on maintainer review is never stale.
 
 Showcase submissions should include the prompt, agent/client, model, Archify version, redacted JSON, artifact, receipts, and truthful visual-review status. Maintainers may request a smaller safe reproduction. Preserve attribution; showcase acceptance is not a controlled model-quality benchmark.
 
@@ -134,6 +142,10 @@ Maintainers should assess the first
 5–10 reviewed PRs for useful findings, false positives, review time, and repeated
 evidence requests before expanding the pilot. Pause automatic reviews by setting
 `reviews.auto_review.enabled: false`; this does not change CI or branch protection.
+
+Alongside CodeRabbit, [`.github/workflows/pr-triage-card.yml`](.github/workflows/pr-triage-card.yml) posts one advisory "Triage card" comment per PR: linked issues and whether they carry `accepted`, overlapping open PRs for the same issues, changed paths grouped by class, and which PR template sections are filled or empty. It is an evidence index, not an acceptance decision. "Template section empty" means the section has no content beyond the template text; fill it or write `Not applicable` with a reason. "Overlapping PRs" lists other open PRs linking the same issue so you can coordinate under the primary-implementation rule; it does not say which PR is primary.
+
+Users listed in [`.github/triage-allowlist.json`](.github/triage-allowlist.json) may run comment commands on issues and PRs: `/label <name>`, `/unlabel <name>`, `/dup #N`, and `/needs-repro`. Closing issues and PRs stays with collaborators. Changes to the allowlist are PRs reviewed under CODEOWNERS.
 
 ## License
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -14,6 +14,8 @@ If scope remains undecided, report the specific decision needed and keep feedbac
 
 Check the author's [impact classification](CONTRIBUTING.md#choose-evidence-by-impact) against the changed paths and callers. Shared helpers, templates, and authoring instructions may affect more modes than the title suggests.
 
+Use the PR's Triage card comment as the index of linked scope, overlapping PRs, and changed-path classes before detailed review. It is an index, not a disposition; verify anything you rely on.
+
 Name the affected modes/contracts and the smallest evidence set that covers them. Include relevant historical failures and authored constraints. Explain any expansion beyond that set. Repository-only policy changes need consistency and process checks, not layout screenshots.
 
 Use focused evidence during design and repair. Reserve broad integration checks and final artifact rebuilds for the settled change. Required remote CI and branch protection remain in force.
@@ -37,6 +39,8 @@ Lead with the problem, value, and approach. Then report scope, evidence, and a c
 - **Required evidence or scope decision:** the unresolved claim, why it matters to acceptance, and the smallest check or decision that would settle it. An unverified risk is not a reproduced defect.
 - **Suggestion:** a worthwhile improvement outside the acceptance conditions; personal preference alone does not block.
 - **Ready:** the agreed behavior is delivered, relevant evidence is sufficient, and no acceptance blocker remains.
+
+When a collaborator requests changes, the `awaiting-author` label and the stale clock follow automatically. State clearly which items block, so the author can address them and clear the label with one push.
 
 Consolidate scope and compatibility concerns in the first substantive review where possible. Explain any later blocker with newly found evidence, an overlooked acceptance requirement, or a new diff. Record unrelated issues separately instead of growing the PR's scope.
 

--- a/docs/maintenance-roadmap.md
+++ b/docs/maintenance-roadmap.md
@@ -1,0 +1,77 @@
+# Maintenance roadmap: governance controls
+
+Maintainer-facing plan for the controls introduced on branch `governance/maintenance-controls` and the phases that follow. Contributor-facing rules live in [CONTRIBUTING.md](../CONTRIBUTING.md) and [REVIEWING.md](../REVIEWING.md); the one-screen focus list lives in [.github/CURRENT_FOCUS.md](../.github/CURRENT_FOCUS.md). This document does not restate them.
+
+## Why
+
+As of 2026-09-08 the repository had 74 open PRs and 64 open issues, with roughly 5 new issues per day in early September and 3 collaborators with write access. Several issues attracted 3–6 parallel PRs: the lifecycle rail #243 drew #253, #268, #273, #292, #293, #304, and #306; SVG export drew #264, #272, and #328; non-positive dimensions drew #174, #177, and #186. PR diffs of +30K to +159K lines were dominated by regenerated Gallery and ZIP output rather than source. The goal of this roadmap is to reduce the reading a maintainer must do per decision without lowering the evidence standards already in CONTRIBUTING.md.
+
+## Phase 0 — controls shipped in this change
+
+- `.github/workflows/pr-triage-card.yml` — posts one advisory "Triage card" comment per PR: linked issues and whether they carry `accepted`, overlapping open PRs for the same issues, changed paths grouped by class, and which PR template sections are filled or empty. Sets or removes `generated-artifacts`; sets `awaiting-author` when a collaborator submits Changes Requested and removes it on push. It does not approve, reject, or fail a check.
+- `.github/workflows/triage-commands.yml` with `.github/triage-allowlist.json` — comment commands `/label`, `/unlabel`, `/dup #N`, and `/needs-repro` for allowlisted users, because the repository cannot grant GitHub Triage (see below). It does not close issues or PRs; closing stays with collaborators. It never checks out or executes PR code.
+- `.github/workflows/stale-awaiting-author.yml` — `actions/stale` scoped to PRs labeled `awaiting-author`: 14 days to `stale` plus a reminder, 7 more days to close with resume instructions. It does not touch issues, PRs waiting on maintainer review, or PRs without the label.
+- `.github/workflows/generated-artifacts-report.yml` — Phase 1 of the generated-artifacts plan: rebuilds Gallery and ZIP for each PR, reports differences against the PR's committed output, and uploads the rebuilt artifacts. It never blocks; `zip-freshness` in `ci.yml` is unchanged.
+- `governance-scripts` CI job in `ci.yml` — syntax-checks every `.github/scripts/*.mjs` and runs `node --test .github/scripts/*.test.mjs`, so the pure logic behind the workflows above is tested without network access.
+- `.github/scripts/ensure-labels.mjs` — creates the fixed label set with `gh label create --force`; `--dry-run` prints the commands. Run manually once after merge, not in CI.
+- Docs — `.github/CURRENT_FOCUS.md`, this roadmap, and additive paragraphs in CONTRIBUTING.md, REVIEWING.md, and the PR template covering primary implementation, the stale rule, the golden-example rule, and the triage card.
+
+## Generated artifacts — three phases
+
+| Phase | Contract | Automation | Exit criteria |
+| --- | --- | --- | --- |
+| 1 (active) | Unchanged: contributors regenerate and commit Gallery/ZIP; `zip-freshness` byte-matches a rebuild. | `generated-artifacts-report.yml` rebuilds per PR, reports differences, uploads artifacts, never blocks. | Four consecutive weeks in which the report matched the committed output for every merged PR, or every mismatch was explained by a stale contributor rebuild rather than a build nondeterminism. |
+| 2 | `archify.zip` and the generated site on `main` are committed by release/CI automation. Contributors stop committing them. `zip-freshness` is re-scoped to verify the automation's commit. CONTRIBUTING.md `## Packages and generated artifacts` is rewritten. | Release/CI job commits generated output after merge; report workflow becomes informational on source-only PRs. | The automation has produced `main`'s artifacts for one release cycle with no manual rebuild, and the ZIP install path was tested from the automated output on the advertised hosts. |
+| 3 | External PRs no longer commit generated-site or package paths. Golden examples (`archify/examples/*.html`, `examples/*.html`) remain in PRs forever and each change must be explained by the behavior change behind it. | Triage card or a check flags external PRs that still commit generated-site/package paths. | Two consecutive months without a PR needing a maintainer rebuild request, and the flag has produced no false positive on golden-example changes. |
+
+Do not skip a phase. Phase 3 is the only point at which a check may fail for touching generated files.
+
+## Repository placement decision
+
+The repository is on a personal account. GitHub does not offer the Triage or Maintain role on personal repositories, so non-collaborators cannot be given label rights directly. Options:
+
+- (a) Migrate the repository to an organisation. GitHub redirects the old URL and clones. Triage and Maintain roles become available, the single-owner risk is removed, and the comment-command proxy can be retired.
+- (b) Keep the comment-command proxy (`triage-commands.yml` + allowlist). Live now; requires no account change; every allowlist change is a reviewed PR under CODEOWNERS.
+
+Recommendation: (a), as a maintainer decision with its own issue, once the Phase 0 controls have run for a few weeks. (b) is in place until then and stays as a fallback.
+
+## Manual steps after merge
+
+1. Create labels: `node .github/scripts/ensure-labels.mjs --dry-run`, review, then run without the flag. Requires `gh auth status` to succeed for a collaborator.
+2. Pin a short "Current focus" issue pointing to `.github/CURRENT_FOCUS.md`. Draft:
+
+   > **Current focus — read before opening a feature PR**
+   >
+   > Maintainer focus is stability and first-diagram reliability; the active sequence is tracked in #344.
+   > The one-screen list of deferred items and the evidence that would reopen each is `.github/CURRENT_FOCUS.md`.
+   > Before opening an implementation PR, check whether the issue already has an open PR; if so, contribute there or open a clearly scoped complementary PR. One maintainer-designated `primary-implementation` PR per issue.
+   > Narrow fixes and doc/test corrections do not need `accepted`. New contracts, defaults, diagram types, and export formats do.
+   > PRs labeled `awaiting-author` go stale after 14 days and close 7 days later; push a commit or comment to resume. Waiting on maintainer review is never stale.
+   > Decisions are batched into a weekly window; expect async replies otherwise.
+   > This issue is a pointer. Discuss specific items on their own issues.
+
+3. Apply `awaiting-author` once to PRs whose latest review from a collaborator is CHANGES_REQUESTED and whose head SHA is unchanged since that review. Mechanism: `gh pr list --state open --json number,headRefOid`, then `gh api repos/{owner}/{repo}/pulls/<n>/reviews` and compare the latest CHANGES_REQUESTED `commit_id` with `headRefOid`; label with `gh pr edit <n> --add-label awaiting-author`. Do not backdate; the stale clock starts at labeling. Snapshot on 2026-09-09: 29 open PRs carried a collaborator's CHANGES_REQUESTED; 12 had an unchanged head (#72, #122, #125, #127, #141, #172, #206, #207, #208, #212, #220, #260) and 17 had new commits that need a delta re-review, not a stale label. Of the 12, #125 and #141 were already superseded by merged work and #208 is a maintainer branch; close those with a reason instead of letting them age.
+4. Designate `primary-implementation` on the known duplicate clusters: Windows path handling #309 over #276; lifecycle rail #253; SVG export after one command/receipt contract is agreed on the issue. Comment the designation and the reason on each affected PR.
+5. Review the first 10 triage cards for noise: wrong path classes, false "overlapping PR" hits, template-section detection errors. Fix in `.github/scripts/` with a test before widening.
+6. Add triagers to `.github/triage-allowlist.json` by PR, one login per line, reviewed under CODEOWNERS.
+
+## Weekly decision window
+
+- 2 hours, fixed weekly slot, at least one collaborator with write present.
+- Inputs: triage cards, CodeRabbit summaries, CI results on the current head, the `awaiting-author` and `stale` queues.
+- Outputs, one per PR or issue touched: merge; close with a stated reason; request specific evidence (name the check or decision); designate or redesignate `primary-implementation`; label `not-now` with a pointer to `.github/CURRENT_FOCUS.md`.
+- Everything outside the window is asynchronous. Authors should not expect same-day dispositions.
+
+## Measures
+
+Review after 4 weeks and record the numbers in #344:
+
+- Open PR count.
+- Median time from "ready for review" to first maintainer disposition.
+- Duplicate PRs per issue (open PRs linking the same issue).
+- Share of PR diff lines in generated-site and package paths.
+- Stale closures that were reopened (a high number means the clock is too short or labeling was wrong).
+
+## Out of scope for this roadmap
+
+Product direction, including the change-locate and architecture-delta experiments, is tracked separately. This document covers only how contributions are read, decided, and closed.


### PR DESCRIPTION
<!-- Authors: follow CONTRIBUTING.md. Reviewers and Agents: follow REVIEWING.md. -->

## Problem and value

Current-main trigger: 74 open PRs and 64 open issues on 2026-09-08, about 5 new issues per day in early September, 3 collaborators with write, and several issues attracting 3–6 parallel PRs (lifecycle rail #243, SVG export, non-positive dimensions). PR diffs of +30K to +159K lines are dominated by regenerated Gallery/ZIP. Maintainer reading per decision is the bottleneck.

Intended outcome: compress what a maintainer must read per PR without lowering any evidence standard in CONTRIBUTING.md, and put the generated-artifact migration on an explicit phased plan.

Approach: advisory automation only, plus documented rules. No existing CI job changes; `zip-freshness` remains the blocking ZIP contract; nothing fails for touching generated files (that is Phase 3 in `docs/maintenance-roadmap.md`, not this change).

Linked issue and scope status (accepted / narrow fix / recorded decision): recorded maintainer decision (repository governance; owner-authored). Related tracking: #344.

## Stability impact

- Impact class and changed behavior/shared callers: Text or review policy + new repository automation under `.github/`. No runtime, schema, renderer, Viewer, package, or generated-artifact change. `archify/`, `archify.zip`, `docs/gallery/**`, `docs/*.html` are untouched.
- Existing behavior preserved / intended compatibility changes / failure behavior:
  - `pr-triage-card.yml` (`pull_request_target` + `pull_request_review`): reads PR metadata only, checks out the base default ref, posts/updates one advisory comment, syncs `generated-artifacts` and `awaiting-author` labels. Fatal API failure exits 1 (visible), sub-step failures are recorded inside the card and exit 0.
  - `triage-commands.yml` (`issue_comment`): `/label`, `/unlabel`, `/dup #N`, `/needs-repro` for `.github/triage-allowlist.json` users and write collaborators; settable labels are bounded by the allowlist file; no close command; every run replies in-thread.
  - `stale-awaiting-author.yml`: `actions/stale@v9` scoped to `only-pr-labels: awaiting-author`; issues disabled (`-1`).
  - `generated-artifacts-report.yml` (`pull_request`, `contents: read`): rebuilds Gallery/guide/start/ZIP from the PR source into `$RUNNER_TEMP`, reports differences to the job summary, uploads rebuilt output; build steps are `continue-on-error`, the report step never blocks. `build-readme-showcase.mjs` is skipped (Chrome + ffmpeg GIF, not byte-reproducible).
  - `ci.yml`: new `governance-scripts` job (`node --check` + `node --test .github/scripts/*.test.mjs`); not added to `deploy-pages.needs`.
- No unrelated changes: confirmed. `git diff --stat` covers `.github/**`, `CONTRIBUTING.md`, `REVIEWING.md`, `docs/maintenance-roadmap.md` only.

## Tests run

Base `1072200` → candidate head of this branch.

- `node --test .github/scripts/*.test.mjs` → 34 pass, 0 fail (path classification, linked-issue extraction, template-section detection, card rendering with caps and escaping, ghFetch retry/pagination, command parsing/authorization/planning, report rendering, label set).
- `node --check` over all 8 `.github/scripts/*.mjs` → ok.
- `actionlint` on the five touched workflows → clean (one pre-existing SC2016 info in `release.yml` is unrelated and untouched).
- Local end-to-end of the generated-artifacts rebuild shell against a `docs/` copy (gallery 11 artifacts / 99 checks, guide, start) → `26 files identical, 0 differ`; mutation test produced one each of `differs`, `only in checkout`, `only in rebuild`; injected builder failure appeared under `Skipped:` without failing the step. `build-zip.sh` on local Node 26 rejects as designed; CI uses Node 22.
- Stubbed-fetch dry runs of `pr-triage-card.mjs` and `triage-commands.mjs` (authorised, unauthorised, unknown-slash-only, unreadable payload): one-line messages, no stack traces.
- Remote: this PR exercises `governance-scripts` and `generated-artifacts-report` directly. `pr-triage-card` and `triage-commands` use `pull_request_target`/`issue_comment` and therefore only run after merge to `main`; first real cards should be reviewed for noise per roadmap step 5.

## Visual evidence

Not applicable — repository automation and policy text; no rendered output changes.

## Generated artifacts

None regenerated. Sources of Gallery, guide, start, README showcase, and ZIP are unchanged, so committed outputs remain fresh (`zip-freshness` will confirm).

- Changed golden examples and the behavior change behind each: none.

## After merge (manual, from `docs/maintenance-roadmap.md`)

1. Labels already created with `.github/scripts/ensure-labels.mjs`.
2. Pin a short "Current focus" issue (draft text in the roadmap).
3. Label the 12 PRs whose collaborator CHANGES_REQUESTED head is unchanged with `awaiting-author`; close #125/#141/#208 with a reason instead.
4. Designate `primary-implementation` on the known duplicate clusters.
5. Review the first 10 triage cards for noise.
