### PR TITLE
fix(benchmark): reject malformed visual defect lists before passing runs

### DIFF
--- a/archify/test/ordinary-model-floor.test.mjs
+++ b/archify/test/ordinary-model-floor.test.mjs
@@ -200,6 +200,34 @@ test('benchmark never accepts a visual pass without an identified reviewer', () 
   assert.equal(receipt.firstPassUsable, false);
 });
 
+test('benchmark never upgrades missing or malformed visual defects to a clean pass', () => {
+  const caseFile = path.join(repoRoot, 'benchmarks/ordinary-model-floor/cases/web-runtime.architecture.case.json');
+  const candidate = path.join(skillRoot, 'examples/web-app.architecture.json');
+  for (const [index, defects] of [undefined, null, 'clipping', { clipping: true }, false, 0, [], ['clipping']].entries()) {
+    const runFile = writeJson(`visual-defects-${index}.run.json`, {
+      schema_version: 1,
+      case_id: 'web-runtime-architecture',
+      agent: 'fixture-agent',
+      model: 'fixture-model',
+      attempt: 1,
+      visual_review: { status: 'passed', reviewer: 'fixture-reviewer', defects },
+    });
+    const result = run(['verify', '--case', caseFile, '--candidate', candidate, '--run', runFile]);
+    const clean = Array.isArray(defects) && defects.length === 0;
+    assert.equal(result.status, clean ? 0 : 1, result.stderr || result.stdout);
+    const receipt = JSON.parse(result.stdout);
+    assert.equal(receipt.gates.semantic.ok, true);
+    assert.equal(receipt.gates.validation.ok, true);
+    assert.equal(receipt.firstPassUsable, clean);
+    assert.equal(receipt.gates.visualReview.status, Array.isArray(defects) ? 'passed' : 'invalid');
+    if (Array.isArray(defects)) {
+      assert.deepEqual(receipt.gates.visualReview.defects, defects);
+    } else {
+      assert.equal(receipt.gates.visualReview.reason, 'passed visual review requires an explicit defects array');
+    }
+  }
+});
+
 test('benchmark applies the same semantic and delivery seam to workflow, sequence, data-flow, and lifecycle candidates', () => {
   const cases = [
     {

--- a/benchmarks/ordinary-model-floor/benchmark.mjs
+++ b/benchmarks/ordinary-model-floor/benchmark.mjs
@@ -249,6 +249,13 @@ function verify(args) {
       reason: 'passed visual review requires a non-empty reviewer identity',
     };
   }
+  if (visualReview.status === 'passed' && !Array.isArray(run.visual_review?.defects)) {
+    visualReview = {
+      ...visualReview,
+      status: 'invalid',
+      reason: 'passed visual review requires an explicit defects array',
+    };
+  }
   const firstPassUsable = run.attempt === 1
     && semantic.ok
     && validation.ok


### PR DESCRIPTION
A passed visual review with a reviewer identity and `defects: "clipping"` is normalized to an empty list, allowing an otherwise valid first attempt to report `firstPassUsable: true`.

Require an explicit defects array before accepting a passed visual review. Missing or incorrectly typed lists now produce an invalid visual-review gate. Empty arrays still pass, and non-empty arrays retain their defects and prevent acceptance. Optional skipped reviews are unchanged.

Validation:
- `node --test archify/test/ordinary-model-floor.test.mjs` on Windows with Node 22.23.2: 19 passed, 0 failed.
- The regression covers omitted, null, string, object, boolean, numeric, empty-array, and non-empty-array values, while asserting the semantic and renderer gates pass.
- `git diff --check` passed.
- The full suite was not rerun on this isolated branch. An earlier run on the unchanged base had Windows/environment failures; this PR does not claim an all-green full suite.

### Visual evidence

Not applicable: only benchmark metadata validation and its regression test change; no Viewer or diagram presentation changes.

### Scope and artifacts

No schema or packaged runtime changes; no package regeneration is needed. This is a narrow fix with a concrete reproduction under CONTRIBUTING.md's small-fix path.
