### PR TITLE
docs: add Supercode to README Sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Using Cursor? Open the [agent-aware quick start](https://tt-a1i.github.io/archif
 
 ## ❤️ Sponsors
 
+<table>
+<tr>
+  <td align="center" width="240"><a href="https://supercode.sh/?utm_source=archify"><img src="https://cdn.supercode.sh/sponsors/supercode-logo.png" alt="Supercode" width="200"/></a><br/><strong><a href="https://supercode.sh/?utm_source=archify">supercode.sh</a></strong></td>
+  <td><a href="https://supercode.sh/?utm_source=archify">Supercode</a> sponsors Archify and enhances Codex and Cursor with token optimization, curated Skills, and spec-driven development. Archify is featured as a <a href="https://supercode.sh/en/skills/tt-a1i/archify/archify">Supercode Editor’s Choice</a> skill.<br/><a href="https://supercode.sh/en/skills/tt-a1i/archify/archify"><img src="https://supercode.sh/badges/editors-choice.svg" alt="Supercode Editor’s Choice — Archify" width="240" height="55"/></a></td>
+</tr>
+</table>
+
 > Want to sponsor Archify? [Contact us by email.](mailto:2801884530@qq.com)
 
 ## See Archify in action

--- a/README_EN.md
+++ b/README_EN.md
@@ -37,6 +37,13 @@ Using Cursor? Open the [agent-aware quick start](https://tt-a1i.github.io/archif
 
 ## ❤️ Sponsors
 
+<table>
+<tr>
+  <td align="center" width="240"><a href="https://supercode.sh/?utm_source=archify"><img src="https://cdn.supercode.sh/sponsors/supercode-logo.png" alt="Supercode" width="200"/></a><br/><strong><a href="https://supercode.sh/?utm_source=archify">supercode.sh</a></strong></td>
+  <td><a href="https://supercode.sh/?utm_source=archify">Supercode</a> sponsors Archify and enhances Codex and Cursor with token optimization, curated Skills, and spec-driven development. Archify is featured as a <a href="https://supercode.sh/en/skills/tt-a1i/archify/archify">Supercode Editor’s Choice</a> skill.<br/><a href="https://supercode.sh/en/skills/tt-a1i/archify/archify"><img src="https://supercode.sh/badges/editors-choice.svg" alt="Supercode Editor’s Choice — Archify" width="240" height="55"/></a></td>
+</tr>
+</table>
+
 > Want to sponsor Archify? [Contact us by email.](mailto:2801884530@qq.com)
 
 ## See Archify in action

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -32,6 +32,13 @@ npx skills add tt-a1i/archify -g
 
 ## ❤️ 赞助伙伴
 
+<table>
+<tr>
+  <td align="center" width="240"><a href="https://supercode.sh/?utm_source=archify"><img src="https://cdn.supercode.sh/sponsors/supercode-logo.png" alt="Supercode" width="200"/></a><br/><strong><a href="https://supercode.sh/?utm_source=archify">supercode.sh</a></strong></td>
+  <td><a href="https://supercode.sh/?utm_source=archify">Supercode</a> 赞助 Archify，通过 Token 优化、精选 Skills 和规范驱动开发增强 Codex 与 Cursor。Archify 已入选 <a href="https://supercode.sh/en/skills/tt-a1i/archify/archify">Supercode Editor’s Choice</a> 技能。<br/><a href="https://supercode.sh/en/skills/tt-a1i/archify/archify"><img src="https://supercode.sh/badges/editors-choice.svg" alt="Supercode Editor’s Choice — Archify" width="240" height="55"/></a></td>
+</tr>
+</table>
+
 > 想赞助 Archify？[欢迎通过邮件联系我们。](mailto:2801884530@qq.com)
 
 ## 看看 Archify 能做什么


### PR DESCRIPTION
## Summary
- Add Supercode logo, supplied copy, destination links and Editor’s Choice badge within the Sponsors section.
- Keep the README top unchanged; preserve supplied utm_source=archify links.
- Update English and Chinese README variants without changing other sponsors or product code.

## Validation
- node --test archify/test/readme-showcase.test.mjs: 7 passed
- git diff --check
- README.md and README_EN.md are identical
- Sponsor image endpoints return HTTP 200